### PR TITLE
Improved list merge algorithm and autoresolve + various minor things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_install:
 install:
     - pip install -e .
 script:
-    - py.test -l --cov=nbdime
+    - py.test -l --cov-report html --cov=nbdime
 after_success:
     - codecov

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -27,6 +27,13 @@ class DiffEntry(dict):
         self[name] = value
 
 
+def offset_op(e, n):
+    "Recreate sequence diff entry with offset added to key."
+    e = DiffEntry(e)
+    e.key += n
+    return e
+
+
 class DiffOp:
     "Collection of valid values for the action field in diff entries."
     ADD = "add"
@@ -91,17 +98,23 @@ class SequenceDiffBuilder(object):
 
     def validated(self):
         return self._diff
-    
+
     def append(self, entry):
+        # Simplifies some algorithms
+        if entry is None:
+            return
+
+        # Typechecking (just for internal consistency checking)
         assert isinstance(entry, DiffEntry)
         assert "op" in entry
         assert entry.op in SequenceDiffBuilder.OPS
         assert "key" in entry
-        # Assert consistent ordering
+
+        # Assert consistent ordering of diff entries
         _prev = self._diff[-1].key if self._diff else 0
         assert _prev <= entry.key
 
-        # Add entry
+        # Add entry!
         self._diff.append(entry)
 
         # Swap last two entries if insertion was inserted
@@ -146,11 +159,18 @@ class MappingDiffBuilder(object):
         return sorted(self._diff.values(), key=lambda x: x.key)
 
     def append(self, entry):
+        # Simplifies some algorithms
+        if entry is None:
+            return
+
+        # Typechecking (just for internal consistency checking)
         assert isinstance(entry, DiffEntry)
         assert "op" in entry
         assert entry.op in MappingDiffBuilder.OPS
         assert "key" in entry
         assert entry.key not in self._diff
+
+        # Add entry!
         self._diff[entry.key] = entry
 
     #def keep(self, key):

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -345,8 +345,7 @@ def to_json_patch(d, path=""):
 
     This is untested and will need some details worked out.
     """
-    # FIXME: Test with some conforming tool.
-    print("to_json_patch is not tested, see github issues.")
+    print("Warning: to_json_patch is not thouroughly tested.")
     jp = []
     offset = 0
     for e in d:
@@ -375,7 +374,7 @@ def to_json_patch(d, path=""):
             assert isinstance(e.key, int)
             # JSONPatch only has single value remove, no removerange,
             # repeat removal at same index instead
-            p = "/".join((path, str(e.key)))
+            p = "/".join((path, str(e.key + offset)))
             for i in range(e.length):
                 jp.append({"op": "remove", "path": p})
                 offset -= 1

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -123,9 +123,9 @@ class SequenceDiffBuilder(object):
         if length:
             self.append(op_removerange(key, length))
 
-    def keeprange(self, key, length):
-        if length:
-            self.append(op_keeprange(key, length))
+    #def keeprange(self, key, length):
+    #    if length:
+    #        self.append(op_keeprange(key, length))
 
 
 class MappingDiffBuilder(object):
@@ -153,8 +153,8 @@ class MappingDiffBuilder(object):
         assert entry.key not in self._diff
         self._diff[entry.key] = entry
 
-    def keep(self, key):
-        self.append(op_keep(key))
+    #def keep(self, key):
+    #    self.append(op_keep(key))
 
     def add(self, key, value):
         self.append(op_add(key, value))

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -98,7 +98,21 @@ class SequenceDiff(Diff):
 
     def append(self, entry):
         assert isinstance(entry, DiffEntry)
+
+        # Assert consistent ordering
+        if self.diff:
+            assert self.diff[-1].key <= entry.key
+
+        # Add entry
         self.diff.append(entry)
+
+        # Swap last two entries if insertion was inserted
+        # at same location as remove or patch
+        if (len(self.diff) >= 2 and
+                entry.op == Diff.ADDRANGE and
+                entry.key == self.diff[-2].key
+                ):
+            self.diff[-2], self.diff[-1] = self.diff[-1], self.diff[-2]
 
     def add(self, key, valuelist):
         self.append(make_op(Diff.ADDRANGE, key, valuelist))

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -89,14 +89,6 @@ class SequenceDiffBuilder(object):
     def __init__(self):
         self._diff = []
 
-    # TODO: Remove these?
-    def __len__(self):
-        return len(self._diff)
-    def __iter__(self):
-        return iter(self._diff)
-    def __getitem__(self, i):
-        return self._diff[i]
-
     def validated(self):
         return self._diff
     
@@ -149,12 +141,6 @@ class MappingDiffBuilder(object):
 
     def __init__(self):
         self._diff = {}
-
-    # TODO: Remove these?
-    def __len__(self):
-        return len(self._diff)
-    def __iter__(self):
-        return iter(sorted(self._diff.values(), key=lambda x: x.key))
 
     def validated(self):
         return sorted(self._diff.values(), key=lambda x: x.key)

--- a/nbdime/diff_format.py
+++ b/nbdime/diff_format.py
@@ -7,12 +7,8 @@ from __future__ import unicode_literals
 
 from six import string_types
 from six.moves import xrange as range
-from collections import namedtuple
 
 from .log import NBDiffFormatError
-
-
-# TODO: Move some of the less official utilities in here to another submodule
 
 
 class DiffEntry(dict):
@@ -31,7 +27,7 @@ class DiffEntry(dict):
         self[name] = value
 
 
-class Diff:
+class DiffOp:
     "Collection of valid values for the action field in diff entries."
     ADD = "add"
     REMOVE = "remove"
@@ -49,45 +45,45 @@ class Diff:
 
 #def op_keep(key):
 #    "Create a diff entry to keep value at key."
-#    return DiffEntry(op=Diff.KEEP, key=key)
+#    return DiffEntry(op=DiffOp.KEEP, key=key)
 
 def op_add(key, value):
     "Create a diff entry to add value at/before key."
-    return DiffEntry(op=Diff.ADD, key=key, value=value)
+    return DiffEntry(op=DiffOp.ADD, key=key, value=value)
 
 def op_remove(key):
     "Create a diff entry to remove value at key."
-    return DiffEntry(op=Diff.REMOVE, key=key)
+    return DiffEntry(op=DiffOp.REMOVE, key=key)
 
 def op_replace(key, value):
     "Create a diff entry to replace value at key with given value."
-    return DiffEntry(op=Diff.REPLACE, key=key, value=value)
+    return DiffEntry(op=DiffOp.REPLACE, key=key, value=value)
 
 #def op_keeprange(key, length):
 #    "Create a diff entry to keep values in range key:key+length."
-#    return DiffEntry(op=Diff.KEEPRANGE, key=key, length=length)
+#    return DiffEntry(op=DiffOp.KEEPRANGE, key=key, length=length)
 
 def op_addrange(key, valuelist):
     "Create a diff entry to add given list of values before key."
-    return DiffEntry(op=Diff.ADDRANGE, key=key, valuelist=valuelist)
+    return DiffEntry(op=DiffOp.ADDRANGE, key=key, valuelist=valuelist)
 
 def op_removerange(key, length):
     "Create a diff entry to remove values in range key:key+length."
-    return DiffEntry(op=Diff.REMOVERANGE, key=key, length=length)
+    return DiffEntry(op=DiffOp.REMOVERANGE, key=key, length=length)
 
 def op_patch(key, diff):
     "Create a diff entry to patch value at key with diff."
-    return DiffEntry(op=Diff.PATCH, key=key, diff=diff)
+    return DiffEntry(op=DiffOp.PATCH, key=key, diff=diff)
 
 
 class SequenceDiffBuilder(object):
 
     # Valid values for the action field in sequence diff entries
     OPS = (
-        Diff.ADDRANGE,
-        Diff.REMOVERANGE,
-        #Diff.KEEPRANGE,
-        Diff.PATCH,
+        DiffOp.ADDRANGE,
+        DiffOp.REMOVERANGE,
+        #DiffOp.KEEPRANGE,
+        DiffOp.PATCH,
         )
 
     def __init__(self):
@@ -117,7 +113,7 @@ class SequenceDiffBuilder(object):
 
         # Swap last two entries if insertion was inserted
         # at same location as a previous remove or patch
-        if (entry.op == Diff.ADDRANGE and
+        if (entry.op == DiffOp.ADDRANGE and
             len(self.diff) >= 2 and entry.key == self.diff[-2].key
             ):
             self.diff[-2], self.diff[-1] = self.diff[-1], self.diff[-2]
@@ -143,11 +139,11 @@ class MappingDiffBuilder(object):
 
     # Valid values for the action field in mapping diff entries
     OPS = (
-        #Diff.KEEP,
-        Diff.ADD,
-        Diff.REMOVE,
-        Diff.REPLACE,
-        Diff.PATCH,
+        #DiffOp.KEEP,
+        DiffOp.ADD,
+        DiffOp.REMOVE,
+        DiffOp.REPLACE,
+        DiffOp.PATCH,
         )
 
     def __init__(self):
@@ -199,7 +195,7 @@ def is_valid_diff(diff, deep=False):
 
 def validate_diff(diff, deep=False):
     if not isinstance(diff, list):
-        raise NBDiffFormatError("Diff must be a list.")
+        raise NBDiffFormatError("DiffOp must be a list.")
     for e in diff:
         validate_diff_entry(e, deep=deep)
 
@@ -212,19 +208,19 @@ def validate_diff_entry(e, deep=False):
 
     # Entry is always a list with 3 items, or 2 in the special case of single item deletion
     if not isinstance(e, DiffEntry):
-        raise NBDiffFormatError("Diff entry '{}' is not a diff type.".format(e))
+        raise NBDiffFormatError("DiffOp entry '{}' is not a diff type.".format(e))
 
     # Check key (list or str uses int key, dict uses str key)
     op = e.op
     key = e.key
     if isinstance(key, int) and op in SequenceDiffBuilder.OPS:
-        if op == Diff.ADDRANGE:
+        if op == DiffOp.ADDRANGE:
             if not isinstance(e.valuelist, sequence_types):
                 raise NBDiffFormatError("addrange expects a sequence of values to insert, not '{}'.".format(e.valuelist))
-        elif op == Diff.REMOVERANGE:
+        elif op == DiffOp.REMOVERANGE:
             if not isinstance(e.length, int):
                 raise NBDiffFormatError("removerange expects a number of values to delete, not '{}'.".format(e.length))
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             # e.diff is itself a diff, check it recursively if the "deep" argument is true
             # (the "deep" argument is here to avoid recursion and potential O(>n) performance pitfalls)
             if deep:
@@ -232,14 +228,14 @@ def validate_diff_entry(e, deep=False):
         else:
             raise NBDiffFormatError("Unknown diff op '{}'.".format(op))
     elif isinstance(key, string_types) and op in MappingDiffBuilder.OPS:
-        if op == Diff.ADD:
+        if op == DiffOp.ADD:
             pass  # e.value is a single value to insert at key
-        elif op == Diff.REMOVE:
+        elif op == DiffOp.REMOVE:
             pass  # no argument
-        elif op == Diff.REPLACE:
+        elif op == DiffOp.REPLACE:
             # e.value is a single value to replace value at key with
             pass
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             # e.diff is itself a diff, check it recursively if the "deep" argument is true
             # (the "deep" argument is here to avoid recursion and potential O(>n) performance pitfalls)
             if deep:
@@ -258,11 +254,11 @@ def validate_diff_entry(e, deep=False):
 def count_consumed_symbols(e):
     "Count how many symbols are consumed from each sequence by a single sequence diff entry."
     op = e.op
-    if op == Diff.ADDRANGE:
+    if op == DiffOp.ADDRANGE:
         return (0, len(e.valuelist))
-    elif op == Diff.REMOVERANGE:
+    elif op == DiffOp.REMOVERANGE:
         return (e.length, 0)
-    elif op == Diff.PATCH:
+    elif op == DiffOp.PATCH:
         return (1, 1)
     else:
         raise NBDiffFormatError("Invalid op '{}'".format(op))
@@ -310,12 +306,12 @@ def decompress_sequence_diff(di, n):
     decompressed = [op_keep(i) for i in range(n)]
     for e in di:
         op = e.op
-        if op in (Diff.PATCH, Diff.REPLACE, Diff.REMOVE):
+        if op in (DiffOp.PATCH, DiffOp.REPLACE, DiffOp.REMOVE):
             decompressed[e.key] = e
-        elif op == Diff.REMOVERANGE:
+        elif op == DiffOp.REMOVERANGE:
             for i in range(e.length):
                 decompressed[e.key + i] = op_remove(e.key + i)
-        elif op in (Diff.ADDRANGE, Diff.ADD):
+        elif op in (DiffOp.ADDRANGE, DiffOp.ADD):
             raise ValueError("Not expexting insertions.")
         else:
             raise ValueError("Unknown op {}.".format(op))
@@ -347,24 +343,24 @@ def to_json_patch(d, path=""):
     for e in d:
         op = e.op
         p = "/".join([path, str(e.key)])
-        if op == Diff.ADD:
+        if op == DiffOp.ADD:
             jp.append({"op": "add", "path": p, "value": e.value})
-        elif op == Diff.REPLACE:
+        elif op == DiffOp.REPLACE:
             jp.append({"op": "replace", "path": p, "value": e.value})
-        elif op == Diff.REMOVE:
+        elif op == DiffOp.REMOVE:
             jp.append({"op": "remove", "path": p})
-        elif op == Diff.ADDRANGE:
+        elif op == DiffOp.ADDRANGE:
             # JSONPatch only has single value add, no addrange
             # FIXME: Reverse this or not? Read RFC carefully and/or test with some conforming tool.
             #for value in reversed(e.valuelist):
             for value in e.valuelist:
                 jp.append({"op": "add", "path": p, "value": value})
-        elif op == Diff.REMOVERANGE:
+        elif op == DiffOp.REMOVERANGE:
             # JSONPatch only has single value remove, no removerange
             for i in range(e.length):
                 p_i = "/".join((path, str(e.key + i)))  # Note: not using p
                 jp.append({"op": "remove", "path": p_i})
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             # JSONPatch has no recursion, recurse here to flatten diff
             jp.extend(to_json_patch(e.diff, p))
     return jp

--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -11,7 +11,7 @@ import operator
 from collections import defaultdict
 
 from ..diff_format import validate_diff, count_consumed_symbols
-from ..diff_format import SequenceDiff, MappingDiff
+from ..diff_format import SequenceDiffBuilder, MappingDiffBuilder
 
 from .sequences import diff_strings, diff_sequence
 from .snakes import compute_snakes_multilevel, compute_diff_from_snakes
@@ -98,7 +98,7 @@ def diff_lists(a, b, path="", predicates=None, differs=None, shallow_diff=None):
 
     # Count consumed items i,j from a,b, (i="take" in patch_list)
     i, j = 0, 0
-    di = SequenceDiff()
+    di = SequenceDiffBuilder()
     M = len(shallow_diff)
     for ie in range(M+1):
         if ie < M:
@@ -162,7 +162,7 @@ def diff_dicts(a, b, path="", predicates=None, differs=None):
     akeys = set(a.keys())
     bkeys = set(b.keys())
 
-    di = MappingDiff()
+    di = MappingDiffBuilder()
 
     # Sorting keys in loops to get a deterministic diff result
     for key in sorted(akeys - bkeys):

--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -139,7 +139,7 @@ def diff_lists(a, b, path="", predicates=None, differs=None, shallow_diff=None):
     assert i == len(a)
     assert j == len(b)
 
-    return di.diff  # XXX
+    return di.validated()
 
 
 def diff_dicts(a, b, path="", predicates=None, differs=None):
@@ -189,4 +189,4 @@ def diff_dicts(a, b, path="", predicates=None, differs=None):
     for key in sorted(bkeys - akeys):
         di.add(key, b[key])
 
-    return di.diff  # XXX
+    return di.validated()

--- a/nbdime/diffing/lcs.py
+++ b/nbdime/diffing/lcs.py
@@ -32,4 +32,4 @@ def diff_from_lcs(A, B, A_indices, B_indices):
         di.removerange(x, N-x)
     if y < M:
         di.addrange(x, B[y:M])
-    return di.diff  # XXX
+    return di.validated()

--- a/nbdime/diffing/lcs.py
+++ b/nbdime/diffing/lcs.py
@@ -7,12 +7,12 @@ from __future__ import unicode_literals
 
 from six.moves import xrange as range
 
-from ..diff_format import SequenceDiff
+from ..diff_format import SequenceDiffBuilder
 
 
 def diff_from_lcs(A, B, A_indices, B_indices):
     """Compute the diff of A and B, given indices of their lcs."""
-    di = SequenceDiff()
+    di = SequenceDiffBuilder()
     N, M = len(A), len(B)
     llcs = len(A_indices)
     assert llcs == len(B_indices)

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -135,7 +135,7 @@ def compare_output_data(x, y):
 
 # Keeping these here for the comments and as as a reminder for possible future extension points:
 def __unused_diff_single_outputs(a, b, path="/cells/*/output/*"):
-    "Diff a pair of output cells."
+    "DiffOp a pair of output cells."
     assert path == "/cells/*/outputs/*"
     # TODO: Handle output diffing with plugins? I.e. image diff, svg diff, json diff, etc.
     # FIXME: Use linebased diff of some types of outputs:
@@ -145,7 +145,7 @@ def __unused_diff_single_outputs(a, b, path="/cells/*/output/*"):
     #    a.text
     return diff(a, b)
 def __unused_diff_source(a, b, path, predicates, differs):
-    "Diff a pair of sources."
+    "DiffOp a pair of sources."
     assert path == "/cells/*/source"
     # FIXME: Make sure we use linebased diff of sources
     # TODO: Use google-diff-patch-match library to diff the sources?

--- a/nbdime/diffing/seq_difflib.py
+++ b/nbdime/diffing/seq_difflib.py
@@ -31,7 +31,7 @@ def opcodes_to_diff(a, b, opcodes):
             di.removerange(abegin, asize)
         else:
             raise RuntimeError("Unknown action {}".format(action))
-    return di.diff  # XXX
+    return di.validated()
 
 
 def diff_sequence_difflib(a, b):

--- a/nbdime/diffing/seq_difflib.py
+++ b/nbdime/diffing/seq_difflib.py
@@ -6,7 +6,7 @@
 from __future__ import unicode_literals
 
 from difflib import SequenceMatcher
-from ..diff_format import SequenceDiff
+from ..diff_format import SequenceDiffBuilder
 
 
 __all__ = ["diff_sequence_difflib"]
@@ -14,7 +14,7 @@ __all__ = ["diff_sequence_difflib"]
 
 def opcodes_to_diff(a, b, opcodes):
     "Convert difflib opcodes to nbdime diff format."
-    di = SequenceDiff()
+    di = SequenceDiffBuilder()
     for opcode in opcodes:
         action, abegin, aend, bbegin, bend = opcode
         asize = aend - abegin

--- a/nbdime/diffing/snakes.py
+++ b/nbdime/diffing/snakes.py
@@ -96,4 +96,4 @@ def compute_diff_from_snakes(a, b, snakes, path="", predicates=None, differs=Non
 
         # Update corner offsets for next rectangle
         i0, j0 = i+n, j+n
-    return di.diff  # XXX
+    return di.validated()

--- a/nbdime/diffing/snakes.py
+++ b/nbdime/diffing/snakes.py
@@ -10,7 +10,7 @@ Utilities for computing 'snakes', or contiguous sequences of equal elements of t
 """
 
 import operator
-from ..diff_format import SequenceDiff
+from ..diff_format import SequenceDiffBuilder
 from .seq_bruteforce import bruteforce_compute_snakes
 
 __all__ = ["compute_snakes_multilevel"]
@@ -79,7 +79,7 @@ def compute_diff_from_snakes(a, b, snakes, path="", predicates=None, differs=Non
     subpath = "/".join((path, "*"))
     diffit = differs[subpath]
 
-    di = SequenceDiff()
+    di = SequenceDiffBuilder()
     i0, j0, i1, j1 = 0, 0, len(a), len(b)
     for i, j, n in snakes + [(i1, j1, 0)]:
         if i > i0:

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from six import string_types
 
-from ..diff_format import SequenceDiffBuilder, MappingDiffBuilder, Diff, make_op
+from ..diff_format import SequenceDiffBuilder, MappingDiffBuilder, Diff, op_replace
 from ..diff_format import as_dict_based_diff, revert_as_dict_based_diff, decompress_sequence_diff
 from ..patching import patch
 from .chunks import make_merge_chunks
@@ -149,22 +149,22 @@ def resolve_single_conflict(value, le, re, strategy, path):
 
     elif strategy == "clear":
         v = make_cleared_value(value)
-        e = make_op(Diff.REPLACE, le.key, v)
+        e = op_replace(le.key, v)
         le, re = None, None
 
     elif strategy == "inline-source":
         v = make_inline_source_value(value, le, re)
-        e = make_op(Diff.REPLACE, le.key, v)
+        e = op_replace(le.key, v)
         le, re = None, None
 
     elif strategy == "inline-outputs":
         v = make_inline_outputs_value(value, le, re)
-        e = make_op(Diff.REPLACE, le.key, v)
+        e = op_replace(le.key, v)
         le, re = None, None
 
     elif strategy == "join":
         v = make_join_value(value, le, re)
-        e = make_op(Diff.REPLACE, le.key, v)
+        e = op_replace(le.key, v)
         le, re = None, None
 
     else:

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 from six import string_types
 
 from ..diff_format import SequenceDiffBuilder, MappingDiffBuilder, DiffOp, op_replace
-from ..diff_format import as_dict_based_diff, revert_as_dict_based_diff, decompress_sequence_diff
+from ..diff_format import as_dict_based_diff
 from ..patching import patch
 from .chunks import make_merge_chunks
 
@@ -16,7 +16,7 @@ from .chunks import make_merge_chunks
 # FIXME: Move to utils
 def as_text_lines(text):
     if isinstance(text, string_types):
-        text = text.split("\n")
+        text = text.splitlines(True)
     if isinstance(text, tuple):
         text = list(text)
     assert isinstance(text, list)

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -90,6 +90,7 @@ def make_inline_outputs_value(value, le, re):
 
     return newvalue
 
+
 def make_inline_source_value(value, le, re):  # FIXME: Test this!
     if le.op == DiffOp.REPLACE:
         local = le.value

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -262,7 +262,7 @@ def autoresolve_lists(merged, lcd, rcd, strategies, path):
             for e in d1:
                 newrcd.append(e)  # offset_op(e, merged_offset))
 
-    return resolutions.diff, newlcd.diff, newrcd.diff
+    return resolutions.validated(), newlcd.validated(), newrcd.validated()
 
 
 def autoresolve_dicts(merged, lcd, rcd, strategies, path):
@@ -318,7 +318,7 @@ def autoresolve_dicts(merged, lcd, rcd, strategies, path):
             newlcd.append(le)
             newrcd.append(re)
 
-    return resolutions.diff, newlcd.diff, newrcd.diff
+    return resolutions.validated(), newlcd.validated(), newrcd.validated()
 
 
 def autoresolve(merged, local_diff, remote_diff, strategies, path):

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -10,6 +10,7 @@ from six import string_types
 from ..diff_format import SequenceDiff, MappingDiff, Diff, make_op
 from ..diff_format import as_dict_based_diff, revert_as_dict_based_diff, decompress_sequence_diff
 from ..patching import patch
+from .chunks import make_merge_chunks
 
 
 # FIXME: Move to utils
@@ -33,13 +34,13 @@ def format_text_merge_display(local, remote,
     mid = "="*n
     post = "%s %s" % (">"*n, remote_title)
 
-    return "\n".join([pre, local, mid, remote, post])
+    return "\n".join([pre] + local + [mid] + remote + [post])
 
 
 # Sentinel object
 Deleted = object()
 
-def __patch_item(value, diffentry):
+def patch_item(value, diffentry):
     op = diffentry.op
     if op == Diff.REPLACE:
         return diffentry.value
@@ -50,7 +51,8 @@ def __patch_item(value, diffentry):
     else:
         raise ValueError("Invalid item patch op {}".format(op))
 
-def __make_join_diffentry(value, le, re):
+
+def make_join_value(value, le, re):
     # Joining e.g. an outputs list means concatenating all items
     lvalue = patch_item(value, le)
     rvalue = patch_item(value, re)
@@ -59,12 +61,36 @@ def __make_join_diffentry(value, le, re):
         lvalue = []
     if rvalue is Deleted:
         rvalue = []
+
+    # New list
     newvalue = value + lvalue + rvalue
-    e = FIXME
-    return e
+
+    return newvalue
 
 
-def make_inline_diffentry(value, le, re):  # FIXME: Test this!
+def make_inline_outputs_value(value, le, re):
+    # FIXME: Use this for inline outputs diff?
+    # Joining e.g. an outputs list means concatenating all items
+    lvalue = patch_item(value, le)
+    rvalue = patch_item(value, re)
+
+    if lvalue is Deleted:
+        lvalue = []
+    if rvalue is Deleted:
+        rvalue = []
+
+    # Note: This is very notebook specific while the rest of this file is more generic
+    newvalue = (
+        [{"output_type": "stream", "name": "stderr", "text": ["<"*7 + local_title]}]
+        + lvalue
+        + [{"output_type": "stream", "name": "stderr", "text": ["="*7]}]
+        + rvalue
+        + [{"output_type": "stream", "name": "stderr", "text": ["<"*7 + remote_title]}]
+        )
+
+    return newvalue
+
+def make_inline_source_value(value, le, re):  # FIXME: Test this!
     if le.op == Diff.REPLACE:
         local = le.value
     elif le.op == Diff.PATCH:
@@ -88,7 +114,7 @@ def make_inline_diffentry(value, le, re):  # FIXME: Test this!
     return e
 
 
-def cleared_value(value):
+def make_cleared_value(value):
     if isinstance(value, list):
         # Clearing e.g. an outputs list means setting it to an empty list
         return []
@@ -122,18 +148,24 @@ def resolve_single_conflict(value, le, re, strategy, path):
         e, le, re = re, None, None
 
     elif strategy == "clear":
-        v = cleared_value(value)
+        v = make_cleared_value(value)
         e = make_op(Diff.REPLACE, le.key, v)
         le, re = None, None
 
-    elif strategy == "inline":
-        e = make_inline_diffentry(value, le, re)
-        le, re = None
+    elif strategy == "inline-source":
+        v = make_inline_source_value(value, le, re)
+        e = make_op(Diff.REPLACE, le.key, v)
+        le, re = None, None
 
-    # FIXME: Implement
-    #elif strategy == "join":
-    #    e = make_join_diffentry(value, le, re)
-    #    le, re = None
+    elif strategy == "inline-outputs":
+        v = make_inline_outputs_value(value, le, re)
+        e = make_op(Diff.REPLACE, le.key, v)
+        le, re = None, None
+
+    elif strategy == "join":
+        v = make_join_value(value, le, re)
+        e = make_op(Diff.REPLACE, le.key, v)
+        le, re = None, None
 
     else:
         raise RuntimeError("Invalid strategy {}.".format(strategy))
@@ -146,49 +178,89 @@ def autoresolve_lists(merged, lcd, rcd, strategies, path):
     subpath = "/".join((path, key))
     strategy = strategies.get(subpath)
 
-    n = len(merged)
-    local = decompress_sequence_diff(lcd, n)
-    remote = decompress_sequence_diff(rcd, n)
+    # Cutting off handling of strategies of subitems if there's a strategy for these list items
+    if strategy is None:
+        pass  # Go on and potentially recurse
+    elif strategy == "mergetool":
+        return [], lcd, rcd
+    elif strategy == "use-base":
+        return [], [], []
+    elif strategy == "use-local":
+        return lcd, [], []
+    elif strategy == "use-remote":
+        return rcd, [], []
+    # I think these don't make sense for list items? Applied to lists instead?
+    #elif strategy == "clear":
+    #elif strategy == "inline"
+    #elif strategy == "join":
+    elif strategy == "fail":
+        raise RuntimeError("Not expecting a conflict at path {}.".format(path))
+    else:
+        raise RuntimeError("Not expecting strategy {} for list items at path {}.".format(strategy, path))
 
+    # Data structures for storing conflicts
     resolutions = SequenceDiff()
     newlcd = SequenceDiff()
     newrcd = SequenceDiff()
-    for key, value in enumerate(merged):
-        # Figure out what lcd and rcd wants to do with merged[key]
-        le = local[key]
-        re = remote[key]
 
-        assert (le.op == Diff._KEEP) == (re.op == Diff._KEEP)
+    # Offset of indices between merged and resolved
+    merged_offset = 0
 
-        if le.op == Diff._KEEP or re.op == Diff._KEEP:
-            # Skip items without conflict
-            pass
-        elif strategy is not None:
-            # Autoresolve conflicts for this key
-            e, le, re = resolve_single_conflict(value, le, re, strategy, subpath)
-            if e is not None:
-                resolutions.append(e)
-            if le is not None:
-                newlcd.append(le)
-            if re is not None:
-                newrcd.append(re)
-        elif le.op == Diff.PATCH and re.op == Diff.PATCH:
-            # Recurse if we have no strategy for this key but diffs available for the subdocument
-            di, ldi, rdi = autoresolve(value, le.diff, re.diff, strategies, subpath)
+    # Split up and combine diffs into chunks [(begin, end, localdiffs, remotediffs)]
+    chunks = make_merge_chunks(merged, lcd, rcd)
+
+    # Loop over chunks of base[j:k], grouping insertion at j into
+    # the chunk starting with j
+    for (j, k, d0, d1) in chunks:
+        # Skip chunks with no conflict
+        if not (d0 or d1):
+            continue
+
+        linserts = [e for e in d0 if e.op == Diff.ADDRANGE]
+        rinserts = [e for e in d1 if e.op == Diff.ADDRANGE]
+        lpatches = [e for e in d0 if e.op == Diff.PATCH]
+        rpatches = [e for e in d1 if e.op == Diff.PATCH]
+
+        if lpatches and rpatches:
+            assert len(lpatches) == 1
+            assert len(rpatches) == 1
+            assert len(lpatches) + len(linserts) == len(d0)
+            assert len(rpatches) + len(rinserts) == len(d1)
+            assert k == j + 1
+            assert all(e.key == j for e in linserts + rinserts)
+            le, = lpatches
+            re, = rpatches
+            # Recurse if we have diffs available for both subdocuments
+            di, ldi, rdi = autoresolve(merged[j], le.diff, re.diff, strategies, subpath)
+
+            # NB! Possibly contentious handling of inserts here:
+            # if patch conflicts have been resolved, allow inserts from both sides
+            if not (ldi or rdi):
+                for e in linserts + rinserts:
+                    resolutions.append(e)
+            else:
+                for e in linserts:
+                    newlcd.append(e)
+                for e in rinserts:
+                    newrcd.append(e)
+
+            # Now add patch entries with result of autoresolve recursion
             if di:
-                resolutions.patch(key, di)
+                resolutions.patch(j, di)
             if ldi:
-                newlcd.patch(key, ldi)
+                newlcd.patch(j, ldi)
             if rdi:
-                newrcd.patch(key, rdi)
+                newrcd.patch(j, rdi)
         else:
             # Alternatives if we don't have PATCH, are:
             #  - INSERT: not happening
             #  - REPLACE: technically possible, if so we can can convert it to PATCH, but does it happen?
             #  - REMOVE: more likely, but resolving subdocument diff will still leave us with a full conflict on parent here
             # No resolution, keep conflicts le, re
-            newlcd.append(le)
-            newrcd.append(re)
+            for e in d0:
+                newlcd.append(e)  # offset_op(e, merged_offset))
+            for e in d1:
+                newrcd.append(e)  # offset_op(e, merged_offset))
 
     return resolutions.diff, newlcd.diff, newrcd.diff
 
@@ -227,6 +299,7 @@ def autoresolve_dicts(merged, lcd, rcd, strategies, path):
                 newlcd.append(le)
             if re is not None:
                 newrcd.append(re)
+
         elif le.op == Diff.PATCH and re.op == Diff.PATCH:
             # Recurse if we have no strategy for this key but diffs available for the subdocument
             di, ldi, rdi = autoresolve(value, le.diff, re.diff, strategies, subpath)
@@ -238,7 +311,7 @@ def autoresolve_dicts(merged, lcd, rcd, strategies, path):
                 newrcd.patch(key, rdi)
         else:
             # Alternatives if we don't have PATCH, are:
-            #  - INSERT: not happening
+            #  - INSERT: only happens if inserted values are different, could possibly autoresolve some cases but nothing important
             #  - REPLACE: technically possible, if so we can can convert it to PATCH, but does it happen?
             #  - REMOVE: more likely, but resolving subdocument diff will still leave us with a full conflict on parent here
             # No resolution, keep conflicts le, re

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 from six import string_types
 
-from ..diff_format import SequenceDiff, MappingDiff, Diff, make_op
+from ..diff_format import SequenceDiffBuilder, MappingDiffBuilder, Diff, make_op
 from ..diff_format import as_dict_based_diff, revert_as_dict_based_diff, decompress_sequence_diff
 from ..patching import patch
 from .chunks import make_merge_chunks
@@ -199,9 +199,9 @@ def autoresolve_lists(merged, lcd, rcd, strategies, path):
         raise RuntimeError("Not expecting strategy {} for list items at path {}.".format(strategy, path))
 
     # Data structures for storing conflicts
-    resolutions = SequenceDiff()
-    newlcd = SequenceDiff()
-    newrcd = SequenceDiff()
+    resolutions = SequenceDiffBuilder()
+    newlcd = SequenceDiffBuilder()
+    newrcd = SequenceDiffBuilder()
 
     # Offset of indices between merged and resolved
     merged_offset = 0
@@ -274,9 +274,9 @@ def autoresolve_dicts(merged, lcd, rcd, strategies, path):
     # We can't have a one-sided conflict so keys must match
     assert set(lcd) == set(rcd)
 
-    resolutions = MappingDiff()
-    newlcd = MappingDiff()
-    newrcd = MappingDiff()
+    resolutions = MappingDiffBuilder()
+    newlcd = MappingDiffBuilder()
+    newrcd = MappingDiffBuilder()
 
     for key in sorted(lcd):
         # Query out how to handle conflicts in this part of the document

--- a/nbdime/merging/chunks.py
+++ b/nbdime/merging/chunks.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import unicode_literals
+
+from six import string_types
+from six.moves import xrange as range
+
+from ..diff_format import DiffOp, SequenceDiffBuilder
+
+
+def __unused__get_diff_range(diffs, i):
+    "Returns diff entry and range j..k which this diff affects, i.e. base[j:k] is affected."
+    assert i < len(diffs)
+    e = diffs[i]
+    j = e.key
+    if e.op == DiffOp.PATCH:
+        k = j + 1
+    elif e.op == DiffOp.ADDRANGE:
+        k = j
+    elif e.op == DiffOp.REMOVERANGE:
+        k = j + e.length
+    else:
+        raise ValueError("Unexpected diff op {}".format(e.op))
+    return e, j, k
+
+
+def get_section_boundaries(diffs):
+    boundaries = set()
+    for e in diffs:
+        j = e.key
+        boundaries.add(j)
+        if e.op == DiffOp.ADDRANGE:
+            pass
+        elif e.op == DiffOp.REMOVERANGE:
+            k = j + e.length
+            boundaries.add(k)
+        elif e.op == DiffOp.PATCH:
+            k = j + 1
+            boundaries.add(k)
+    return boundaries
+
+
+def split_diffs_on_boundaries(diffs, boundaries):
+    newdiffs = SequenceDiffBuilder()
+    assert isinstance(boundaries, list)
+
+    # Next relevant boundary index
+    b = 0
+
+    for e in diffs:
+        if e.op in (DiffOp.ADDRANGE, DiffOp.PATCH):
+            # Nothing to split
+            newdiffs.append(e)
+        elif e.op == DiffOp.REMOVERANGE:
+            # Skip boundaries smaller than key
+            while boundaries[b] < e.key:
+                b += 1
+
+            # key should be included in the boundaries
+            assert boundaries[b] == e.key
+
+            # Add diff entries for each interval between boundaries up to k
+            while b < len(boundaries)-1 and boundaries[b + 1] <= e.key + e.length:
+                newdiffs.removerange(boundaries[b], boundaries[b + 1] - boundaries[b])
+                b += 1
+        else:
+            raise ValueError("Unhandled diff entry op {}.".format(e.op))
+
+    return newdiffs.validated()
+
+
+def make_chunks(boundaries, diff0, diff1):
+    """Make list of chunks on the form (j, k, diffs0, diffs1).
+
+    Because the diff entries have been split on the union of
+    begin/end boundaries of all diff entries, the keys of
+    diff entries on each side will always match a boundary
+    exactly. The only situation where multiple diff entries
+    on one side matches a boundary is when add/remove or
+    add/patch pairs occur, i.e. when inserting something
+    just before an item that is removed or modified.
+    """
+    i0 = 0
+    i1 = 0
+    chunks = []
+    nb = len(boundaries)
+    for i in range(nb):
+        # Find span of next chunk
+        j = boundaries[i]
+        k = boundaries[i+1] if i < nb-1 else j
+        # Collect diff entries from each side
+        # starting at beginning of this chunk
+        d0 = ()
+        while i0 < len(diff0) and diff0[i0].key == j:
+            d0 += (diff0[i0],)
+            i0 += 1
+        d1 = ()
+        while i1 < len(diff1) and diff1[i1].key == j:
+            d1 += (diff1[i1],)
+            i1 += 1
+        # Add non-empty chunks
+        if j < k or d0 or d1:
+            chunks.append((j, k, d0, d1))
+    return chunks
+
+
+def make_merge_chunks(base, base_local_diff, base_remote_diff):
+    """Return list of chunks (i,j,d0,d1) where d0 and d1 are 
+    lists of diff entries affecting the range base[i:j].
+
+    If d0 and d1 are both empty the chunk is not modified.
+
+    Includes full range 0:len(base).
+
+    Each d0,d1 list contain either 0, 1, or 2 entries,
+    in case of 2 entries the first will be an insert
+    at i (the beginning of the range) and the other a
+    removerange or patch covering the full range i:j.
+    """
+    # Split diffs on union of diff entry boundaries such that
+    # no diff entry overlaps with more than one other entry.
+    # Including 0,N makes loop over chunks cleaner.
+    boundaries = sorted(set((0,len(base)))
+                        | get_section_boundaries(base_local_diff)
+                        | get_section_boundaries(base_remote_diff))
+    diff0 = split_diffs_on_boundaries(base_local_diff, boundaries)
+    diff1 = split_diffs_on_boundaries(base_remote_diff, boundaries)
+
+    # Make list of chunks on the form (j, k, diffs0, diffs1)
+    chunks = make_chunks(boundaries, diff0, diff1)
+
+    # Some sanity checking
+    if base or diff0 or diff1:
+        assert chunks
+        assert chunks[0][0] == 0
+        assert chunks[-1][1] == len(base)
+
+    return chunks

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -192,7 +192,7 @@ def split_diffs_on_boundaries(diffs, boundaries):
 
             # Add diff entries for each interval between boundaries up to k
             while b < len(boundaries)-1 and boundaries[b + 1] <= e.key + e.length:
-                newdiffs.removerange(boundaries[b], boundaries[b + 1])
+                newdiffs.removerange(boundaries[b], boundaries[b + 1] - boundaries[b])
                 b += 1
         else:
             raise ValueError("Unhandled diff entry op {}.".format(e.op))
@@ -282,7 +282,7 @@ def _merge_lists(base, local, remote, base_local_diff, base_remote_diff):
         print(remote)
         print('\n'.join(map(repr,chunks)))
         print()
-        
+
     # Loop over chunks of base[j:k], grouping insertion at j into
     # the chunk starting with j
     for (j, k, d0, d1) in chunks:

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -11,7 +11,7 @@ import copy
 from collections import namedtuple
 
 from ..diffing import diff
-from ..diff_format import DiffOp, SequenceDiffBuilder, MappingDiffBuilder, DiffEntry, as_dict_based_diff
+from ..diff_format import DiffOp, SequenceDiffBuilder, MappingDiffBuilder, DiffEntry, as_dict_based_diff, offset_op
 from ..patching import patch
 from .chunks import make_merge_chunks
 
@@ -71,7 +71,7 @@ def _merge_dicts(base, local, remote, base_local_diff, base_remote_diff):
 
     # (4) (5) (6)
     # Then we have the potentially conflicting changes
-    for key in brdkeys & bldkeys:
+    for key in sorted(brdkeys & bldkeys):
         # Get diff entries for this key (we know both sides have an
         # entry here because all other cases are covered above)
         ld = base_local_diff[key]
@@ -136,13 +136,6 @@ def _merge_dicts(base, local, remote, base_local_diff, base_remote_diff):
             raise ValueError("Invalid diff ops {} and {].".format(lop, rop))
 
     return merged, local_conflict_diff.validated(), remote_conflict_diff.validated()
-
-
-
-def offset_op(e, n):
-    e = DiffEntry(e)
-    e.key += n
-    return e
 
 
 def _merge_lists(base, local, remote, base_local_diff, base_remote_diff):

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -11,7 +11,7 @@ import copy
 from collections import namedtuple
 
 from ..diffing import diff
-from ..diff_format import Diff, SequenceDiff, MappingDiff, DiffEntry, as_dict_based_diff
+from ..diff_format import Diff, SequenceDiffBuilder, MappingDiffBuilder, DiffEntry, as_dict_based_diff
 from ..patching import patch
 from .chunks import make_merge_chunks
 
@@ -66,8 +66,8 @@ def _merge_dicts(base, local, remote, base_local_diff, base_remote_diff):
             merged[key] = remote[key]
 
     # Data structures for storing conflicts
-    local_conflict_diff = MappingDiff()
-    remote_conflict_diff = MappingDiff()
+    local_conflict_diff = MappingDiffBuilder()
+    remote_conflict_diff = MappingDiffBuilder()
 
     # (4) (5) (6)
     # Then we have the potentially conflicting changes
@@ -155,8 +155,8 @@ def _merge_lists(base, local, remote, base_local_diff, base_remote_diff):
     merged = []
 
     # Data structures for storing conflicts
-    local_conflict_diff = SequenceDiff()
-    remote_conflict_diff = SequenceDiff()
+    local_conflict_diff = SequenceDiffBuilder()
+    remote_conflict_diff = SequenceDiffBuilder()
 
     # Offset of indices between base and merged
     merged_offset = 0

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -135,9 +135,7 @@ def _merge_dicts(base, local, remote, base_local_diff, base_remote_diff):
         else:
             raise ValueError("Invalid diff ops {} and {].".format(lop, rop))
 
-    lco = sorted(local_conflict_diff.diff, key=lambda x: x.key)  # XXX
-    rco = sorted(remote_conflict_diff.diff, key=lambda x: x.key)  # XXX
-    return merged, lco, rco
+    return merged, local_conflict_diff.validated(), remote_conflict_diff.validated()
 
 
 
@@ -221,7 +219,7 @@ def _merge_lists(base, local, remote, base_local_diff, base_remote_diff):
             for e in d1:
                 remote_conflict_diff.append(offset_op(e, merged_offset))
 
-    return merged, local_conflict_diff.diff, remote_conflict_diff.diff  # XXX
+    return merged, local_conflict_diff.validated(), remote_conflict_diff.validated()
 
 
 def _merge_strings(base, local, remote, base_local_diff, base_remote_diff):

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -51,9 +51,9 @@ def merge_notebooks(base, local, remote, args):
     merged, local_diffs, remote_diffs = merge_with_diff(base, local, remote, local_diffs, remote_diffs)
 
     # Try to resolve conflicts based on behavioural options
-    #resolved = merged
-    resolved, local_diffs, remote_diffs = \
-      autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
+    resolved = merged  # FIXME: Enable again
+    #resolved, local_diffs, remote_diffs = \
+    #  autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
 
     resolved = nbformat.from_dict(resolved)
     return resolved, local_diffs, remote_diffs

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -51,6 +51,7 @@ def merge_notebooks(base, local, remote, args):
     merged, local_diffs, remote_diffs = merge_with_diff(base, local, remote, local_diffs, remote_diffs)
 
     # Try to resolve conflicts based on behavioural options
+    #resolved = merged
     resolved, local_diffs, remote_diffs = \
       autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
 

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -51,9 +51,9 @@ def merge_notebooks(base, local, remote, args):
     merged, local_diffs, remote_diffs = merge_with_diff(base, local, remote, local_diffs, remote_diffs)
 
     # Try to resolve conflicts based on behavioural options
-    resolved = merged  # FIXME: Enable autoresolve again when basic merge works properly
-    #resolved, local_diffs, remote_diffs = \
-    #  autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
+    #resolved = merged  # FIXME: Enable autoresolve again when basic merge works properly
+    resolved, local_diffs, remote_diffs = \
+      autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
 
     resolved = nbformat.from_dict(resolved)
     return resolved, local_diffs, remote_diffs

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -15,9 +15,9 @@ from ..diffing.notebooks import diff_notebooks
 
 # Strategies for handling conflicts  TODO: Implement these and refine further!
 generic_conflict_strategies = ("mergetool", "fail", "use-base", "use-local", "use-remote", "clear")
-source_conflict_strategies = generic_conflict_strategies # + ("merge-inline",)
+source_conflict_strategies = generic_conflict_strategies # + ("inline-source",)
 transient_conflict_strategies = generic_conflict_strategies # + ()
-output_conflict_strategies = transient_conflict_strategies # + ("use-all",)
+output_conflict_strategies = transient_conflict_strategies # + ("join", "inline-outputs")
 
 
 def autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args):
@@ -28,9 +28,9 @@ def autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args):
         "/cells/*/cell_type": "fail",
         "/cells/*/execution_count": "clear",
         "/cells/*/metadata": "use-base",
-        #"/cells/*/source": "inline",  # FIXME: Implement
-        #"/cells/*/outputs": "join",   # FIXME: Implement
-        "/cells/*/outputs": "clear",
+        #"/cells/*/source": "inline-source",  # FIXME: Debug this mode
+        "/cells/*/source": "mergetool",
+        "/cells/*/outputs": "inline-outputs", # "clear", "join"
         }
     resolutions, local_diffs, remote_diffs = \
         autoresolve(merged, local_diffs, remote_diffs, strategies, "")

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -28,8 +28,8 @@ def autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args):
         "/cells/*/cell_type": "fail",
         "/cells/*/execution_count": "clear",
         "/cells/*/metadata": "use-base",
-        #"/cells/*/source": "inline",
-        #"/cells/*/outputs": "join",
+        #"/cells/*/source": "inline",  # FIXME: Implement
+        #"/cells/*/outputs": "join",   # FIXME: Implement
         "/cells/*/outputs": "clear",
         }
     resolutions, local_diffs, remote_diffs = \
@@ -51,7 +51,7 @@ def merge_notebooks(base, local, remote, args):
     merged, local_diffs, remote_diffs = merge_with_diff(base, local, remote, local_diffs, remote_diffs)
 
     # Try to resolve conflicts based on behavioural options
-    resolved = merged  # FIXME: Enable again
+    resolved = merged  # FIXME: Enable autoresolve again when basic merge works properly
     #resolved, local_diffs, remote_diffs = \
     #  autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
 

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -32,9 +32,8 @@ def autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args):
         "/cells/*/source": "mergetool",
         "/cells/*/outputs": "inline-outputs", # "clear", "join"
         }
-    resolutions, local_diffs, remote_diffs = \
+    resolved, local_diffs, remote_diffs = \
         autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
     return resolved, local_diffs, remote_diffs
 
 
@@ -51,7 +50,6 @@ def merge_notebooks(base, local, remote, args):
     merged, local_diffs, remote_diffs = merge_with_diff(base, local, remote, local_diffs, remote_diffs)
 
     # Try to resolve conflicts based on behavioural options
-    #resolved = merged  # FIXME: Enable autoresolve again when basic merge works properly
     resolved, local_diffs, remote_diffs = \
       autoresolve_notebook_conflicts(merged, local_diffs, remote_diffs, args)
 

--- a/nbdime/patching.py
+++ b/nbdime/patching.py
@@ -56,7 +56,7 @@ def patch_list(obj, diff):
 
         # Skip the specified number of elements, but never decrement take.
         # Note that take can pass index in diffs with repeated +/- on the
-        # same index, i.e. [make_op(Diff.REMOVE, index), make_op(Diff.ADD, index, value)]
+        # same index, i.e. [op_remove(index), op_add(index, value)]
         take = max(take, index + skip)
 
     # Take values at end not mentioned in diff

--- a/nbdime/patching.py
+++ b/nbdime/patching.py
@@ -9,7 +9,7 @@ from six import string_types
 import copy
 import nbformat
 
-from .diff_format import Diff, NBDiffFormatError
+from .diff_format import DiffOp, NBDiffFormatError
 
 
 __all__ = ["patch", "patch_notebook"]
@@ -28,26 +28,26 @@ def patch_list(obj, diff):
         # Take values from obj not mentioned in diff, up to not including index
         newobj.extend(copy.deepcopy(value) for value in obj[take:index])
 
-        if op == Diff.ADDRANGE:
+        if op == DiffOp.ADDRANGE:
             # Extend with new values directly
             newobj.extend(e.valuelist)
             skip = 0
-        elif op == Diff.REMOVERANGE:
+        elif op == DiffOp.REMOVERANGE:
             # Delete a number of values by skipping
             skip = e.length
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             newobj.append(patch(obj[index], e.diff))
             skip = 1
         # Note that the operations ADD, REMOVE, REPLACE are not produced by the
         # diff algorithm anymore, keeping these cases just in case we want them back:
-        elif op == Diff.ADD:
+        elif op == DiffOp.ADD:
             # Append new value directly
             newobj.append(e.value)
             skip = 0
-        elif op == Diff.REMOVE:
+        elif op == DiffOp.REMOVE:
             # Delete values obj[index] by incrementing take to skip
             skip = 1
-        elif op == Diff.REPLACE:
+        elif op == DiffOp.REPLACE:
             # Add replacement value and skip old
             newobj.append(e.value)
             skip = 1
@@ -80,15 +80,15 @@ def patch_dict(obj, diff):
         key = e.key
         assert isinstance(key, string_types)
 
-        if op == Diff.ADD:
+        if op == DiffOp.ADD:
             assert key not in keys_to_copy
             newobj[key] = e.value
-        elif op == Diff.REMOVE:
+        elif op == DiffOp.REMOVE:
             keys_to_copy.remove(key)
-        elif op == Diff.REPLACE:
+        elif op == DiffOp.REPLACE:
             keys_to_copy.remove(key)
             newobj[key] = e.value
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             keys_to_copy.remove(key)
             newobj[key] = patch(obj[key], e.diff)
         else:

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -31,7 +31,7 @@ except ImportError:
     from backports.shutil_which import which
 
 # Toggle indentation here
-with_indent = True
+with_indent = False  #True
 
 
 def present_dict_no_markup(prefix, d, exclude_keys=None):
@@ -228,10 +228,14 @@ def present_list_diff(a, d, path):
 
     return pp
 
+
 def present_string_diff(a, di, path):
     "Pretty-print a nbdime diff."
+    header = ["patch {}:".format(path)]
+
     if _base64.match(a):
-        return ['<base64 data changed>']
+        return header + ['<base64 data changed>']
+
     b = patch(a, di)
     td = tempfile.mkdtemp()
     try:
@@ -239,7 +243,7 @@ def present_string_diff(a, di, path):
             f.write(a)
         with open(os.path.join(td, 'after'), 'w') as f:
             f.write(b)
-        print(which)
+        #print(which)
         if which('git'):
             cmd = 'git diff --no-index --color-words'.split()
             heading_lines = 4
@@ -251,8 +255,10 @@ def present_string_diff(a, di, path):
         dif = out.decode('utf8')
     finally:
         shutil.rmtree(td)
-    return dif.splitlines()[heading_lines:]
+    return header + dif.splitlines()[heading_lines:]
 
+
+def __unused_old_present_string_diff(a, di, path): # Just delete this?
     consumed = 0
     lines = []
     continuation = False

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from six import string_types
 
-from .diff_format import NBDiffFormatError, Diff
+from .diff_format import NBDiffFormatError, DiffOp
 from .patching import patch
 
 try:
@@ -173,20 +173,20 @@ def present_dict_diff(a, di, path):
 
         nextpath = "/".join((path, key))
 
-        if op == Diff.REMOVE:
+        if op == DiffOp.REMOVE:
             pp.append("delete from {}:".format(nextpath))
             pp += present_value("- ", a[key])
 
-        elif op == Diff.ADD:
+        elif op == DiffOp.ADD:
             pp.append("insert at {}:".format(nextpath))
             pp += present_value("+ ", e.value)
 
-        elif op == Diff.REPLACE:
+        elif op == DiffOp.REPLACE:
             pp.append("replace at {}:".format(nextpath))
             pp += present_value("- ", a[key])
             pp += present_value(" +", e.value)
 
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             if with_indent:
                 pp.append("patch {}:".format(nextpath))
             pp += present_diff(a[key], e.diff, nextpath)
@@ -206,11 +206,11 @@ def present_list_diff(a, d, path):
 
         nextpath = "/".join((path, str(index)))
 
-        if op == Diff.ADDRANGE:
+        if op == DiffOp.ADDRANGE:
             pp.append("insert before {}:".format(nextpath))
             pp += present_value("+ ", e.valuelist)
 
-        elif op == Diff.REMOVERANGE:
+        elif op == DiffOp.REMOVERANGE:
             if e.length > 1:
                 r = "{}-{}".format(index, index + e.length - 1)
             else:
@@ -218,7 +218,7 @@ def present_list_diff(a, d, path):
             pp.append("delete {}/{}:".format(path, r))
             pp += present_value("- ", a[index: index + e.length])
 
-        elif op == Diff.PATCH:
+        elif op == DiffOp.PATCH:
             if with_indent:
                 pp.append("patch {}:".format(nextpath))
             pp += present_diff(a[index], e.diff, nextpath)
@@ -274,7 +274,7 @@ def present_string_diff(a, di, path):
             continuation_indent2 = continuation_indent
             consumed = index
 
-        if op == Diff.ADDRANGE:
+        if op == DiffOp.ADDRANGE:
             dlines = e.valuelist.split("\n")
             lines.append("+ " + " "*continuation_indent + dlines[0])
             for dline in dlines[1:]:
@@ -282,7 +282,7 @@ def present_string_diff(a, di, path):
             continuation = True
             continuation_indent2 = max(continuation_indent2, len(lines[-1]) - 2)
 
-        elif op == Diff.REMOVERANGE:
+        elif op == DiffOp.REMOVERANGE:
             dlines = a[index: index + e.length].split("\n")
             lines.append("- " + " "*continuation_indent + dlines[0])
             for dline in dlines[1:]:

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -264,7 +264,7 @@ def present_string_diff(a, di, path):
 
         # Consume untouched characters
         if index > consumed:
-            dlines = a[consumed:index].split("\n")
+            dlines = a[consumed:index].splitlines()
             for dline in dlines:
                 prefix = ".." if continuation else "  "
                 lines.append(prefix + " "*continuation_indent2 + dline)
@@ -275,7 +275,7 @@ def present_string_diff(a, di, path):
             consumed = index
 
         if op == DiffOp.ADDRANGE:
-            dlines = e.valuelist.split("\n")
+            dlines = e.valuelist.splitlines()
             lines.append("+ " + " "*continuation_indent + dlines[0])
             for dline in dlines[1:]:
                 lines.append("+ " + dline)
@@ -283,7 +283,7 @@ def present_string_diff(a, di, path):
             continuation_indent2 = max(continuation_indent2, len(lines[-1]) - 2)
 
         elif op == DiffOp.REMOVERANGE:
-            dlines = a[index: index + e.length].split("\n")
+            dlines = a[index: index + e.length].splitlines()
             lines.append("- " + " "*continuation_indent + dlines[0])
             for dline in dlines[1:]:
                 lines.append("- " + dline)
@@ -297,7 +297,7 @@ def present_string_diff(a, di, path):
     # Consume untouched characters at end
     index = len(a)  # copy-paste from top of loop...
     if index > consumed:
-        dlines = a[consumed:index].split("\n")
+        dlines = a[consumed:index].splitlines()
         for dline in dlines:
             prefix = ".." if continuation else "  "
             lines.append(prefix + " "*continuation_indent2 + dline)

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -154,6 +154,6 @@ def notebook_to_sources(nb, as_str=True):
         if as_str and isinstance(source, list):
             source = "\n".join([line.strip("\n") for line in source])
         elif not as_str and isinstance(source, str):
-            source = source.split("\n")
+            source = source.splitlines(True)
         sources.append(source)
     return sources

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -140,6 +140,8 @@ def check_symmetric_diff_and_patch(a, b):
 
 
 def sources_to_notebook(sources):
+    assert isinstance(sources, list)
+    assert len(sources) == 0 or isinstance(sources[0], list)
     nb = nbformat.v4.new_notebook()
     nb.cells.extend(nbformat.v4.new_code_cell(source) for source in sources)
     return nb

--- a/nbdime/tests/test_diff.py
+++ b/nbdime/tests/test_diff.py
@@ -82,7 +82,7 @@ def test_diff_and_patch():
         op_add("added", 7),
         op_remove("deleted"),
         op_patch("mix", [
-            op_add("add", 42)
+            op_add("add", 42),
             op_remove("del"),
             op_replace("mod", 37),
             ]),

--- a/nbdime/tests/test_diff.py
+++ b/nbdime/tests/test_diff.py
@@ -79,16 +79,16 @@ def test_diff_and_patch():
     check_symmetric_diff_and_patch(mda, mdb)
     # A more explicit assert showing the diff format and testing that paths are sorted:
     assert diff(mda, mdb) == [
+        op_add("added", 7),
         op_remove("deleted"),
         op_patch("mix", [
+            op_add("add", 42)
             op_remove("del"),
             op_replace("mod", 37),
-            op_add("add", 42)
             ]),
         op_patch("modparent", [
             op_replace("mod", 22)
             ]),
-        op_add("added", 7),
         ]
 
 

--- a/nbdime/tests/test_diff.py
+++ b/nbdime/tests/test_diff.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import operator
 
 from nbdime import diff
-from nbdime.diff_format import make_op, Diff
+from nbdime.diff_format import op_patch, op_add, op_replace, op_remove
 from nbdime.diffing.snakes import compute_snakes, compute_snakes_multilevel
 
 from .fixtures import check_symmetric_diff_and_patch
@@ -79,16 +79,16 @@ def test_diff_and_patch():
     check_symmetric_diff_and_patch(mda, mdb)
     # A more explicit assert showing the diff format and testing that paths are sorted:
     assert diff(mda, mdb) == [
-        make_op(Diff.REMOVE, "deleted"),
-        make_op(Diff.PATCH, "mix", [
-            make_op(Diff.REMOVE, "del"),
-            make_op(Diff.REPLACE, "mod", 37),
-            make_op(Diff.ADD, "add", 42)
+        op_remove("deleted"),
+        op_patch("mix", [
+            op_remove("del"),
+            op_replace("mod", 37),
+            op_add("add", 42)
             ]),
-        make_op(Diff.PATCH, "modparent", [
-            make_op(Diff.REPLACE, "mod", 22)
+        op_patch("modparent", [
+            op_replace("mod", 22)
             ]),
-        make_op(Diff.ADD, "added", 7),
+        op_add("added", 7),
         ]
 
 

--- a/nbdime/tests/test_diff_json_conversion.py
+++ b/nbdime/tests/test_diff_json_conversion.py
@@ -1,7 +1,7 @@
 
 import json
 from nbdime import diff
-from nbdime.diff_format import to_clean_dicts
+from nbdime.diff_format import to_clean_dicts, to_json_patch
 
 def test_diff_to_json():
     a = { "foo": [1,2,3], "bar": {"ting": 7, "tang": 123 } }
@@ -17,3 +17,24 @@ def test_diff_to_json():
     assert len(d3) == len(d1)
     assert all(len(e3) == len(e1) for e1, e3 in zip(d1, d3))
     assert d2 == d3
+
+
+def test_diff_to_json_patch():
+    a = [2, 3, 4]
+    b = [1, 2, 4, 6]
+    d = diff(a, b)
+
+    assert to_json_patch(d) == [
+        {'op': 'add', 'path': '/0', 'value': 1},
+        {'op': 'remove', 'path': '/2'},
+        {'op': 'add', 'path': '/3', 'value': 6}
+        ]
+
+    try:
+        import jsonpatch
+    except:
+        jsonpatch = None
+        pytest.xfail("Not comparing to jsonpatch")
+
+    if jsonpatch:
+        assert to_json_patch(d) == jsonpatch.make_patch(a, b).patch

--- a/nbdime/tests/test_diff_json_conversion.py
+++ b/nbdime/tests/test_diff_json_conversion.py
@@ -1,4 +1,5 @@
 
+import pytest
 import json
 from nbdime import diff
 from nbdime.diff_format import to_clean_dicts, to_json_patch

--- a/nbdime/tests/test_merge.py
+++ b/nbdime/tests/test_merge.py
@@ -242,8 +242,8 @@ def test_deep_merge_lists_insert_no_conflict():
     assert lc == [make_op("addrange", 0, [[1, 2]])]
     assert rc == [make_op("addrange", 0, [[1, 3]])]
     assert m == [[1]]  # This is the behaviour we get now, with conflicts left:
-    assert lc == [make_op("removerange", 0, 1), make_op("addrange", 0, [[1, 2]])]
-    assert rc == [make_op("removerange", 0, 1), make_op("addrange", 0, [[1, 3]])]
+    assert lc == [make_op("addrange", 0, [[1, 2]]), make_op("removerange", 0, 1)]
+    assert rc == [make_op("addrange", 0, [[1, 3]]), make_op("removerange", 0, 1)]
 
     # local and remote adds the same entry plus an entry each
     b = [[1]]

--- a/nbdime/tests/test_merge.py
+++ b/nbdime/tests/test_merge.py
@@ -195,8 +195,7 @@ def test_deep_merge_lists_delete_no_conflict__currently_expected_failures():
             assert rc == []
 
 
-def test_deep_merge_lists_insert_no_conflict():
-
+def test_deep_merge_onesided_inner_list_insert_no_conflict():
     # local adds an entry
     b = [[1]]
     l = [[1, 2]]
@@ -215,6 +214,36 @@ def test_deep_merge_lists_insert_no_conflict():
     assert lc == []
     assert rc == []
 
+
+def test_deep_merge_twosided_inserts_no_conflict():
+    # local and remote adds an entry each in a new sublist
+    b = []
+    l = [[2], [3]]
+    r = [[2], [4]]
+    assert diff(b, l) == [make_op("addrange", 0, [[2], [3]])]
+    assert diff(b, r) == [make_op("addrange", 0, [[2], [4]])]
+    m, lc, rc = merge(b, l, r)
+    # No identification of equal inserted list [2] expected from current algorithm
+    assert m == [[2], [3], [2], [4]]
+    assert lc == []
+    assert rc == []
+
+
+def test_deep_merge_twosided_inserts_no_conflict():
+    # local and remote adds an entry each in a new sublist
+    b = [[1]]
+    l = [[1], [2], [3]]
+    r = [[1], [2], [4]]
+    assert diff(b, l) == [make_op("addrange", 1, [[2], [3]])]
+    assert diff(b, r) == [make_op("addrange", 1, [[2], [4]])]
+    m, lc, rc = merge(b, l, r)
+    # No identification of equal inserted list [2] expected from current algorithm
+    assert m == [[1], [2], [3], [2], [4]]
+    assert lc == []
+    assert rc == []
+
+
+def test_deep_merge_lists_insert_no_conflict():
 
     # Some notes explaining the below expected values... while this works:
     assert diff([1], [1, 2]) == [make_op("addrange", 1, [2])]
@@ -238,9 +267,6 @@ def test_deep_merge_lists_insert_no_conflict():
     m, lc, rc = merge(b, l, r)
     #assert m == [[1, 2], [1, 3]]  # This was expected behaviour in old code, obviously not what we want
     #assert m == [[1, 2, 3]]  # This is the behaviour we want from an ideal thought-reading algorithm, unclear if possible
-    assert m == []  # This is the behaviour we get now, with conflicts left:
-    assert lc == [make_op("addrange", 0, [[1, 2]])]
-    assert rc == [make_op("addrange", 0, [[1, 3]])]
     assert m == [[1]]  # This is the behaviour we get now, with conflicts left:
     assert lc == [make_op("addrange", 0, [[1, 2]]), make_op("removerange", 0, 1)]
     assert rc == [make_op("addrange", 0, [[1, 3]]), make_op("removerange", 0, 1)]
@@ -250,21 +276,14 @@ def test_deep_merge_lists_insert_no_conflict():
     l = [[1, 2, 4]]
     r = [[1, 3, 4]]
     m, lc, rc = merge(b, l, r)
-    # No identification of equal insert value 4 expected from current algorithm
-    assert m == [[1, 2, 4], [1, 3, 4]]  # This is expected behaviour today
-    #assert m == [[1, 2, 4, 3, 4]]  # TODO: This is the behaviour we want
-    assert lc == []
-    assert rc == []
-
-    # local and remote adds an entry each in a new sublist
-    b = [[1]]
-    l = [[1], [2], [3]]
-    r = [[1], [2], [4]]
-    m, lc, rc = merge(b, l, r)
-    # No identification of equal inserted list [2] expected from current algorithm
-    assert m == [[1], [2], [3], [2], [4]]
-    assert lc == []
-    assert rc == []
+    # No identification of equal inserted value 4 expected from current algorithm
+    #assert m == [[1, 2, 4, 3, 4]]  # TODO: Is this the behaviour we want, merge in inner list?
+    #assert m == [[1, 2, 4], [1, 3, 4]]  # This was expected behaviour in previous algorithm
+    #assert lc == []
+    #assert rc == []
+    assert m == [[1]]  # This is expected behaviour today, base left for conflict resolution
+    assert lc == [make_op("addrange", 0, [[1, 2, 4]]), make_op("removerange", 0, 1)]
+    assert rc == [make_op("addrange", 0, [[1, 3, 4]]), make_op("removerange", 0, 1)]
 
 
 def test_shallow_merge_dicts_delete_no_conflict():

--- a/nbdime/tests/test_merge.py
+++ b/nbdime/tests/test_merge.py
@@ -21,6 +21,22 @@ def cut(li, *indices):
     return c
 
 
+def test_mytemp():
+    # both remove the same entry
+    b = [1, 3, 2, 7]
+    i = 1
+    if 1:
+        l = copy.deepcopy(b)
+        r = copy.deepcopy(b)
+        l.pop(i)
+        r.pop(i)
+        m, lc, rc = merge(b, l, r)
+        e = copy.deepcopy(b)
+        e.pop(i)
+        assert m == e
+        assert lc == []
+        assert rc == []
+
 def test_shallow_merge_lists_delete_no_conflict():
     # local removes an entry
     b = [1, 3]
@@ -171,10 +187,11 @@ def test_deep_merge_lists_delete_no_conflict():
     l = [[1, 5], [2, 4]]  # deletes 3 and 6
     r = [[1, 5], [4, 6]]  # deletes 3 and 2
     m, lc, rc = merge(b, l, r)
-    assert m == [[1, 5], [2, 4], [1, 5], [4, 6]]  # This is expected behaviour today: clear b, add l, add r
-    #assert m == [[1, 5], [4]]  # 2,3,6 should be gone. TODO: This is the behaviour we want.
-    assert lc == []
-    assert rc == []
+    #assert m == [[1, 5], [2, 4], [1, 5], [4, 6]]  # This was expected behaviour before: clear b, add l, add r
+    #assert m == [[1, 5], [4]]  # 2,3,6 should be gone. TODO: This is the naively ideal thought-reading behaviour. Possible?
+    assert m == b  # conflicts lead to original kept in m
+    assert lc == [make_op("addrange", 0, l), make_op("removerange", 0, 2)]
+    assert rc == [make_op("addrange", 0, r), make_op("removerange", 0, 2)]
 
 
 # TODO: We want this to work, requires improvements to nested list diffing.

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -54,8 +54,7 @@ def test_autoresolve_clear():
     assert merged == { "foo": 1 }
     assert local_diffs != []
     assert remote_diffs != []
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert resolved == { "foo": None }
     assert local_conflicts == []
     assert remote_conflicts == []
@@ -65,8 +64,7 @@ def test_autoresolve_clear():
     #remote = { "foo": [3] }
     #strategies = { "/foo": "clear" }
     #merged, local_diffs, remote_diffs = merge(base, local, remote)
-    #resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    #resolved = patch(merged, resolutions)
+    #resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     # This isn't happening because merge passes without conflict by removing [1] and adding [2,3] to foo:
     #assert local_diffs != []
     #assert remote_diffs != []
@@ -83,24 +81,21 @@ def test_autoresolve_use_one_side():
 
     strategies = { "/foo": "use-base" }
     merged, local_diffs, remote_diffs = merge(base, local, remote)
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert local_conflicts == []
     assert remote_conflicts == []
     assert resolved == { "foo": 1 }
 
     strategies = { "/foo": "use-local" }
     merged, local_diffs, remote_diffs = merge(base, local, remote)
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert local_conflicts == []
     assert remote_conflicts == []
     assert resolved == { "foo": 2 }
 
     strategies = { "/foo": "use-remote" }
     merged, local_diffs, remote_diffs = merge(base, local, remote)
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert local_conflicts == []
     assert remote_conflicts == []
     assert resolved == { "foo": 3 }
@@ -112,24 +107,21 @@ def test_autoresolve_use_one_side():
 
     strategies = { "/foo/bar": "use-base" }
     merged, local_diffs, remote_diffs = merge(base, local, remote)
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert local_conflicts == []
     assert remote_conflicts == []
     assert resolved == { "foo": {"bar": 1 } }
 
     strategies = { "/foo/bar": "use-local" }
     merged, local_diffs, remote_diffs = merge(base, local, remote)
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert local_conflicts == []
     assert remote_conflicts == []
     assert resolved == { "foo": {"bar": 2 } }
 
     strategies = { "/foo/bar": "use-remote" }
     merged, local_diffs, remote_diffs = merge(base, local, remote)
-    resolutions, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
-    resolved = patch(merged, resolutions)
+    resolved, local_conflicts, remote_conflicts = autoresolve(merged, local_diffs, remote_diffs, strategies, "")
     assert local_conflicts == []
     assert remote_conflicts == []
     assert resolved == { "foo": {"bar": 3 } }
@@ -408,8 +400,8 @@ def test_merge_insert_cells_around_conflicting_cell():
     elif 0:
         # This is how it would look if source inserts but not cell inserts resulted in conflicts:
         expected_partial = [local[0], source, remote[1]]
-        expected_lco = _patch_cell_source(1, [op_addrange(0, ["new local cell"])])
-        expected_rco = _patch_cell_source(1, [op_addrange(len(source), ["new remote cell"])])
+        expected_lco = _patch_cell_source(1, [op_addrange(len(source), ["local"])])
+        expected_rco = _patch_cell_source(1, [op_addrange(len(source), ["remote"])])
     else:
         # In current behaviour:
         # - base cell 0 is aligned correctly (this is the notebook diff heuristics)
@@ -428,9 +420,7 @@ def test_merge_insert_cells_around_conflicting_cell():
                                   [op_addrange(len(source), ["local"])]
                                   )]),
             ])]
-        expected_rco = [op_patch("cells", [op_patch(0, [op_patch("source", [
-            op_addrange(len(source), remote[0][-1:])
-            ])])])]
+        expected_rco = _patch_cell_source(0, [op_addrange(len(source), ["remote"])])
     _check(base, local, remote, expected_partial, expected_lco, expected_rco)
 
 

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -268,7 +268,7 @@ def src2nb(src):
     or a list (cells) of lists (lines) of singleline strings.
     """
     if isinstance(src, string_types):
-        src = [src.split("\n")]
+        src = [src.splitlines(True)]
     if isinstance(src, list):
         src  = sources_to_notebook(src)
     assert isinstance(src, dict)

--- a/nbdime/tests/test_patch.py
+++ b/nbdime/tests/test_patch.py
@@ -6,7 +6,7 @@
 from __future__ import unicode_literals
 
 from nbdime import patch
-from nbdime.diff_format import make_op, Diff
+from nbdime.diff_format import op_patch, op_add, op_remove, op_replace, op_addrange, op_removerange
 
 
 # TODO: Check and improve test coverage
@@ -16,79 +16,79 @@ from nbdime.diff_format import make_op, Diff
 
 def test_patch_str():
     # Test +, single item insertion
-    assert patch("42", [make_op(Diff.ADD, 0, "3"), make_op(Diff.REMOVE, 1)]) == "34"
+    assert patch("42", [op_add(0, "3"), op_remove(1)]) == "34"
 
     # Test -, single item deletion
-    assert patch("3", [make_op(Diff.REMOVE, 0)]) == ""
-    assert patch("42", [make_op(Diff.REMOVE, 0)]) == "2"
-    assert patch("425", [make_op(Diff.REMOVE, 0)]) == "25"
-    assert patch("425", [make_op(Diff.REMOVE, 1)]) == "45"
-    assert patch("425", [make_op(Diff.REMOVE, 2)]) == "42"
+    assert patch("3", [op_remove(0)]) == ""
+    assert patch("42", [op_remove(0)]) == "2"
+    assert patch("425", [op_remove(0)]) == "25"
+    assert patch("425", [op_remove(1)]) == "45"
+    assert patch("425", [op_remove(2)]) == "42"
 
     # Test :, single item replace
-    assert patch("52", [make_op(Diff.REPLACE, 0, "4")]) == "42"
-    assert patch("41", [make_op(Diff.REPLACE, 1, "2")]) == "42"
-    assert patch("42", [make_op(Diff.REPLACE, 0, "3"), make_op(Diff.REPLACE, 1, "5")]) == "35"
-    assert patch("hello", [make_op(Diff.REPLACE, 0, "H")]) == "Hello"
+    assert patch("52", [op_replace(0, "4")]) == "42"
+    assert patch("41", [op_replace(1, "2")]) == "42"
+    assert patch("42", [op_replace(0, "3"), op_replace(1, "5")]) == "35"
+    assert patch("hello", [op_replace(0, "H")]) == "Hello"
     # Replace by delete-then-insert
-    assert patch("world", [make_op(Diff.REMOVE, 0), make_op(Diff.ADD, 0, "W")]) == "World"
+    assert patch("world", [op_remove(0), op_add(0, "W")]) == "World"
 
     # Test !, item patch (doesn't make sense for str)
     pass
 
     # Test ++, sequence insertion
-    assert patch("", [make_op(Diff.ADDRANGE, 0, "34"), make_op(Diff.ADD, 0, "5"), make_op(Diff.ADDRANGE, 0, "67")]) == "34567"
+    assert patch("", [op_addrange( 0, "34"), op_add(0, "5"), op_addrange( 0, "67")]) == "34567"
 
     # Test --, sequence deletion
-    assert patch("abcd", [make_op(Diff.REMOVERANGE, 0, 2)]) == "cd"
-    assert patch("abcd", [make_op(Diff.REMOVERANGE, 1, 2)]) == "ad"
-    assert patch("abcd", [make_op(Diff.REMOVERANGE, 2, 2)]) == "ab"
+    assert patch("abcd", [op_removerange(0, 2)]) == "cd"
+    assert patch("abcd", [op_removerange(1, 2)]) == "ad"
+    assert patch("abcd", [op_removerange(2, 2)]) == "ab"
 
 
 def test_patch_list():
     # Test +, single item insertion
-    assert patch([], [make_op(Diff.ADD, 0, 3)]) == [3]
-    assert patch([], [make_op(Diff.ADD, 0, 3), make_op(Diff.ADD, 0, 4)]) == [3, 4]
-    assert patch([], [make_op(Diff.ADD, 0, 3), make_op(Diff.ADD, 0, 4), make_op(Diff.ADD, 0, 5)]) == [3, 4, 5]
+    assert patch([], [op_add(0, 3)]) == [3]
+    assert patch([], [op_add(0, 3), op_add(0, 4)]) == [3, 4]
+    assert patch([], [op_add(0, 3), op_add(0, 4), op_add(0, 5)]) == [3, 4, 5]
 
     # Test -, single item deletion
-    assert patch([3], [make_op(Diff.REMOVE, 0)]) == []
-    assert patch([5, 6, 7], [make_op(Diff.REMOVE, 0)]) == [6, 7]
-    assert patch([5, 6, 7], [make_op(Diff.REMOVE, 1)]) == [5, 7]
-    assert patch([5, 6, 7], [make_op(Diff.REMOVE, 2)]) == [5, 6]
-    assert patch([5, 6, 7], [make_op(Diff.REMOVE, 0), make_op(Diff.REMOVE, 2)]) == [6]
+    assert patch([3], [op_remove(0)]) == []
+    assert patch([5, 6, 7], [op_remove(0)]) == [6, 7]
+    assert patch([5, 6, 7], [op_remove(1)]) == [5, 7]
+    assert patch([5, 6, 7], [op_remove(2)]) == [5, 6]
+    assert patch([5, 6, 7], [op_remove(0), op_remove(2)]) == [6]
 
     # Test :, single item replace
     pass
 
     # Test !, item patch
-    assert patch(["hello", "world"], [make_op(Diff.PATCH, 0, [make_op(Diff.REPLACE, 0, "H")]),
-                                      make_op(Diff.PATCH, 1, [make_op(Diff.REMOVE, 0), make_op(Diff.ADD, 0, "W")])]) == ["Hello", "World"]
+    assert patch(["hello", "world"], [op_patch(0, [op_replace(0, "H")]),
+                                      op_patch(1, [op_remove(0), op_add(0, "W")])]) == ["Hello", "World"]
 
     # Test ++, sequence insertion
-    assert patch([], [make_op(Diff.ADDRANGE, 0, [3, 4]), make_op(Diff.ADD, 0, 5), make_op(Diff.ADDRANGE, 0, [6, 7])]) == [3, 4, 5, 6, 7]
+    assert patch([], [op_addrange( 0, [3, 4]), op_add(0, 5), op_addrange( 0, [6, 7])]) == [3, 4, 5, 6, 7]
 
     # Test --, sequence deletion
-    assert patch([5, 6, 7, 8], [make_op(Diff.REMOVERANGE, 0, 2)]) == [7, 8]
-    assert patch([5, 6, 7, 8], [make_op(Diff.REMOVERANGE, 1, 2)]) == [5, 8]
-    assert patch([5, 6, 7, 8], [make_op(Diff.REMOVERANGE, 2, 2)]) == [5, 6]
+    assert patch([5, 6, 7, 8], [op_removerange(0, 2)]) == [7, 8]
+    assert patch([5, 6, 7, 8], [op_removerange(1, 2)]) == [5, 8]
+    assert patch([5, 6, 7, 8], [op_removerange(2, 2)]) == [5, 6]
 
 
 def test_patch_dict():
     # Test +, single item insertion
-    assert patch({}, [make_op(Diff.ADD, "d", 4)]) == {"d": 4}
-    assert patch({"a": 1}, [make_op(Diff.ADD, "d", 4)]) == {"a": 1, "d": 4}
+    assert patch({}, [op_add("d", 4)]) == {"d": 4}
+    assert patch({"a": 1}, [op_add("d", 4)]) == {"a": 1, "d": 4}
 
-    #assert patch({"d": 1}, [make_op(Diff.ADD, "d", 4)]) == {"d": 4} # currently triggers assert, raise exception or allow?
+    #assert patch({"d": 1}, [op_add("d", 4)]) == {"d": 4} # currently triggers assert, raise exception or allow?
 
     # Test -, single item deletion
-    assert patch({"a": 1}, [make_op(Diff.REMOVE, "a")]) == {}
-    assert patch({"a": 1, "b": 2}, [make_op(Diff.REMOVE, "a")]) == {"b": 2}
+    assert patch({"a": 1}, [op_remove("a")]) == {}
+    assert patch({"a": 1, "b": 2}, [op_remove("a")]) == {"b": 2}
 
     # Test :, single item replace
-    assert patch({"a": 1, "b": 2}, [make_op(Diff.REPLACE, "a", 3)]) == {"a": 3, "b": 2}
-    assert patch({"a": 1, "b": 2}, [make_op(Diff.REPLACE, "a", 3), make_op(Diff.REPLACE, "b", 5)]) == {"a": 3, "b": 5}
+    assert patch({"a": 1, "b": 2}, [op_replace("a", 3)]) == {"a": 3, "b": 2}
+    assert patch({"a": 1, "b": 2}, [op_replace("a", 3), op_replace("b", 5)]) == {"a": 3, "b": 5}
 
     # Test !, item patch
-    subdiff = [make_op(Diff.PATCH, 0, [make_op(Diff.REPLACE, 0, "H")]), make_op(Diff.PATCH, 1, [make_op(Diff.REMOVE, 0), make_op(Diff.ADD, 0, "W")])]
-    assert patch({"a": ["hello", "world"], "b": 3}, [make_op(Diff.PATCH, "a", subdiff)]) == {"a": ["Hello", "World"], "b": 3}
+    subdiff = [op_patch(0, [op_replace(0, "H")]), op_patch(1, [op_remove(0), op_add(0, "W")])]
+    assert patch({"a": ["hello", "world"], "b": 3}, [op_patch("a", subdiff)]) == {"a": ["Hello", "World"], "b": 3}

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -153,10 +153,10 @@ def test_present_list_diff():
     di = diff(a, b, path=path)
     lines = pp.present_diff(a, di, path=path)
     assert lines == [
-        '  delete a/b/0:',
-        '  - [1]',
         '  insert before a/b/0:',
         '  + [2]',
+        '  delete a/b/0:',
+        '  - [1]',
     ]
 
 def test_present_string_diff():

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -141,9 +141,9 @@ def test_present_dict_diff():
     di = diff(a, b, path='x/y')
     lines = pp.present_diff(a, di, path='x/y')
     assert lines == [
-        '  replace at x/y/a:',
-        '  - 1',
-        '   +2',
+        'replace at x/y/a:',
+        '- 1',
+        ' +2',
     ]
 
 def test_present_list_diff():
@@ -153,10 +153,10 @@ def test_present_list_diff():
     di = diff(a, b, path=path)
     lines = pp.present_diff(a, di, path=path)
     assert lines == [
-        '  insert before a/b/0:',
-        '  + [2]',
-        '  delete a/b/0:',
-        '  - [1]',
+        'insert before a/b/0:',
+        '+ [2]',
+        'delete a/b/0:',
+        '- [1]',
     ]
 
 def test_present_string_diff():
@@ -176,4 +176,4 @@ def test_present_string_diff_b64():
     path = 'a/b'
     di = diff(a, b, path=path)
     lines = pp.present_diff(a, di, path=path)
-    assert lines == ['  <base64 data changed>']
+    assert lines[1:] == ['<base64 data changed>']

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -14,7 +14,7 @@ def strings_to_lists(obj):
     elif isinstance(obj, list):
         return [strings_to_lists(v) for v in obj]
     elif isinstance(obj, string_types):
-        return obj.split("\n")
+        return obj.splitlines(True)
     else:
         return obj
 
@@ -26,7 +26,7 @@ def revert_strings_to_lists(obj):
         if not obj:
             return obj
         elif isinstance(obj[0], string_types):
-            return "\n".join(obj)
+            return "".join(obj)
         else:
             return [revert_strings_to_lists(v) for v in obj]
     else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 testpaths=nbdime/tests
-addopts=-l --cov-report html --cov=nbdime
+addopts=-l


### PR DESCRIPTION
Sorry for the big collection of changes in one PR.

This implements an improved merge algorithm for lists, although still not perfect.

Adds safety checks, documents some code a bit better, and various minor things.


I think this solves shifting of indices in conflicts remaining after merge and autoresolve:
https://github.com/jupyter/nbdime/issues/34

At least some cases of conflicts on adjacent changes (some more cases should probably fail):
https://github.com/jupyter/nbdime/issues/32

Most of the merge strategy options (not configurable) with somewhat sensible notebook defaults:
https://github.com/jupyter/nbdime/issues/19

And json patch conversion with index shifting:
https://github.com/jupyter/nbdime/issues/15

Although all of these need more testing before being trustworthy.