### PR TITLE
prettydiff fallback

### DIFF
--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -167,8 +167,8 @@ def test_present_string_diff():
     with mock.patch('nbdime.prettyprint.which', lambda cmd: None):
         lines = pp.present_diff(a, di, path=path)
     text = '\n'.join(lines)
-    assert '< line 2' in text
-    assert '> line 4' in text
+    assert ('< line 2' in text) or ('-line 2' in text)
+    assert ('> line 4' in text) or ('+line 4' in text)
 
 def test_present_string_diff_b64():
     a = b64text(1024)


### PR DESCRIPTION
> Congrats on inclusion in `jupyter`! :cake:

On a vanilla Windows install, `diff` is not available, so `test_present_string_diff` will always fail.

This adds a fallback based on stdlib `difflib.unified_diff`, and accepts either unified or diff-default.

Another approach would be to always use `diff -u` (and keep the fallback) but just always assume unified diff.