### PR TITLE
Git diff driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb	diff=jupyternotebook

--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+"""A git diff driver for notebooks.
+
+Uses nbdime to create diffs for notebooks instead of plain text diffs of JSON.
+Note that this requires the following to be set in .gitattributes to correctly
+identify filetypes with the driver:
+
+    *.ipynb     jupyternotebook
+
+Enable in your global git config with:
+
+    git-nbdiffdriver config --enable [--global]
+
+Use with:
+
+    git diff [<commit> [<commit>]]
+"""
+import os
+import sys
+from subprocess import check_call
+
+from . import nbdiffapp
+
+
+def enable(global_=False):
+    """Enable nbdime git diff driver"""
+    cmd = ['git', 'config']
+    if global_:
+        cmd.append('--global')
+
+    check_call(cmd + ['diff.jupyternotebook.command', 'git-nbdiffdriver diff'])
+
+
+def disable(global_=False):
+    """Disable nbdime git diff drivers"""
+    cmd = ['git', 'config']
+    if global_:
+        cmd.append('--global')
+    check_call(cmd + ['--unset', 'diff.jupyternotebook'])
+
+
+def show_diff(before, after):
+    """Run the diff
+    """
+    # TODO: handle /dev/null (Windows equivalent?) for new or deleted files
+    nbdiffapp.main([before, after])
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser('git-nbdiffdriver', description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest='subcommand')
+
+    diff_parser = subparsers.add_parser('diff',
+        description="The actual entrypoint for the diff tool. Git will call this."
+    )
+    # Argument list
+    # path old-file old-hex old-mode new-file new-hex new-mode [ rename-to ]
+    diff_parser.add_argument('path')
+    diff_parser.add_argument('a', nargs='?', default=None)
+    diff_parser.add_argument('a_sha1', nargs='?', default=None)
+    diff_parser.add_argument('a_mode', nargs='?', default=None)
+    diff_parser.add_argument('b', nargs='?', default=None)
+    diff_parser.add_argument('b_sha1', nargs='?', default=None)
+    diff_parser.add_argument('b_mode', nargs='?', default=None)
+    diff_parser.add_argument('rename_to', nargs='?', default=None)
+
+    # TODO: From git docs: "For a path that is unmerged, GIT_EXTERNAL_DIFF is called with 1 parameter, <path>."
+
+    config = subparsers.add_parser('config',
+        description="Configure git to use nbdime for notebooks in `git diff`")
+    config.add_argument('--global', action='store_true', dest='global_',
+        help="configure your global git config instead of the current repo"
+    )
+    enable_disable = config.add_mutually_exclusive_group(required=True)
+    enable_disable.add_argument('--enable', action='store_const',
+        dest='config_func', const=enable,
+        help="enable nbdime diff driver via git config"
+    )
+    enable_disable.add_argument('--disable', action='store_const',
+        dest='config_func', const=disable,
+        help="disable nbdime diff driver via git config"
+    )
+    opts = parser.parse_args()
+    if opts.subcommand == 'diff':
+        show_diff(opts.a, opts.b)
+    elif opts.subcommand == 'config':
+        opts.config_func(opts.global_)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
-import unittest
+import mock
 import os
 from  os.path import join as pjoin
 
@@ -37,7 +37,7 @@ def test_git_diff_driver(capsys):
         pjoin(test_dir, 'files/foo-foe-1.ipynb'),
         pjoin(test_dir, 'files/foo-foe-1.ipynb'), 'invalid_mock_checksum', '100644',
         pjoin(test_dir, 'files/foo-foe-2.ipynb'), 'invalid_mock_checksum', '100644']
-    with unittest.mock.patch('sys.argv', mock_argv):
+    with mock.patch('sys.argv', mock_argv):
         with pytest.raises(SystemExit) as cm:
             gdd_main()
         assert cm.value.code == 0

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -44,4 +44,4 @@ def test_git_diff_driver(capsys):
         cap_out = capsys.readouterr()[0]
         assert cap_out  == expected_output.format(
             pjoin(test_dir, 'files/foo-foe-1.ipynb'),
-            pjoin(test_dir, 'files/foo-foe-2.ipynb')
+            pjoin(test_dir, 'files/foo-foe-2.ipynb'))

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -1,0 +1,47 @@
+
+from __future__ import unicode_literals
+
+import pytest
+import unittest
+import os
+from  os.path import join as pjoin
+
+from nbdime.gitdiffdriver import main as gdd_main
+
+
+# Expected output includes coloring characters
+expected_output = """nbdiff {0} {1}
+--- a: {0}
++++ b: {1}
+
+patch a/cells/0/outputs/0/data/text/plain:
+\x1b[36m@@ -1 +1 @@\x1b[m
+\x1b[31m6\x1b[m\x1b[32m3\x1b[m
+patch a/cells/0/source:
+\x1b[36m@@ -1,3 +1,3 @@\x1b[m
+def \x1b[31mfoe(x,\x1b[m\x1b[32mfoo(x,\x1b[m y):
+    return x + y\x1b[m
+\x1b[31mfoe(3,\x1b[m\x1b[32mfoo(1,\x1b[m 2)
+patch a/cells/1/source:
+\x1b[36m@@ -1,3 +1,3 @@\x1b[m
+def \x1b[31mfoo(x,\x1b[m\x1b[32mfoe(x,\x1b[m y):
+    return x * y\x1b[m
+\x1b[31mfoo(1,\x1b[m\x1b[32mfoe(1,\x1b[m 2)
+"""
+
+
+def test_git_diff_driver(capsys):
+    # Simulate a call from `git diff` to check basic driver functionality
+    test_dir = os.path.abspath(os.path.dirname(__file__))
+    mock_argv = ['/mock/path/git-nbdiffdriver', 'diff',
+        pjoin(test_dir, 'files/foo-foe-1.ipynb'),
+        pjoin(test_dir, 'files/foo-foe-1.ipynb'), 'invalid_mock_checksum', '100644',
+        pjoin(test_dir, 'files/foo-foe-2.ipynb'), 'invalid_mock_checksum', '100644']
+    with unittest.mock.patch('sys.argv', mock_argv):
+        with pytest.raises(SystemExit) as cm:
+            gdd_main()
+        assert cm.value.code == 0
+        cap_out = capsys.readouterr()[0]
+        assert cap_out  == expected_output.format(
+            pjoin(test_dir, 'files/foo-foe-1.ipynb'),
+            pjoin(test_dir, 'files/foo-foe-2.ipynb')

--- a/setup.py
+++ b/setup.py
@@ -95,8 +95,9 @@ extras_require = setuptools_args['extras_require'] = {
     'test': [
         'pytest',
         'testpath',
+        'mock',
     ],
-    
+
     ':python_version == "2.7"': [
         'backports.shutil_which',
     ],

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ if 'setuptools' in sys.modules:
             'nbpatch= nbdime.nbpatchapp:main',
             'nbmerge = nbdime.nbmergeapp:main',
             'git-nbdifftool = nbdime.gitdifftool:main',
+            'git-nbdiffdriver = nbdime.gitdiffdriver:main',
         ]
     }
     setup_args.pop('scripts', None)


### PR DESCRIPTION
Adds a notebook diff driver for git, which produces a diff for notebooks only. This can be used by `git diff` (as compared to `git difftool`), and relies on filename filtering in `.gitattributes` to be supplied the right files. The `.gitattributes`need to be configured for each repo, but the line included in this PR's `.gitattributes` file should be sufficient (`*.ipynb	diff=jupyternotebook`).

Also added a test that mocks a call by git to the diff driver, comparing the output. Currently it has to use coloring characters to match the captured output, but I'm not sure if this is correct/expected for all setups?