### PR TITLE
Remove `--color-words` when testing

### DIFF
--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -35,12 +35,15 @@ except ImportError:
 # Toggle indentation here
 with_indent = False  #True
 
+# Change to enable/disable color print etc.
+_git_diff_print_cmd = 'git diff --no-index --color-words'
+
 
 def present_dict_no_markup(prefix, d, exclude_keys=None):
     """Pretty-print a dict without wrapper keys
-    
+
     Instead of {'key': 'value'}, do
-    
+
         key: value
         key:
           long
@@ -83,7 +86,7 @@ def present_multiline_string(prefix, s):
 
 def present_output(prefix, output):
     """Present an output (whole output add/delete)
-    
+
     Called by present_value
     """
     pp = []
@@ -95,17 +98,17 @@ def present_output(prefix, output):
     if output['output_type'] in {'display_data', 'execute_result'} and 'data' in output:
         pp.append(prefix + 'data:')
         pp.extend(present_dict_no_markup(value_prefix, output['data']))
-    
+
     pp.extend(present_dict_no_markup(prefix, output,
         exclude_keys={'output_type', 'metadata', 'data'},
     ))
-    
+
     return pp
 
 
 def present_cell(prefix, cell):
     """Present a cell as a scalar (whole cell delete/add)
-    
+
     Called by present_value
     """
     pp = []
@@ -137,9 +140,9 @@ def present_cell(prefix, cell):
 
 def present_value(prefix, arg):
     """Present a whole value that is either added or deleted.
-    
+
     Calls out to other formatters for cells, outputs, and multiline strings.
-    
+
     Uses pprint.pformat, otherwise.
     """
     # TODO: improve pretty-print of arbitrary values?
@@ -247,7 +250,7 @@ def present_string_diff(a, di, path):
         with open(os.path.join(td, 'after'), 'w') as f:
             f.write(b)
         if which('git'):
-            cmd = 'git diff --no-index --color-words'.split()
+            cmd = _git_diff_print_cmd.split()
             heading_lines = 4
         elif which('diff'):
             cmd = ['diff']
@@ -353,10 +356,10 @@ nbdiff {afn} {bfn}
 
 def pretty_print_notebook_diff(afn, bfn, a, di):
     """Pretty-print a notebook diff
-    
+
     Parameters
     ----------
-    
+
     afn: str
         Filename of a, the base notebook
     bfn: str

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -15,18 +15,29 @@ expected_output = """nbdiff {0} {1}
 +++ b: {1}
 
 patch a/cells/0/outputs/0/data/text/plain:
-\x1b[36m@@ -1 +1 @@\x1b[m
-\x1b[31m6\x1b[m\x1b[32m3\x1b[m
+@@ -1 +1 @@
+-6
+\ No newline at end of file
++3
+\ No newline at end of file
 patch a/cells/0/source:
-\x1b[36m@@ -1,3 +1,3 @@\x1b[m
-def \x1b[31mfoe(x,\x1b[m\x1b[32mfoo(x,\x1b[m y):
-    return x + y\x1b[m
-\x1b[31mfoe(3,\x1b[m\x1b[32mfoo(1,\x1b[m 2)
+@@ -1,3 +1,3 @@
+-def foe(x, y):
++def foo(x, y):
+     return x + y
+-foe(3, 2)
+\ No newline at end of file
++foo(1, 2)
+\ No newline at end of file
 patch a/cells/1/source:
-\x1b[36m@@ -1,3 +1,3 @@\x1b[m
-def \x1b[31mfoo(x,\x1b[m\x1b[32mfoe(x,\x1b[m y):
-    return x * y\x1b[m
-\x1b[31mfoo(1,\x1b[m\x1b[32mfoe(1,\x1b[m 2)
+@@ -1,3 +1,3 @@
+-def foo(x, y):
++def foe(x, y):
+     return x * y
+-foo(1, 2)
+\ No newline at end of file
++foe(1, 2)
+\ No newline at end of file
 """
 
 
@@ -37,6 +48,10 @@ def test_git_diff_driver(capsys):
         pjoin(test_dir, 'files/foo-foe-1.ipynb'),
         pjoin(test_dir, 'files/foo-foe-1.ipynb'), 'invalid_mock_checksum', '100644',
         pjoin(test_dir, 'files/foo-foe-2.ipynb'), 'invalid_mock_checksum', '100644']
+    import nbdime.prettyprint
+    # Disable color printing for test
+    nbdime.prettyprint._git_diff_print_cmd = \
+        nbdime.prettyprint._git_diff_print_cmd.replace(' --color-words', '')
     with mock.patch('sys.argv', mock_argv):
         with pytest.raises(SystemExit) as cm:
             gdd_main()


### PR DESCRIPTION
Remove `--color-word` argument when prettyprinting diff for test, in order to avoid coloring characters in captured output. See #44.