### PR TITLE
Added a command to setup.py to run npm install and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,5 @@ Install the [codecov browser extension](https://github.com/codecov/browser-exten
 
     git clone https://github.com/jupyter/nbdime
     cd nbdime
-    # for web-based diff tool:
-      cd nbdime/webapp
-      npm install && npm run build
-      cd ../..
     pip install .
     

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,9 @@ PY3 = (sys.version_info[0] >= 3)
 
 import os
 from glob import glob
+from subprocess import check_call
 
+from distutils import log
 from distutils.core import setup
 from distutils.cmd import Command
 from distutils.command.build import build
@@ -38,6 +40,63 @@ from distutils.command.sdist import sdist
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))
 pkg_root = pjoin(here, name)
+
+
+def run(cmd, cwd=None):
+    """Run a command
+
+    >>> run('npm install', cwd='./subdir')
+    """
+    # On Windows, shell should be True so that the path is searched for the command.
+    shell = (sys.platform == 'win32')
+    check_call(cmd.split(), shell=shell, cwd=cwd, stdout=sys.stdout, stderr=sys.stderr)
+
+
+def js_prerelease(command):
+    """Decorator for building minified js/css prior to another command"""
+    class DecoratedCommand(command):
+        def run(self):
+            self.distribution.run_command('jsdeps')
+            command.run(self)
+
+    return DecoratedCommand
+
+
+def install_npm(path):
+    """Return a Command for running npm install and npm build at a given path."""
+
+    class NPM(Command):
+        description = 'install package.json dependencies using npm'
+        user_options = []
+
+        node_package = path
+        node_modules = pjoin(node_package, 'node_modules')
+
+        def initialize_options(self):
+            pass
+
+        def finalize_options(self):
+            pass
+
+        def has_npm(self):
+            try:
+                run('npm --version')
+                return True
+            except:
+                return False
+
+        def run(self):
+            log.info('Checking npm-installation:')
+            has_npm = self.has_npm()
+            if not has_npm:
+                log.error("`npm` unavailable.  If you're running this command "
+                          "using sudo, make sure `npm` is availble to sudo")
+            if not os.path.exists(self.node_modules):
+                log.info('Installing build dependencies with npm.  This may '
+                         'take a while...')
+                run('npm install', cwd=self.node_package)
+            run('npm build', cwd=self.node_package)
+    return NPM
 
 packages = []
 for d, _, _ in os.walk(pjoin(here, name)):
@@ -85,8 +144,19 @@ setup_args = dict(
     ],
 )
 
+cmdclass = dict(
+    build  = js_prerelease(build),
+    sdist  = js_prerelease(sdist),
+    jsdeps = install_npm(pjoin(here, 'nbdime', 'webapp')),
+)
+
 if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
     import setuptools
+    from setuptools.command.develop import develop
+
+    cmdclass['develop'] = js_prerelease(develop)
+
+setup_args['cmdclass'] = cmdclass
 
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [


### PR DESCRIPTION
See Issue #51.

I have added a command for running `npm install` and `npm build` during setup.py. The command is set to be run automatically on `build`, `develop`, and `sdist`. The code is mainly inspired by the similar code for jupyterlab, https://github.com/jupyter/jupyterlab/blob/master/setup.py

For now, the `npm install` checks for the `node_modules` directory, and runs if that directory does not exist, while `npm build` runs every time. There might be better ways to trigger this (I am not very familiar with node)?