### PR TITLE
Consistency fixes in CLI tools

### DIFF
--- a/nbdime/__main__.py
+++ b/nbdime/__main__.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import sys
+
+
+def main_dispatch(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    cmd = args[0]
+    args = args[1:]
+
+    if cmd == "nbdiff":
+        from nbdime.nbdiffapp import main
+    elif cmd == "nbmerge":
+        from nbdime.nbmergeapp import main
+    elif cmd == "nbpatch":
+        from nbdime.nbpatchapp import main
+    elif cmd == "nbdiff-web":
+        from nbdime.webapp.nbdiffweb import main
+    elif cmd == "nbmerge-web":
+        from nbdime.webapp.nbmergeweb import main
+    else:
+        print("Invalid command '%s', expecting one"
+              "of diff, merge, or patch." % (cmd,))
+        return -1
+
+    return main(args)
+
+
+if __name__ == "__main__":
+    # This is triggered by "python -m nbdime <args>"
+    sys.exit(main_dispatch())

--- a/nbdime/__main__.py
+++ b/nbdime/__main__.py
@@ -26,9 +26,9 @@ def main_dispatch(args=None):
     elif cmd == "nbmerge-web":
         from nbdime.webapp.nbmergeweb import main
     else:
-        print("Invalid command '%s', expecting one"
-              "of diff, merge, or patch." % (cmd,))
-        return -1
+        print("Invalid command '%s', expecting one of:\n"
+              "  nbdiff, nbmerge, nbpatch, nbdiff-web, nbmerge-web." % (cmd,))
+        return 1
 
     return main(args)
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -66,6 +66,7 @@ def add_diff_args(parser):
     #parser.add_argument('-d', '--diff-strategy',
     #                    default="default", choices=("foo", "bar"),
     #                    help="specify the diff strategy to use.")
+    pass
 
 
 def add_merge_args(parser):

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -29,16 +29,6 @@ def add_generic_args(parser):
             action="store_true",
             help="silence console output.")
 
-    parser.add_argument(
-        'base',
-        help="The base notebook filename.")
-    parser.add_argument(
-        'local',
-        help="The local modified notebook filename (merge only).")
-    parser.add_argument(
-        'remote',
-        help="The remote modified notebook filename.")
-
 
 def add_web_args(parser, default_port=8888):
     """Adds a set of arguments common to all commands that show a web gui.
@@ -93,3 +83,19 @@ def add_merge_args(parser):
         default=False,
         help="Allow deletion of transient data such as outputs and "
              "execution counts in order to resolve conflicts.")
+
+
+def add_filename_args(parser, names):
+    """Add the base, local, remote, and merged positional arguments.
+
+    Helps getting consistent doc strings.
+    """
+    helps = {
+        "base":   "The base notebook filename.",
+        "local":  "The local modified notebook filename.",
+        "remote": "The remote modified notebook filename.",
+        "merged": "The merge result notebook filename.",
+        "patch":  "The patch filename, output from nbdiff.",
+        }
+    for name in names:
+        parser.add_argument(name, help=helps[name])

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -15,6 +15,7 @@ def add_generic_args(parser):
         '--version',
         action="version",
         version="%(prog)s " + __version__)
+
     if 0:  # TODO: Use verbose and quiet across nbdime and enable these:
         qv_group = parser.add_mutually_exclusive_group()
         qv_group.add_argument(
@@ -27,6 +28,16 @@ def add_generic_args(parser):
             default=False,
             action="store_true",
             help="silence console output.")
+
+    parser.add_argument(
+        'base',
+        help="The base notebook filename.")
+    parser.add_argument(
+        'local',
+        help="The local modified notebook filename (merge only).")
+    parser.add_argument(
+        'remote',
+        help="The remote modified notebook filename.")
 
 
 def add_web_args(parser, default_port=8888):
@@ -45,7 +56,7 @@ def add_web_args(parser, default_port=8888):
     cwd = os.path.abspath(os.path.curdir)
     parser.add_argument(
         '-w', '--workdirectory',
-        default=cwd,  # TODO: Are there any security implications of doing this?
+        default=cwd,
         help="specify the working directory you want "
                 "the server to run from. Default is the "
                 "actual cwd at program start.")
@@ -65,7 +76,6 @@ def add_diff_args(parser):
     #parser.add_argument('-d', '--diff-strategy',
     #                    default="default", choices=("foo", "bar"),
     #                    help="specify the diff strategy to use.")
-    pass
 
 
 def add_merge_args(parser):
@@ -83,13 +93,3 @@ def add_merge_args(parser):
         default=False,
         help="Allow deletion of transient data such as outputs and "
              "execution counts in order to resolve conflicts.")
-
-    parser.add_argument(
-        'base',
-        help="The base notebook filename.")
-    parser.add_argument(
-        'local',
-        help="The local modified notebook filename.")
-    parser.add_argument(
-        'remote',
-        help="The remote modified notebook filename.")

--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -116,3 +116,7 @@ def main(args=None):
     else:
         parser.print_help()
         return 1
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -68,7 +68,9 @@ def disable(global_=False):
         pass
 
 
-def main():
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     import argparse
     parser = argparse.ArgumentParser('git-nbdiffdriver', description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -105,14 +107,12 @@ def main():
         dest='config_func', const=disable,
         help="disable nbdime diff driver via git config"
     )
-    opts = parser.parse_args()
+    opts = parser.parse_args(args)
     if opts.subcommand == 'diff':
-        nbdiffapp.main([opts.a, opts.b])
+        return nbdiffapp.main([opts.a, opts.b])
     elif opts.subcommand == 'config':
         opts.config_func(opts.global_)
+        return 0
     else:
         parser.print_help()
-        sys.exit(1)
-
-if __name__ == '__main__':
-    main()
+        return 1

--- a/nbdime/gitdifftool.py
+++ b/nbdime/gitdifftool.py
@@ -83,12 +83,15 @@ def show_diff(before, after):
     """
     # TODO: handle /dev/null (Windows equivalent?) for new or deleted files
     if before.endswith('.ipynb') or after.endswith('ipynb'):
-        nbdiffapp.main([before, after])
+        return nbdiffapp.main([before, after])
     else:
+        # Never returns
         os.execvp('git', ['git', 'diff', before, after])
 
 
-def main():
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     import argparse
     parser = argparse.ArgumentParser('git-nbdifftool', description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -115,14 +118,12 @@ def main():
         dest='config_func', const=disable,
         help="disable nbdime difftool via git config"
     )
-    opts = parser.parse_args()
+    opts = parser.parse_args(args)
     if opts.subcommand == 'diff':
-        show_diff(opts.local, opts.remote)
+        return show_diff(opts.local, opts.remote)
     elif opts.subcommand == 'config':
         opts.config_func(opts.global_)
+        return 0
     else:
         parser.print_help()
-        sys.exit(1)
-
-if __name__ == '__main__':
-    main()
+        return 1

--- a/nbdime/gitdifftool.py
+++ b/nbdime/gitdifftool.py
@@ -101,8 +101,8 @@ def main(args=None):
     diff_parser = subparsers.add_parser('diff',
         description="The actual entrypoint for the diff tool. Git will call this."
     )
-    diff_parser.add_argument('local')
-    diff_parser.add_argument('remote')
+    from .args import add_filename_args
+    add_filename_args(diff_parser, ["local", "remote"])
 
     config = subparsers.add_parser('config',
         description="Configure git to use nbdime via `git difftool`")

--- a/nbdime/gitdifftool.py
+++ b/nbdime/gitdifftool.py
@@ -127,3 +127,7 @@ def main(args=None):
     else:
         parser.print_help()
         return 1
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/gitmergedriver.py
+++ b/nbdime/gitmergedriver.py
@@ -16,6 +16,8 @@ Use with:
     git merge [<commit> [<commit>]]
 """
 
+from __future__ import print_function
+
 import sys
 import os
 import argparse
@@ -70,7 +72,9 @@ def disable(global_=False):
         pass
 
 
-def main():
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     parser = argparse.ArgumentParser('git-nbmergedriver', description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -104,19 +108,16 @@ def main():
         dest='config_func', const=disable,
         help="disable nbdime merge driver via git config"
     )
-    opts = parser.parse_args()
+    opts = parser.parse_args(args)
     if opts.subcommand == 'merge':
         # "The merge driver is expected to leave the result of the merge in the
         # file named with %A by overwriting it, and exit with zero status if it
         # managed to merge them cleanly, or non-zero if there were conflicts."
         opts.output = opts.local
-        returncode = nbmergeapp.main_merge(opts)
-        sys.exit(returncode)
+        return nbmergeapp.main_merge(opts)
     elif opts.subcommand == 'config':
         opts.config_func(opts.global_)
+        return 0
     else:
         parser.print_help()
-        sys.exit(1)
-
-if __name__ == '__main__':
-    main()
+        return 1

--- a/nbdime/gitmergedriver.py
+++ b/nbdime/gitmergedriver.py
@@ -24,7 +24,7 @@ import argparse
 from subprocess import check_call, check_output, CalledProcessError
 
 from . import nbmergeapp
-from .args import add_generic_args, add_diff_args, add_merge_args
+from .args import add_generic_args, add_diff_args, add_merge_args, add_filename_args
 
 
 def enable(global_=False):
@@ -85,8 +85,11 @@ def main(args=None):
     )
     add_diff_args(merge_parser)
     add_merge_args(merge_parser)
+
     # Argument list
     # we are given base, local remote
+    add_filename_args(merge_parser, ["base", "local", "remote"])
+
     # TODO: support git-config-specified conflict markers inside sources
     merge_parser.add_argument('marker')
     merge_parser.add_argument('output', nargs='?')

--- a/nbdime/gitmergedriver.py
+++ b/nbdime/gitmergedriver.py
@@ -124,3 +124,7 @@ def main(args=None):
     else:
         parser.print_help()
         return 1
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/gitmergetool.py
+++ b/nbdime/gitmergetool.py
@@ -99,3 +99,7 @@ def main(args=None):
     else:
         parser.print_help()
         return 1
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/gitmergetool.py
+++ b/nbdime/gitmergetool.py
@@ -60,7 +60,9 @@ def disable(global_=False):
         check_call(cmd + ['merge.tool', previous])
 
 
-def main():
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     import argparse
     parser = argparse.ArgumentParser('git-nbmergetool', description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -89,15 +91,12 @@ def main():
         dest='config_func', const=disable,
         help="disable nbdime mergetool via git config"
     )
-    opts = parser.parse_args()
+    opts = parser.parse_args(args)
     if opts.subcommand == 'merge':
-        nbmergeapp.main([opts.base, opts.local, opts.remote, opts.merged])
+        return nbmergeapp.main([opts.base, opts.local, opts.remote, opts.merged])
     elif opts.subcommand == 'config':
         opts.config_func(opts.global_)
+        return 0
     else:
         parser.print_help()
-        sys.exit(1)
-
-
-if __name__ == '__main__':
-    main()
+        return 1

--- a/nbdime/gitmergetool.py
+++ b/nbdime/gitmergetool.py
@@ -16,6 +16,7 @@ import sys
 from subprocess import check_call, check_output, CalledProcessError
 
 from . import nbmergeapp
+from .args import add_filename_args
 
 def enable(global_=False):
     """Enable nbdime git mergetool"""
@@ -72,10 +73,8 @@ def main(args=None):
     merge_parser = subparsers.add_parser('merge',
         description="The actual entrypoint for the mergetool. Git will call this."
     )
-    merge_parser.add_argument('base')
-    merge_parser.add_argument('local')
-    merge_parser.add_argument('remote')
-    merge_parser.add_argument('merged')
+
+    add_filename_args(merge_parser, ["base", "local", "remote", "merged"])
 
     config = subparsers.add_parser('config',
         description="Configure git to use nbdime via `git mergetool`")

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -75,3 +75,7 @@ def main(args=None):
         colorama.init()
     arguments = _build_arg_parser().parse_args(args)
     return main_diff(arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -63,17 +63,17 @@ def _build_arg_parser():
         help="if supplied, the diff is written to this file. "
              "Otherwise it is printed to the terminal.")
 
-    parser.add_argument('base',
-                        help="the base notebook file.")
-    parser.add_argument('remote',
-                        help="the modified notebook file.")
     return parser
 
 
-def main(argv=None):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     if sys.platform.startswith('win'):
         import colorama
         colorama.init()
-    args = _build_arg_parser().parse_args(argv)
-    r = main_diff(args)
-    sys.exit(r)
+    arguments = _build_arg_parser().parse_args(args)
+    if arguments.local:
+        print("Please use base and remote for diff, not local.")
+        return 1
+    return main_diff(arguments)

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -14,7 +14,7 @@ import json
 
 from .diffing.notebooks import diff_notebooks
 from .prettyprint import pretty_print_notebook_diff
-from .args import add_generic_args, add_diff_args
+from .args import add_generic_args, add_diff_args, add_filename_args
 
 
 _description = "Compute the difference between two Jupyter notebooks."
@@ -56,6 +56,7 @@ def _build_arg_parser():
         )
     add_generic_args(parser)
     add_diff_args(parser)
+    add_filename_args(parser, ["base", "remote"])
 
     parser.add_argument(
         '-o', '--output',
@@ -73,7 +74,4 @@ def main(args=None):
         import colorama
         colorama.init()
     arguments = _build_arg_parser().parse_args(args)
-    if arguments.local:
-        print("Please use base and remote for diff, not local.")
-        return 1
     return main_diff(arguments)

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -72,10 +72,11 @@ def _build_arg_parser():
         description=_description,
         add_help=True,
         )
-    from .args import add_generic_args, add_diff_args, add_merge_args
+    from .args import add_generic_args, add_diff_args, add_merge_args, add_filename_args
     add_generic_args(parser)
     add_diff_args(parser)
     add_merge_args(parser)
+    add_filename_args(parser, ["base", "local", "remote"])
 
     parser.add_argument(
         '-o', '--output',

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -93,3 +93,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
     return main_merge(arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -87,7 +87,8 @@ def _build_arg_parser():
     return parser
 
 
-def main():
-    args = _build_arg_parser().parse_args()
-    r = main_merge(args)
-    sys.exit(r)
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    arguments = _build_arg_parser().parse_args(args)
+    return main_merge(arguments)

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -67,7 +67,8 @@ def _build_arg_parser():
     return parser
 
 
-def main():
-    args = _build_arg_parser().parse_args()
-    r = main_patch(args)
-    sys.exit(r)
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    arguments = _build_arg_parser().parse_args(args)
+    return main_patch(arguments)

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -66,3 +66,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
     return main_patch(arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -49,15 +49,9 @@ def _build_arg_parser():
         description=_description,
         add_help=True,
         )
-    from .args import add_generic_args
+    from .args import add_generic_args, add_filename_args
     add_generic_args(parser)
-
-    parser.add_argument(
-        'base',
-        help="The base notebook filename.")
-    parser.add_argument(
-        'patch',
-        help="The patch filename, output from nbdiff.")
+    add_filename_args(parser, ["base", "patch"])
     parser.add_argument(
         '-o', '--output',
         default=None,

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -49,9 +49,11 @@ def test_git_diff_driver(capsys, noindent):
         pjoin(test_dir, 'files/foo--1.ipynb'), 'invalid_mock_checksum', '100644',
         pjoin(test_dir, 'files/foo--2.ipynb'), 'invalid_mock_checksum', '100644']
     with mock.patch('sys.argv', mock_argv):
-        with pytest.raises(SystemExit) as cm:
-            gdd_main()
-        assert cm.value.code == 0
+        r = gdd_main()
+        assert r == 0
+        #with pytest.raises(SystemExit) as cm:
+        #    gdd_main()
+        #assert cm.value.code == 0
         cap_out = capsys.readouterr()[0]
         assert cap_out  == expected_output.format(
             pjoin(test_dir, 'files/foo--1.ipynb'),

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
 from argparse import ArgumentParser
 import os.path
 import webbrowser
@@ -27,7 +28,10 @@ def build_arg_parser():
     user specify a port and displays a help message.
     """
     description = 'difftool for Nbdime.'
-    parser = ArgumentParser(description=description)
+    parser = ArgumentParser(
+        description=description,
+        add_help=True
+        )
     add_generic_args(parser)
     add_web_args(parser, 0)
     add_diff_args(parser)
@@ -47,15 +51,17 @@ def browse(port):
         threading.Thread(target=launch_browser).start()
 
 
-def main():
-    arguments = build_arg_parser().parse_args()
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    arguments = build_arg_parser().parse_args(args)
+    if arguments.local:
+        print("Please use base and remote for diff, not local.")
+        return 1
     port = arguments.port
     cwd = arguments.workdirectory
-    local = arguments.local
+    base = arguments.base
     remote = arguments.remote
     browse(port)
-    run_server(port=port, cwd=cwd,
-               difftool_args=dict(base=local, remote=remote))
-
-if __name__ == "__main__":
-    main()
+    return run_server(port=port, cwd=cwd,
+                      difftool_args=dict(base=base, remote=remote))

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -11,8 +11,8 @@ import webbrowser
 import logging
 import threading
 
-from ..args import (add_generic_args, add_diff_args,
-    add_web_args)
+from ..args import add_generic_args, add_diff_args
+from ..args import add_web_args, add_filename_args
 from .nbdimeserver import main as run_server
 
 
@@ -35,6 +35,7 @@ def build_arg_parser():
     add_generic_args(parser)
     add_web_args(parser, 0)
     add_diff_args(parser)
+    add_filename_args(parser, ["base", "remote"])
     return parser
 
 
@@ -55,9 +56,6 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
-    if arguments.local:
-        print("Please use base and remote for diff, not local.")
-        return 1
     port = arguments.port
     cwd = arguments.workdirectory
     base = arguments.base

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -63,3 +63,7 @@ def main(args=None):
     browse(port)
     return run_server(port=port, cwd=cwd,
                       difftool_args=dict(base=base, remote=remote))
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -13,7 +13,7 @@ import threading
 from tornado.httputil import url_concat
 
 from .nbdimeserver import main as run_server
-from ..args import add_generic_args, add_web_args, add_diff_args
+from ..args import add_generic_args, add_web_args, add_diff_args, add_filename_args
 
 
 _logger = logging.getLogger(__name__)
@@ -32,6 +32,7 @@ def build_arg_parser():
     add_generic_args(parser)
     add_web_args(parser, 0)
     add_diff_args(parser)
+    add_filename_args(parser, ["base", "remote"])
     return parser
 
 

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -61,3 +61,7 @@ def main(args=None):
     remote = arguments.remote
     browse(port, base, remote)
     return run_server(port=port, cwd=cwd)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
 from argparse import ArgumentParser
 import os.path
 import webbrowser
@@ -24,7 +25,10 @@ def build_arg_parser():
     user specify a port and displays a help message.
     """
     description = 'Difftool for Nbdime.'
-    parser = ArgumentParser(description=description)
+    parser = ArgumentParser(
+        description=description,
+        add_help=True
+        )
     add_generic_args(parser)
     add_web_args(parser, 0)
     add_diff_args(parser)
@@ -46,14 +50,13 @@ def browse(port, base, remote):
         threading.Thread(target=b).start()
 
 
-def main():
-    arguments = build_arg_parser().parse_args()
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    arguments = build_arg_parser().parse_args(args)
     port = arguments.port
     cwd = arguments.workdirectory
-    local = arguments.local
+    base = arguments.base
     remote = arguments.remote
-    browse(port, local, remote)
-    run_server(port=port, cwd=cwd)
-
-if __name__ == "__main__":
-    main()
+    browse(port, base, remote)
+    return run_server(port=port, cwd=cwd)

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -262,3 +262,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
     return main_server(port=arguments.port, cwd=arguments.workdirectory)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -235,14 +235,14 @@ def make_app(**params):
     return web.Application(handlers, **settings)
 
 
-def main(**params):
+def main_server(**params):
     print("Using params:")
     print(params)
     port = params.pop("port")
     app = make_app(**params)
     app.listen(port)
     ioloop.IOLoop.current().start()
-    sys.exit(exit_code)
+    return exit_code
 
 
 def _build_arg_parser():
@@ -257,6 +257,8 @@ def _build_arg_parser():
     return parser
 
 
-if __name__ == "__main__":
-    arguments = _build_arg_parser().parse_args()
-    main(port=arguments.port, cwd=arguments.workdirectory)
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    arguments = _build_arg_parser().parse_args(args)
+    return main_server(port=arguments.port, cwd=arguments.workdirectory)

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
 from argparse import ArgumentParser
 import os.path
 import webbrowser
@@ -27,7 +28,10 @@ def build_arg_parser():
     user specify a port and displays a help message.
     """
     description = 'mergetool for Nbdime.'
-    parser = ArgumentParser(description=description)
+    parser = ArgumentParser(
+        description=description,
+        add_help=True
+        )
     add_generic_args(parser)
     add_diff_args(parser)
     add_merge_args(parser)
@@ -53,7 +57,9 @@ def browse(port):
         threading.Thread(target=launch_browser).start()
 
 
-def main():
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     arguments = build_arg_parser().parse_args()
     port = arguments.port
     cwd = arguments.workdirectory
@@ -62,9 +68,6 @@ def main():
     remote = arguments.remote
     merged = arguments.merged
     browse(port)
-    run_server(port=port, cwd=cwd,
-               mergetool_args=dict(base=base, local=local, remote=remote),
-               outputfilename=merged)
-
-if __name__ == "__main__":
-    main()
+    return run_server(port=port, cwd=cwd,
+                      mergetool_args=dict(base=base, local=local, remote=remote),
+                      outputfilename=merged)

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -12,7 +12,7 @@ import logging
 import threading
 
 from ..args import add_generic_args, add_filename_args
-from ..args import add_diff_args, add_merge_args, add_web_args, 
+from ..args import add_diff_args, add_merge_args, add_web_args
 from .nbdimeserver import main as run_server
 
 

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -72,3 +72,7 @@ def main(args=None):
     return run_server(port=port, cwd=cwd,
                       mergetool_args=dict(base=base, local=local, remote=remote),
                       outputfilename=merged)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -11,8 +11,8 @@ import webbrowser
 import logging
 import threading
 
-from ..args import (add_generic_args, add_diff_args,
-    add_merge_args, add_web_args)
+from ..args import add_generic_args, add_filename_args
+from ..args import add_diff_args, add_merge_args, add_web_args, 
 from .nbdimeserver import main as run_server
 
 
@@ -41,6 +41,7 @@ def build_arg_parser():
         default=None,
         help="if supplied, the merged notebook is written "
              "to this file. Otherwise it cannot be saved.")
+    add_filename_args(parser, ["base", "local", "remote", "merged"])
     return parser
 
 

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -65,3 +65,7 @@ def main(args=None):
     remote = arguments.remote
     browse(port, base, local, remote)
     return run_server(port=port, cwd=cwd)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -12,8 +12,8 @@ import logging
 import threading
 from tornado.httputil import url_concat
 
-from ..args import (add_generic_args, add_diff_args,
-    add_merge_args, add_web_args)
+from ..args import add_generic_args, add_diff_args
+from ..args import add_merge_args, add_web_args, add_filename_args
 from .nbdimeserver import main as run_server
 
 
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
 
 def build_arg_parser():
     """
-    Creates an argument parser for the diff tool, that also lets the
+    Creates an argument parser for the merge tool, that also lets the
     user specify a port and displays a help message.
     """
     description = 'Mergetool for Nbdime.'
@@ -34,11 +34,7 @@ def build_arg_parser():
     add_diff_args(parser)
     add_merge_args(parser)
     add_web_args(parser, 0)
-    parser.add_argument(
-        '-o', '--output',
-        default=None,
-        help="if supplied, the merged notebook is written "
-             "to this file. Otherwise it cannot be saved.")
+    add_filename_args(parser, ["base", "local", "remote"])
     return parser
 
 

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
 from argparse import ArgumentParser
 import os.path
 import webbrowser
@@ -24,8 +25,11 @@ def build_arg_parser():
     Creates an argument parser for the diff tool, that also lets the
     user specify a port and displays a help message.
     """
-    description = 'Difftool for Nbdime.'
-    parser = ArgumentParser(description=description)
+    description = 'Mergetool for Nbdime.'
+    parser = ArgumentParser(
+        description=description,
+        add_help=True
+        )
     add_generic_args(parser)
     add_diff_args(parser)
     add_merge_args(parser)
@@ -54,15 +58,14 @@ def browse(port, base, local, remote):
         threading.Thread(target=b).start()
 
 
-def main():
-    arguments = build_arg_parser().parse_args()
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    arguments = build_arg_parser().parse_args(args)
     port = arguments.port
     cwd = arguments.workdirectory
     base = arguments.base
     local = arguments.local
     remote = arguments.remote
     browse(port, base, local, remote)
-    run_server(port=port, cwd=cwd)
-
-if __name__ == "__main__":
-    main()
+    return run_server(port=port, cwd=cwd)

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -35,6 +35,11 @@ def build_arg_parser():
     add_merge_args(parser)
     add_web_args(parser, 0)
     add_filename_args(parser, ["base", "local", "remote"])
+    parser.add_argument(
+        '-o', '--output',
+        default=None,
+        help="if supplied, the merged notebook is written "
+             "to this file. Otherwise it cannot be saved.")
     return parser
 
 
@@ -63,8 +68,9 @@ def main(args=None):
     base = arguments.base
     local = arguments.local
     remote = arguments.remote
+    output = arguments.output
     browse(port, base, local, remote)
-    return run_server(port=port, cwd=cwd)
+    return run_server(port=port, cwd=cwd, outputfilename=output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
… exit.

Also enable help text for all apps.

Canonical pattern:

    def main(args=None):
        if args is None:
            args = sys.argv[1:]
        ...
        return returncode

Outside of `__main__`, there's no need to have `if __name__ ==
"__main__"`.

With the addition of __main__, you can now do:

  python -m nbdime nbdiff <args>

instead of

  nbdiff <args>

which may be convenient to test with different python versions.

There is still some confusion about where --base --local --remote
are defined, I tried fixing a failure one place but the args.py utils
are not used consistently.