### PR TITLE
Use io.open with utf-8 encoding everywhere

### DIFF
--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -18,6 +18,7 @@ Use with:
 
 from __future__ import print_function
 
+import io
 import os
 import sys
 from subprocess import check_call, check_output, CalledProcessError
@@ -47,12 +48,12 @@ def enable(global_=False):
         gitattributes = os.path.join(path, '.gitattributes')
 
     if os.path.exists(gitattributes):
-        with open(gitattributes) as f:
+        with io.open(gitattributes, encoding="utf8") as f:
             if 'diff=jupyternotebook' in f.read():
                 # already written, nothing to do
                 return
 
-    with open(gitattributes, 'a') as f:
+    with io.open(gitattributes, 'a', encoding="utf8") as f:
         f.write('\n*.ipynb\tdiff=jupyternotebook\n')
 
 

--- a/nbdime/gitmergedriver.py
+++ b/nbdime/gitmergedriver.py
@@ -18,6 +18,7 @@ Use with:
 
 from __future__ import print_function
 
+import io
 import sys
 import os
 import argparse
@@ -51,12 +52,12 @@ def enable(global_=False):
         gitattributes = os.path.join(path, '.gitattributes')
 
     if os.path.exists(gitattributes):
-        with open(gitattributes) as f:
+        with io.open(gitattributes, encoding="utf8") as f:
             if 'merge=jupyternotebook' in f.read():
                 # already written, nothing to do
                 return
 
-    with open(gitattributes, 'a') as f:
+    with io.open(gitattributes, 'a', encoding="utf8") as f:
         f.write('\n*.ipynb\tmerge=jupyternotebook\n')
 
 

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -6,6 +6,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import io
 import os
 import sys
 import argparse
@@ -40,7 +41,7 @@ def main_diff(args):
         pretty_print_notebook_diff(afn, bfn, a, d)
 
     if dfn:
-        with open(dfn, "w") as df:
+        with io.open(dfn, "w", encoding="utf8") as df:
             # Compact version:
             #json.dump(d, df)
             # Verbose version:

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -6,6 +6,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import io
 import os
 import sys
 import argparse
@@ -49,7 +50,7 @@ def main_merge(args):
         if conflicted:
             m["metadata"]["nbdime-conflicts"] = conflicted
         # Write partial or fully completed merge to given foo.ipynb filename
-        with open(mfn, "wb") as mf:
+        with io.open(mfn, "wb") as mf:
             # FIXME: We currently write this way as git needs \n line endings,
             # when used as merge driver. However, we should write using OS
             # line endings otherwise.

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -11,6 +11,7 @@ import sys
 import argparse
 import json
 import nbformat
+import io
 from ._version import __version__
 from .patching import patch_notebook
 from .diff_format import to_diffentry_dicts
@@ -29,7 +30,7 @@ def main_patch(args):
             return 1
 
     before = nbformat.read(base_filename, as_version=4)
-    with open(path_filename) as patch_file:
+    with io.open(path_filename, encoding="utf8") as patch_file:
         diff = json.load(patch_file)
     diff = to_diffentry_dicts(diff)
 

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 from itertools import chain
+import io
 import os
 import pprint
 import re
@@ -259,9 +260,9 @@ def present_string_diff(a, di, path):
     td = tempfile.mkdtemp()
     cmd = None
     try:
-        with open(os.path.join(td, 'before'), 'w') as f:
+        with io.open(os.path.join(td, 'before'), 'w', encoding="utf8") as f:
             f.write(a)
-        with open(os.path.join(td, 'after'), 'w') as f:
+        with io.open(os.path.join(td, 'after'), 'w', encoding="utf8") as f:
             f.write(b)
         if which('git'):
             cmd = _git_diff_print_cmd.split()

--- a/nbdime/tests/files/unicode--1.ipynb
+++ b/nbdime/tests/files/unicode--1.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Norwegian alphabet contains the letters æøå which are outside the ASCII charset.\n",
+    "\n",
+    "Many languages such as French contain accented letters such as è, é, ê.\n",
+    "\n",
+    "Some libraries print mathematical symbols such as\n",
+    "\n",
+    "Einstein is famous for the formula e=mc².\n",
+    "\n",
+    "There's 360° in a circle, and 1 µm is 10⁻⁶ m."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/nbdime/tests/files/unicode--2.ipynb
+++ b/nbdime/tests/files/unicode--2.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Norwegian alphabet contains the letters æøå which are outside the ASCII charset.\n",
+    "\n",
+    "Many languages such as French contain accented letters such as è, é, ê.\n",
+    "\n",
+    "Some libraries print mathematical symbols such as\n",
+    "\n",
+    "Greek letters such as δ, Σ, and θ are popular in mathematics.\n",
+    "\n",
+    "Einstein is famous for the formula e=mc²."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -141,7 +141,7 @@ def matching_nb_triplets(request):
 def assert_is_valid_notebook(nb):
     """These are the current assumptions on notebooks in these tests. Loosen on demand."""
     assert nb["nbformat"] == 4
-    assert nb["nbformat_minor"] == 0
+    #assert nb["nbformat_minor"] == 0
     assert isinstance(nb["metadata"], dict)
     assert isinstance(nb["cells"], list)
     assert all(isinstance(cell, dict) for cell in nb["cells"])

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 from six.moves import xrange as range
 
+import io
 import pytest
 import os
 import glob
@@ -66,7 +67,8 @@ class NBTestDataBase(object):
         # Cache file reads
         nbs = self.cache.get(name)
         if nbs is None:
-            with open(os.path.join(self.filespath, name + ".ipynb")) as f:
+            fn = os.path.join(self.filespath, name + ".ipynb")
+            with io.open(fn, encoding="utf8") as f:
                 nbs = f.read()
             self.cache[name] = nbs
         # But return a new notebook copy every time

--- a/nbdime/tests/test_diff_format.py
+++ b/nbdime/tests/test_diff_format.py
@@ -1,6 +1,7 @@
 
 import pytest
 import json
+import io
 import os
 from jsonschema import ValidationError
 from jsonschema import Draft4Validator as Validator
@@ -11,7 +12,7 @@ schema_path = os.path.join(
     os.path.dirname(__file__),
     '..',
     'diff_format.schema.json')
-with open(schema_path) as f:
+with io.open(schema_path, encoding="utf8") as f:
     schema_json = json.load(f)
 
 validator = Validator(schema_json)

--- a/nbdime/tests/test_diff_format.py
+++ b/nbdime/tests/test_diff_format.py
@@ -8,19 +8,28 @@ from jsonschema import Draft4Validator as Validator
 from nbdime import diff, diff_notebooks
 from .fixtures import matching_nb_pairs
 
-schema_path = os.path.join(
-    os.path.dirname(__file__),
-    '..',
-    'diff_format.schema.json')
-with io.open(schema_path, encoding="utf8") as f:
-    schema_json = json.load(f)
 
-validator = Validator(schema_json)
+schema_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-def test_check_schema():
+
+@pytest.fixture
+def schema_json(request):
+    schema_path = os.path.join(schema_dir, 'diff_format.schema.json')
+    with io.open(schema_path, encoding="utf8") as f:
+        schema_json = json.load(f)
+    return schema_json
+
+
+@pytest.fixture
+def validator(request, schema_json):
+    return Validator(schema_json)
+
+
+def test_check_schema(schema_json):
     Validator.check_schema(schema_json)
 
-def test_validate_obj_diff():
+
+def test_validate_obj_diff(validator):
     a = { "foo": [1,2,3], "bar": {"ting": 7, "tang": 123 } }
     b = { "foo": [1,3,4], "bar": {"tang": 126, "hello": "world" } }
     d = diff(a, b)
@@ -28,7 +37,7 @@ def test_validate_obj_diff():
     validator.validate(d)
 
 
-def test_validate_array_diff():
+def test_validate_array_diff(validator):
     a = [2, 3, 4]
     b = [1, 2, 4, 6]
     d = diff(a, b)
@@ -36,7 +45,7 @@ def test_validate_array_diff():
     validator.validate(d)
 
 
-def test_validate_matching_notebook_diff(matching_nb_pairs):
+def test_validate_matching_notebook_diff(matching_nb_pairs, validator):
     a, b = matching_nb_pairs
     d = diff_notebooks(a, b)
 

--- a/nbdime/tests/test_merge_format.py
+++ b/nbdime/tests/test_merge_format.py
@@ -1,4 +1,5 @@
 
+import io
 import pytest
 import json
 import os
@@ -15,7 +16,7 @@ schema_dir = os.path.abspath(os.path.join(
 schema_path = os.path.join(
     schema_dir,
     'merge_format.schema.json')
-with open(schema_path) as f:
+with io.open(schema_path, encoding="utf8") as f:
     schema_json = json.load(f)
 
 validator = Validator(

--- a/nbdime/tests/test_merge_format.py
+++ b/nbdime/tests/test_merge_format.py
@@ -9,30 +9,35 @@ from nbdime import decide_merge
 from nbdime.merging.notebooks import decide_notebook_merge
 from .fixtures import matching_nb_triplets
 
-schema_dir = os.path.abspath(os.path.join(
-        os.path.dirname(__file__),
-        '..'
-))
-schema_path = os.path.join(
-    schema_dir,
-    'merge_format.schema.json')
-with io.open(schema_path, encoding="utf8") as f:
-    schema_json = json.load(f)
 
-validator = Validator(
-    schema_json,
-    resolver=RefResolver(
-        'file://localhost/' + schema_dir.replace('\\', '/') + '/',
-        schema_json),
-    # Ensure tuples validate to "array" schema type 
-    types={"array" : (list, tuple)},
-)
+schema_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
 
-def test_check_schema():
+@pytest.fixture
+def schema_json(request):
+    schema_path = os.path.join(schema_dir, 'merge_format.schema.json')
+    with io.open(schema_path, encoding="utf8") as f:
+        schema_json = json.load(f)
+    return schema_json
+
+
+@pytest.fixture
+def validator(request, schema_json):
+    return Validator(
+        schema_json,
+        resolver=RefResolver(
+            'file://localhost/' + schema_dir.replace('\\', '/') + '/',
+            schema_json),
+        # Ensure tuples validate to "array" schema type 
+        types={"array" : (list, tuple)},
+    )
+
+
+def test_check_schema(schema_json):
     Validator.check_schema(schema_json)
 
-def test_validate_obj_merge():
+
+def test_validate_obj_merge(validator):
     b = {"p": {"b": 1}}
     l = {"p": {"b": 1}, "n": {"s": 7, "l": 2}}
     r = {"p": {"b": 1}, "n": {"s": 7, "r": 3}}
@@ -41,7 +46,7 @@ def test_validate_obj_merge():
     validator.validate(decisions)
 
 
-def test_validate_array_merge():
+def test_validate_array_merge(validator):
     b = [1, 9]
     l = [1, 2, 7, 9]
     r = [1, 3, 7, 9]
@@ -50,7 +55,7 @@ def test_validate_array_merge():
     validator.validate(decisions)
 
 
-def test_validate_matching_notebook_merge(matching_nb_triplets):
+def test_validate_matching_notebook_merge(matching_nb_triplets, validator):
     base, local, remote = matching_nb_triplets
     decisions = decide_notebook_merge(base, local, remote)
 

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import io
 import os
 import json
 import sys
@@ -176,7 +177,7 @@ class ApiMergeStoreHandler(NbdimeApiHandler):
         # Somehow store unsolved conflicts?
         # conflicts = body["conflicts"]
 
-        with open(path, "w") as f:
+        with io.open(path, "w", encoding="utf8") as f:
             nbformat.write(merged_nb, f)
         self.finish()
 

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ PY3 = (sys.version_info[0] >= 3)
 # get on with it
 #-----------------------------------------------------------------------------
 
+import io
 import os
 from glob import glob
 from subprocess import check_call
@@ -155,7 +156,7 @@ package_data = {
 }
 
 version_ns = {}
-with open(pjoin(here, name, '_version.py')) as f:
+with io.open(pjoin(here, name, '_version.py'), encoding="utf8") as f:
     exec(f.read(), {}, version_ns)
 
 


### PR DESCRIPTION
Fixes nbdiff on commandline with notebooks containing unicode chars.