### PR TITLE
Add error notifications in web-views

### DIFF
--- a/nbdime-web/src/common/exceptions.ts
+++ b/nbdime-web/src/common/exceptions.ts
@@ -30,7 +30,7 @@ namespace NotifyUserError {
    * use an exception.
    */
   export
-  type Severity = 'critical' | 'error' | 'warning';
+  type Severity = 'error' | 'warning';
 
 }
 

--- a/nbdime-web/src/common/exceptions.ts
+++ b/nbdime-web/src/common/exceptions.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+'use strict';
+
+
+/**
+ * An error that should be displayed to the user
+ */
+export
+class NotifyUserError extends Error {
+  constructor(
+      message: string,
+      severity: NotifyUserError.Severity = 'error') {
+    super(message);
+    this.message = message;
+    this.stack = new Error().stack;
+    this.severity = severity;
+  }
+
+  severity: NotifyUserError.Severity;
+}
+
+export
+namespace NotifyUserError {
+  /**
+   * Severity of an error.
+   *
+   * Anything less severe that warning shouldn't
+   * use an exception.
+   */
+  export
+  type Severity = 'critical' | 'error' | 'warning';
+
+}
+

--- a/nbdime-web/src/diff/model/cell.ts
+++ b/nbdime-web/src/diff/model/cell.ts
@@ -7,6 +7,10 @@ import {
 } from 'jupyterlab/lib/notebook/notebook/nbformat';
 
 import {
+  NotifyUserError
+} from '../../common/exceptions';
+
+import {
   IDiffEntry, IDiffArrayEntry
 } from '../diffentries';
 
@@ -36,7 +40,7 @@ export class CellDiffModel {
     this.outputs = outputs;
     this.cellType = cellType;
     if (outputs === null && cellType === 'code') {
-      throw new Error('Invalid code cell, missing outputs!');
+      throw new NotifyUserError('Invalid code cell, missing outputs!');
     }
     this.metadata.collapsible = true;
     this.metadata.collapsibleHeader = 'Metadata changed';

--- a/nbdime-web/src/diff/model/output.ts
+++ b/nbdime-web/src/diff/model/output.ts
@@ -7,6 +7,10 @@ import {
 } from 'jupyterlab/lib/notebook/notebook/nbformat';
 
 import {
+  NotifyUserError
+} from '../../common/exceptions';
+
+import {
   IDiffEntry, IDiffArrayEntry
 } from '../diffentries';
 
@@ -104,7 +108,7 @@ class OutputDiffModel implements IDiffModel {
           key.indexOf('data.') === 0) {
       return key.slice('data.'.length);
     }
-    throw new Error('Unknown MIME type for key: ' + key);
+    throw new NotifyUserError('Unknown MIME type for key: ' + key);
   }
 
   /**

--- a/nbdime-web/src/merge/model/common.ts
+++ b/nbdime-web/src/merge/model/common.ts
@@ -27,6 +27,10 @@ import {
 } from '../../patch';
 
 import {
+  NotifyUserError
+} from '../../common/exceptions';
+
+import {
   valueIn, DeepCopyableObject
 } from '../../common/util';
 
@@ -272,7 +276,7 @@ abstract class ObjectMergeModel<ObjectType extends DeepCopyableObject, DiffModel
     let out: MergeDecision[] = [];
     for (let d of diff) {
       if (this._whitelist && !valueIn(d.key, this._whitelist)) {
-        throw new Error('Currently not able to handle decisions on variable \"' +
+        throw new NotifyUserError('Currently not able to handle decisions on variable \"' +
               d.key + '\"');
       }
       let action: Action = (md.action === 'base' ?

--- a/nbdime-web/test/karma.conf.js
+++ b/nbdime-web/test/karma.conf.js
@@ -21,7 +21,9 @@ module.exports = function (config) {
     },
 
     remapCoverageReporter: {
-      'text-summary': null, // to show summary in console
+      // Text summary is currently before remapping to TS,
+      // so disabled.
+      //'text-summary': null, // to show summary in console
       json: './coverage/remapped.json'
     },
   });

--- a/nbdime-web/tsconfig.json
+++ b/nbdime-web/tsconfig.json
@@ -2,6 +2,9 @@
   "compilerOptions": {
     "target": "ES5",
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true
   }
 }

--- a/nbdime/webapp/package.json
+++ b/nbdime/webapp/package.json
@@ -11,22 +11,23 @@
     "watch:web": "watch \"npm run update\" ../../nbdime-web/lib --wait=10"
   },
   "devDependencies": {
-    "@types/node": "6.0.45",
+    "@types/node": "6.0.46",
     "awesome-typescript-loader": "^2.2.4",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
     "json-loader": "^0.5.4",
-    "watch": "^1.0.1",
-    "rimraf": "^2.5.2",
+    "rimraf": "^2.5.4",
     "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.1",
     "typescript": "^2.0.3",
     "url-loader": "^0.5.7",
+    "watch": "^1.0.1",
     "webpack": "^1.13.1"
   },
   "dependencies": {
-    "nbdime": "file:../../nbdime-web",
+    "alertify.js": "^1.0.12",
     "jupyterlab": "~0.4.1",
+    "nbdime": "file:../../nbdime-web",
     "phosphor": "^0.6.1"
   }
 }

--- a/nbdime/webapp/src/app/common.ts
+++ b/nbdime/webapp/src/app/common.ts
@@ -84,7 +84,6 @@ function showError(error: NotifyUserError, url: string, line: number, column: nu
   case 'warning':
     alertify.log(message);
     break;
-  case 'critical':
   case 'error':
     alertify.error(message);
     break;

--- a/nbdime/webapp/src/app/common.ts
+++ b/nbdime/webapp/src/app/common.ts
@@ -7,10 +7,19 @@ import 'jupyterlab/lib/codemirror/index.css';
 import 'nbdime/lib/styles/common.css';
 import './common.css';
 
+import * as alertify from 'alertify.js';
+
+import {
+  NotifyUserError
+} from 'nbdime/lib/common/exceptions';
+
 /**
  * Global config data for the Nbdime application.
  */
 let configData: any = null;
+
+// Ensure error messages stay open until dismissed.
+alertify.delay(0).closeLogOnClick(true);
 
 /**
  *  Make an object fully immutable by freezing each object in it.
@@ -68,3 +77,32 @@ function closeTool(exitCode=0) {
   window.close();
 }
 
+
+function showError(error: NotifyUserError, url: string, line: number, column: number) {
+  let message = error.message.replace('\n', '</br>');
+  switch (error.severity) {
+  case 'warning':
+    alertify.log(message);
+    break;
+  case 'critical':
+  case 'error':
+    alertify.error(message);
+    break;
+  default:
+    alertify.error(message);
+  }
+}
+
+export
+function handleError(msg: string, url: string, line: number, col?: number, error?: Error): boolean {
+  try {
+    if (error instanceof NotifyUserError) {
+      showError(error, url, line, col || 0);
+      return false;  // Suppress error alert
+    }
+  } catch (e) {
+    // Not something that user should care about
+    console.log(e.stack);
+  }
+  return false;  // Do not suppress default error alert
+}

--- a/nbdime/webapp/src/index.ts
+++ b/nbdime/webapp/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from './app/merge';
 
 import {
-  closeTool, getConfigOption
+  closeTool, getConfigOption, handleError
 } from './app/common';
 
 /** */
@@ -34,3 +34,4 @@ function initialize() {
 }
 
 window.onload = initialize;
+window.onerror = handleError;

--- a/nbdime/webapp/src/tsconfig.json
+++ b/nbdime/webapp/src/tsconfig.json
@@ -2,6 +2,12 @@
   "compilerOptions": {
     "declaration": true,
     "target": "es5",
+    "lib": [
+      "dom",
+      "es5",
+      "es2015.collection",
+      "es2015.promise"
+    ],
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/nbdime/webapp/src/typings.d.ts
+++ b/nbdime/webapp/src/typings.d.ts
@@ -1,5 +1,2 @@
+/// <reference path="../typings/alertify.js.d.ts"/>
 /// <reference path="../typings/codemirror.d.ts"/>
-/// <reference path="../typings/sanitizer.d.ts"/>
-/// <reference path="../typings/json-stable-stringify.d.ts"/>
-/// <reference path="../typings/es6-promise.d.ts"/>
-/// <reference types="node"/>

--- a/nbdime/webapp/typings/alertify.js.d.ts
+++ b/nbdime/webapp/typings/alertify.js.d.ts
@@ -1,0 +1,179 @@
+// Type definitions for alertify 0.3.11
+// Project: http://fabien-d.github.io/alertify.js/
+// Definitions by: John Jeffery <http://github.com/jjeffery>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare var alertify: alertify.IAlertify;
+
+declare namespace alertify {
+    interface IAlertify {
+        /**
+         * Create an alert dialog box
+         * @param message   The message passed from the callee
+         * @param onOkay    Callback function
+         * @param onCancel  Callback function
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        alert(message: string, onOkay?: Function, onCancel?: Function): IAlertify;
+
+        /**
+         * Set the cancel button label
+         * @param label     The label to use
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        cancelBtn(label: string): IAlertify;
+
+        /**
+         * Clear any log notifications
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        clearLogs(): IAlertify;
+
+        /**
+         * Set whether logs should close on click
+         * @param bool      The value
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        closeLogOnClick(bool: boolean): IAlertify;
+
+        /**
+         * Create a confirm dialog box
+         * @param message   The message passed from the callee
+         * @param onOkay    Callback function when OK is clicked
+         * @param onCancel  Callback function when cancel is clicked
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        confirm(message: string, onOkay?: Function, onCancel?: Function): IAlertify;
+
+        /**
+         * Set the default value for dialog input prompt
+         * @param str       The new default value
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        defaultValue(str: string): IAlertify;
+
+        /**
+         * Set the delay. Defaults to 5000 (5s).
+         * @param time      Time (in ms) to wait before automatically hiding the message. If 0, never hide.
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        delay(time: number | string): IAlertify;
+
+        /**
+         * Shorthand for log messages
+         * @param message   The message passed from the callee
+         * @param click     Click event listener
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        error(message: string, click?: (this: this, ev: MouseEvent) => any): IAlertify;
+
+        /**
+         * Show a new log message box
+         * @param message   The message passed from the callee
+         * @param click     Click event listener
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        log(message: string, click?: (this: this, ev: MouseEvent) => any): IAlertify;
+
+        /**
+         * Set the position of log notification. Defaults to "bottom left".
+         * @param str       A string of one or more of "left", "right", "top", "bottom", separated by whitespace.
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        logPosition(str: string): IAlertify;
+
+        /**
+         * Set the maximum number of log/success/error messages that will be displayed at a single time. The default is 2.
+         * @param num       The maximum number of message to display.
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        maxLogItems(num: number): IAlertify;
+
+        /**
+         * Set the OK button label
+         * @param label     The label to use
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        okBtn(label: string): IAlertify;
+
+        /**
+         * Set the parent element where Alertify is appended into the DOM. By default, Alertify is appended to document.body.
+         * @param elem     The parent element.
+         * @since 0.0.1
+         */
+        parent(elem: HTMLElement): void;
+
+        /**
+         * Set the placeholder value for the prompt input
+         * @param str       The placeholder string
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        placeholder(str: string): IAlertify;
+
+        /**
+         * Create a prompt dialog box
+         * @param message   The message passed from the callee
+         * @param onOkay    Callback function when OK is clicked
+         * @param onCancel  Callback function when cancel is clicked
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        prompt(message: string, onOkay?: Function, onCancel?: Function): IAlertify;
+
+        /**
+         * Reset alertify settings
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        reset(): IAlertify;
+
+        /**
+         * Shorthand for log messages
+         * @param message   The message passed from the callee
+         * @param click     Click event listener
+         * @return alertify (ie this)
+         * @since 0.0.1
+         */
+        success(message: string, click?: (this: this, ev: MouseEvent) => any): IAlertify;
+
+        /**
+         * Set the log template method
+         * @param templateMethod Template method
+         * @return alertify      (ie this)
+         * @since 0.0.1
+         */
+        setLogTemplate(templateMethod: ((message: string) => string) | null): IAlertify;
+
+        /**
+         * Set the theme to use for dialogs
+         * @return alertify      (ie this)
+         * @since 0.0.1
+         */
+        theme(themeStr: 'bootstrap' | 'purecss' | 'mdl' | 'material-design-light' | 'angular-material' | 'default'): IAlertify;
+
+        /**
+         * The version of alertify
+         * @since 0.0.1
+         */
+        version: string;
+    }
+}
+
+declare module "alertify.js" {
+
+    export = alertify;
+
+}


### PR DESCRIPTION
Adds a custom exception type, and a global exception handler that will display those errors to the user.

Adds an npm dependcy to `alertify.js` for displaying notifications (DOM-based).