### PR TITLE
Fix gutter marker alignments

### DIFF
--- a/nbdime-web/src/common/mergeview.ts
+++ b/nbdime-web/src/common/mergeview.ts
@@ -493,6 +493,7 @@ class DiffView {
           conflictMarker.classList.add(GUTTER_CONFLICT_CLASS);
           editor.setGutterMarker(line, GUTTER_CONFLICT_CLASS, conflictMarker);
         }
+        editor.addLineClass(line, 'background', classes.end + '-empty');
         markers.push(line);
       }
     }

--- a/nbdime-web/src/common/mergeview.ts
+++ b/nbdime-web/src/common/mergeview.ts
@@ -312,6 +312,10 @@ class DiffView {
   }
 
   protected onGutterClick(instance: CodeMirror.Editor, line: number, gutter: string, clickEvent: MouseEvent): void {
+    if (clickEvent.button !== 0) {
+      // Only care about left clicks
+      return;
+    }
     let li = instance.lineInfo(line);
     if (!li.gutterMarkers || !li.gutterMarkers.hasOwnProperty(gutter)) {
       return;

--- a/nbdime-web/src/common/util.ts
+++ b/nbdime-web/src/common/util.ts
@@ -28,6 +28,22 @@ function hasEntries<T>(array: T[] | null): array is T[] {
   return array !== null && array.length !== 0;
 }
 
+
+/**
+ * Splits a multinline string into an array of lines
+ *
+ * @export
+ * @param {string} multiline
+ * @returns {string[]}
+ */
+export
+function splitLines(multiline: string): string[] {
+  // Split lines (retaining newlines)
+  // We use !postfix, as we also match empty string,
+  // so we are guaranteed to get at elast one match
+  return multiline.match(/^.*(\r\n|\r|\n|$)/gm)!;
+}
+
 /**
  * Deepcopy routine for JSON-able data types
  */

--- a/nbdime-web/src/diff/util.ts
+++ b/nbdime-web/src/diff/util.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import {
-  sortByKey, shallowCopy, accumulateLengths
+  sortByKey, shallowCopy, accumulateLengths, splitLines
 } from '../common/util';
 
 import {
@@ -119,9 +119,7 @@ export
 function flattenStringDiff(val: string[] | string, diff: IDiffArrayEntry[]): IDiffArrayEntry[] {
 
   if (typeof val === 'string') {
-    // Split lines (retaining newlines):
-    let lines = val.match(/^.*(\r\n|\r|\n|$)/gm);
-    val = lines!;  // Since we match end of line, we never get null
+    val = splitLines(val);
   }
   let lineToChar = [0].concat(accumulateLengths(val));
   let flattened: IDiffArrayEntry[] = [];

--- a/nbdime-web/src/merge/decisions.ts
+++ b/nbdime-web/src/merge/decisions.ts
@@ -22,7 +22,7 @@ import {
 } from '../patch';
 
 import {
-  deepCopy, valueIn, isPrefixArray, findSharedPrefix
+  deepCopy, valueIn, isPrefixArray, findSharedPrefix, splitLines
 } from '../common/util';
 
 export
@@ -247,6 +247,7 @@ function popPath(diffs: DiffCollection, popInner?: boolean):
   return null;
 }
 
+export
 function pushPath(diffs: IDiffEntry[], prefix: DecisionPath): IDiffEntry[] {
   for (let key of prefix.reverse()) {
     diffs = [opPatch(key, diffs)];
@@ -355,7 +356,7 @@ function resolveAction(base: any, decision: MergeDecision): IDiffEntry[] {
       d.source = {decision, action: 'custom'};
       return [d];
     } else if (typeof(base) === 'string') {
-      let len = base.match(/^.*(\r\n|\r|\n|$)/gm)!.length;
+      let len = splitLines(base).length;
       let d = opRemoveRange(0, len);
       d.source = {decision, action: 'custom'};
       return [d];

--- a/nbdime-web/src/merge/model/common.ts
+++ b/nbdime-web/src/merge/model/common.ts
@@ -109,6 +109,7 @@ class DecisionStringDiffModel extends StringDiffModel {
     for (let v = iter.next(); v !== undefined; v = iter.next()) {
       if (iter.currentModel() === this) {
         // Chunk diffs in own model normally
+        // (they should already be present in own model)
         chunker.addDiff(v.range, v.isAddition);
       } else {
         // Skip ops in other models that are not no-ops

--- a/nbdime-web/src/styles/common.css
+++ b/nbdime-web/src/styles/common.css
@@ -66,16 +66,6 @@
     background-color: #f8cbcb;
 }
 
-.CodeMirror-merge-r-chunk { background: #ffffe0; }
-.CodeMirror-merge-r-chunk-start { border-top: 1px solid #ee8; }
-.CodeMirror-merge-r-chunk-end { border-bottom: 1px solid #ee8; }
-.CodeMirror-merge-r-connect { fill: #ffffe0; stroke: #ee8; stroke-width: 1px; }
-
-.CodeMirror-merge-l-chunk { background: #eef; }
-.CodeMirror-merge-l-chunk-start { border-top: 1px solid #88e; }
-.CodeMirror-merge-l-chunk-end { border-bottom: 1px solid #88e; }
-.CodeMirror-merge-l-connect { fill: #eef; stroke: #88e; stroke-width: 1px; }
-
 .CodeMirror-merge-collapsed-widget:before {
   content: "(...)";
 }

--- a/nbdime-web/src/styles/common.css
+++ b/nbdime-web/src/styles/common.css
@@ -76,10 +76,6 @@
 .CodeMirror-merge-l-chunk-end { border-bottom: 1px solid #88e; }
 .CodeMirror-merge-l-connect { fill: #eef; stroke: #88e; stroke-width: 1px; }
 
-.CodeMirror-merge-l-chunk.CodeMirror-merge-r-chunk { background: #ffdddd; }
-.CodeMirror-merge-l-chunk-start.CodeMirror-merge-r-chunk-start { border-top: 1px solid #f88888; }
-.CodeMirror-merge-l-chunk-end.CodeMirror-merge-r-chunk-end { border-bottom: 1px solid #f88888; }
-
 .CodeMirror-merge-collapsed-widget:before {
   content: "(...)";
 }

--- a/nbdime-web/src/styles/common.css
+++ b/nbdime-web/src/styles/common.css
@@ -66,10 +66,6 @@
     background-color: #f8cbcb;
 }
 
-.jp-Merge-gutter-buttons {
-  width: 16px;
-}
-
 .CodeMirror-merge-r-chunk { background: #ffffe0; }
 .CodeMirror-merge-r-chunk-start { border-top: 1px solid #ee8; }
 .CodeMirror-merge-r-chunk-end { border-bottom: 1px solid #ee8; }

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -120,6 +120,15 @@
   color: #b00
 }
 
+.CodeMirror-gutter-wrapper {
+  top: 0;
+  bottom: 0;
+}
+
+.CodeMirror-linenumber {
+  bottom: 0;
+}
+
 .jp-Merge-oneway-local,.jp-Merge-oneway-remote {
   width: 75%;
 }

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -72,6 +72,10 @@
 .jp-Notebook-merge .CodeMirror-line .CodeMirror-merge-l-inserted { background-color: #cbcbf8 }
 
 
+.CodeMirror-merge-l-chunk.CodeMirror-merge-r-chunk { background: #ffdddd; }
+.CodeMirror-merge-l-chunk-start.CodeMirror-merge-r-chunk-start { border-top: 1px solid #f88888; }
+.CodeMirror-merge-l-chunk-end.CodeMirror-merge-r-chunk-end { border-bottom: 1px solid #f88888; }
+
 .CodeMirror-merge-m-chunk-start-either { border-top: 1px solid #aee; }
 .CodeMirror-merge-m-chunk-end-either { border-bottom: 1px solid #aee }
 

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -63,6 +63,12 @@
 .jp-Notebook-merge .CodeMirror-merge-r-connect { fill: #dfd; stroke: #beb; stroke-width: 1px; }
 .jp-Notebook-merge .CodeMirror-line .CodeMirror-merge-r-inserted { background-color: #beb; }
 
+.jp-Notebook-merge .CodeMirror-merge-r-chunk-end-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-remote-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer {
+  border-bottom: 1px solid #beb;
+  background-color: #d8f9d8;
+}
+
 .jp-Notebook-merge .CodeMirror-merge-l-chunk { background-color: #ececff; }
 .jp-Notebook-merge .CodeMirror-merge-l-chunk-start,
 .jp-Notebook-merge .CodeMirror-merge-m-chunk-start-local { border-top: 1px solid #cbcbf8; }
@@ -71,13 +77,41 @@
 .jp-Notebook-merge .CodeMirror-merge-l-connect { fill: #ececff; stroke: #cbcbf8; stroke-width: 1px; }
 .jp-Notebook-merge .CodeMirror-line .CodeMirror-merge-l-inserted { background-color: #cbcbf8 }
 
+.jp-Notebook-merge .CodeMirror-merge-l-chunk-end-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-local-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer {
+  border-bottom: 1px solid #cbcbf8;
+  background-color: #e6e6ff;
+}
+
 
 .CodeMirror-merge-l-chunk.CodeMirror-merge-r-chunk { background: #ffdddd; }
 .CodeMirror-merge-l-chunk-start.CodeMirror-merge-r-chunk-start { border-top: 1px solid #f88888; }
 .CodeMirror-merge-l-chunk-end.CodeMirror-merge-r-chunk-end { border-bottom: 1px solid #f88888; }
 
+.jp-Notebook-merge .CodeMirror-merge-l-chunk-end-empty.CodeMirror-merge-r-chunk-end-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-remote-empty.CodeMirror-merge-m-chunk-end-local-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer {
+  border-bottom: 1px solid #f88888;
+  background-color: #ffdddd;
+}
+
+.jp-Notebook-merge .CodeMirror-merge-r-chunk-end-empty,
+.jp-Notebook-merge .CodeMirror-merge-l-chunk-end-empty,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-empty,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-either-empty,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-remote-empty,
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-local-empty,
+.jp-Notebook-merge .CodeMirror pre.CodeMirror-line {
+  z-index: 3;
+}
+
+
 .CodeMirror-merge-m-chunk-start-either { border-top: 1px solid #aee; }
 .CodeMirror-merge-m-chunk-end-either { border-bottom: 1px solid #aee }
+
+.jp-Notebook-merge .CodeMirror-merge-m-chunk-end-either-empty + .CodeMirror-linewidget .CodeMirror-merge-spacer {
+  border-bottom: 1px solid #aee;
+  background-color: #cff4f4;
+}
 
 .CodeMirror-merge-pane-base .CodeMirror-line .CodeMirror-merge-m-deleted,
 .CodeMirror-merge-pane-base .CodeMirror-line .CodeMirror-merge-l-deleted,

--- a/nbdime/merging/chunks.py
+++ b/nbdime/merging/chunks.py
@@ -5,7 +5,6 @@
 
 from __future__ import unicode_literals
 
-from six import string_types
 from six.moves import xrange as range
 
 from ..diff_format import DiffOp, SequenceDiffBuilder

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ universal=1
 [flake8]
 max-line-length=140
 ignore=E123,E265,E261,E226,E241,E221,E251s
+[pep8]
+max-line-length=140


### PR DESCRIPTION
Fix some css so that the CodeMirror gutter markers for picking a chunk and for flagging conflicts align with the top of the chunk in all views. Also fix some other styling for chunk visualization.