### PR TITLE
Fix colorama highlighting of multiline string

### DIFF
--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -257,39 +257,46 @@ def present_string_diff(a, di, path):
         return header + ['<base64 data changed>']
 
     b = patch(a, di)
-    td = tempfile.mkdtemp()
     cmd = None
-    try:
-        with io.open(os.path.join(td, 'before'), 'w', encoding="utf8") as f:
-            f.write(a)
-        with io.open(os.path.join(td, 'after'), 'w', encoding="utf8") as f:
-            f.write(b)
-        if which('git'):
-            cmd = _git_diff_print_cmd.split()
-            heading_lines = 4
-        elif which('diff'):
-            cmd = ['diff']
-            heading_lines = 0
-        else:
-            uni = list(unified_diff(
-                a.splitlines(False),
-                b.splitlines(False),
-                lineterm=''))
-            if not a.endswith('\n'):
-                uni.insert(-1, '\ No newline at end of file')
-            if not b.endswith('\n'):
-                uni.append('\ No newline at end of file')
-            dif = '\n'.join(uni)
-            heading_lines = 2
+    if which('git'):
+        cmd = _git_diff_print_cmd.split()
+        heading_lines = 4
+    elif which('diff'):
+        cmd = ['diff']
+        heading_lines = 0
+    else:
+        gen = unified_diff(
+            a.splitlines(False),
+            b.splitlines(False),
+            lineterm='')
+        uni = []
+        for line in gen:
+            if line.startswith('+'):
+                uni.append("%s%s%s" % (ADD, line[1:], RESET))
+            elif line.startswith('-'):
+                uni.append("%s%s%s" % (REMOVE, line[1:], RESET))
+            else:
+                uni.append(" %s" % (line,))
+        if not a.endswith('\n'):
+            uni.insert(-1, r'\ No newline at end of file')
+        if not b.endswith('\n'):
+            uni.append(r'\ No newline at end of file')
+        diff = '\n'.join(uni)
+        heading_lines = 2
 
-        if cmd is not None:
+    if cmd is not None:
+        try:
+            td = tempfile.mkdtemp()
+            with io.open(os.path.join(td, 'before'), 'w', encoding="utf8") as f:
+                f.write(a)
+            with io.open(os.path.join(td, 'after'), 'w', encoding="utf8") as f:
+                f.write(b)
             p = Popen(cmd + ['before', 'after'], cwd=td, stdout=PIPE)
             out, _ = p.communicate()
-            dif = out.decode('utf8')
-
-    finally:
-        shutil.rmtree(td)
-    return header + dif.splitlines()[heading_lines:]
+            diff = out.decode('utf8')
+        finally:
+            shutil.rmtree(td)
+    return header + diff.splitlines()[heading_lines:]
 
 
 def present_diff(a, di, path, indent=True):

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -42,9 +42,10 @@ with_indent = False
 _git_diff_print_cmd = 'git diff --no-index --color-words'
 
 # colors
-REMOVE = colorama.Fore.RED + '- '
-ADD = colorama.Fore.GREEN + '+ '
+REMOVE = colorama.Fore.RED + '-'
+ADD = colorama.Fore.GREEN + '+'
 RESET = colorama.Style.RESET_ALL
+
 
 def present_dict_no_markup(prefix, d, exclude_keys=None):
     """Pretty-print a dict without wrapper keys
@@ -276,7 +277,7 @@ def present_string_diff(a, di, path):
             elif line.startswith('-'):
                 uni.append("%s%s%s" % (REMOVE, line[1:], RESET))
             else:
-                uni.append(" %s" % (line,))
+                uni.append(line)
         if not a.endswith('\n'):
             uni.insert(-1, r'\ No newline at end of file')
         if not b.endswith('\n'):

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -11,7 +11,7 @@ def nocolor(request):
     """Disable color printing for test"""
     import nbdime.prettyprint as pp
     patch = mock.patch.multiple(pp,
-        ADD='+ ', REMOVE='- ', RESET='',
+        ADD='+', REMOVE='-', RESET='',
         _git_diff_print_cmd=pp._git_diff_print_cmd.replace(' --color-words', ''),
     )
     patch.start()

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import pytest
 import mock
 import os
-from  os.path import join as pjoin
+from os.path import join as pjoin
 
 from nbdime.gitdiffdriver import main as gdd_main
 
@@ -44,17 +44,15 @@ patch a/cells/1/source:
 def test_git_diff_driver(capsys, noindent, nocolor):
     # Simulate a call from `git diff` to check basic driver functionality
     test_dir = os.path.abspath(os.path.dirname(__file__))
-    mock_argv = ['/mock/path/git-nbdiffdriver', 'diff',
+    mock_argv = [
+        '/mock/path/git-nbdiffdriver', 'diff',
         pjoin(test_dir, 'files/foo--1.ipynb'),
         pjoin(test_dir, 'files/foo--1.ipynb'), 'invalid_mock_checksum', '100644',
         pjoin(test_dir, 'files/foo--2.ipynb'), 'invalid_mock_checksum', '100644']
     with mock.patch('sys.argv', mock_argv):
         r = gdd_main()
         assert r == 0
-        #with pytest.raises(SystemExit) as cm:
-        #    gdd_main()
-        #assert cm.value.code == 0
         cap_out = capsys.readouterr()[0]
-        assert cap_out  == expected_output.format(
+        assert cap_out == expected_output.format(
             pjoin(test_dir, 'files/foo--1.ipynb'),
             pjoin(test_dir, 'files/foo--2.ipynb'))

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -17,6 +17,7 @@ from nbformat import v4
 from nbdime import prettyprint as pp
 from nbdime.diffing import diff
 
+
 def b64text(nbytes):
     """Return n bytes as base64-encoded text"""
     return encodebytes(os.urandom(nbytes)).decode('ascii')
@@ -25,7 +26,7 @@ def b64text(nbytes):
 def test_present_dict_no_markup():
     d = {
         'a': 5,
-        'b': [1,2,3],
+        'b': [1, 2, 3],
         'c': {
             'x': 'y',
         },
@@ -33,13 +34,13 @@ def test_present_dict_no_markup():
         'short': 'text',
         'long': 'long\ntext',
     }
-    prefix = '- '
+    prefix = '-'
     lines = pp.present_dict_no_markup(prefix, d, exclude_keys={'d',})
     text = '\n'.join(lines)
     print(text)
     for key in d:
         if key != 'd':
-            mark = '- %s:' % key
+            mark = '-%s:' % key
             assert mark in text
     assert "short: text" in text
     assert 'long:\n' in text
@@ -47,7 +48,7 @@ def test_present_dict_no_markup():
 
 def test_present_multiline_string_b64():
     ins = b64text(1024)
-    prefix = '+ '
+    prefix = '+'
     lines = pp.present_multiline_string(prefix, ins)
     assert len(lines) == 1
     line = lines[0]
@@ -57,13 +58,13 @@ def test_present_multiline_string_b64():
 
 def test_present_multiline_string_short():
     ins = 'short string'
-    prefix = '+ '
+    prefix = '+'
     lines = pp.present_multiline_string(prefix, ins)
     assert lines == [prefix + ins]
 
 def test_present_multiline_string_long():
     ins = '\n'.join('line %i' % i for i in range(64))
-    prefix = '+ '
+    prefix = '+'
     lines = pp.present_multiline_string(prefix, ins)
     assert len(lines) == 64
     assert (prefix + 'line 32') in lines
@@ -78,23 +79,23 @@ def test_present_value_str():
 
 def test_present_value_dict():
     d = {'key': 5}
-    lines = pp.present_value('+ ', d)
-    assert '\n'.join(lines) == '+ ' + pformat(d)
+    lines = pp.present_value('+', d)
+    assert '\n'.join(lines) == '+' + pformat(d)
 
 def test_present_value_list():
     lis = ['a', 'b']
-    lines = pp.present_value('+ ', lis)
-    assert '\n'.join(lines) == '+ ' + pformat(lis)
+    lines = pp.present_value('+', lis)
+    assert '\n'.join(lines) == '+' + pformat(lis)
 
 def test_present_stream_output():
     output = v4.new_output('stream', name='stdout', text='some\ntext')
-    lines = pp.present_value('+ ', output)
+    lines = pp.present_value('+', output)
     assert lines == [
-        '+ output_type: stream',
-        "+ name: stdout",
-        "+ text:",
-        "+   some",
-        "+   text",
+        '+output_type: stream',
+        "+name: stdout",
+        "+text:",
+        "+  some",
+        "+  text",
     ]
 
 def test_present_display_data():
@@ -102,22 +103,22 @@ def test_present_display_data():
         'text/plain': 'text',
         'image/png': b64text(1024),
     })
-    lines = pp.present_value('+ ', output)
+    lines = pp.present_value('+', output)
     text = '\n'.join(lines)
     assert 'output_type: display_data' in text
     assert len(text) < 500
     assert 'snip base64' in text
     assert 'image/png' in text
     assert "text/plain: text" in text
-    assert all(line.startswith('+ ') for line in lines if line)
+    assert all(line.startswith('+') for line in lines if line)
 
 def test_present_markdown_cell():
     cell = v4.new_markdown_cell(source='# Heading\n\n*some markdown*')
-    lines = pp.present_value('+ ', cell)
+    lines = pp.present_value('+', cell)
     text = '\n'.join(lines)
     assert lines[0] == ''
-    assert lines[1] == '+ markdown cell:'
-    assert all(line.startswith('+ ') for line in lines if line)
+    assert lines[1] == '+markdown cell:'
+    assert all(line.startswith('+') for line in lines if line)
     assert 'source:' in text
     assert '# Heading' in text
     assert '' in lines
@@ -130,9 +131,9 @@ def test_present_code_cell():
             v4.new_output('display_data', {'text/plain': 'hello display'}),
         ]
     )
-    lines = pp.present_value('+ ', cell)
+    lines = pp.present_value('+', cell)
     assert lines[0] == ''
-    assert lines[1] == '+ code cell:'
+    assert lines[1] == '+code cell:'
 
 
 def test_present_dict_diff(nocolor):
@@ -143,8 +144,8 @@ def test_present_dict_diff(nocolor):
     indent = '  ' if pp.with_indent else ''
     assert lines == [ indent + line for line in [
         'replace at x/y/a:',
-        '- 1',
-        '+ 2',
+        '-1',
+        '+2',
     ]]
 
 def test_present_list_diff(nocolor):
@@ -156,9 +157,9 @@ def test_present_list_diff(nocolor):
     indent = '  ' if pp.with_indent else ''
     assert lines == [ indent + line for line in [
         'insert before a/b/0:',
-        '+ [2]',
+        '+[2]',
         'delete a/b/0:',
-        '- [1]',
+        '-[1]',
     ]]
 
 def test_present_string_diff():
@@ -169,8 +170,8 @@ def test_present_string_diff():
     with mock.patch('nbdime.prettyprint.which', lambda cmd: None):
         lines = pp.present_diff(a, di, path=path)
     text = '\n'.join(lines)
-    assert ('< line 2' in text) or ('-line 2' in text)
-    assert ('> line 4' in text) or ('+line 4' in text)
+    assert ('< line 2' in text) or ((pp.REMOVE + 'line 2' + pp.RESET) in text)
+    assert ('> line 4' in text) or ((pp.ADD + 'line 4' + pp.RESET) in text)
 
 def test_present_string_diff_b64():
     a = b64text(1024)


### PR DESCRIPTION
The fallback method when `git` and `diff` commands are not present did not previously use `colorama` for color highlighting. Also updated to avoid disk I/O when using the fallback.