### PR TITLE
Allow diffs on both sides when encountering a 'clear' decision.

### DIFF
--- a/nbdime-web/src/merge/model/cell.ts
+++ b/nbdime-web/src/merge/model/cell.ts
@@ -213,8 +213,8 @@ class CellMergeModel extends ObjectMergeModel<nbformat.ICell, CellDiffModel> {
       } else if (md.absolutePath.length === 2 && (
             hasEntries(md.localDiff) || hasEntries(md.remoteDiff))) {
         // Have decision on /cells/X/. Such decisions should always
-        // be onsided.
-        if (hasEntries(md.localDiff) && hasEntries(md.remoteDiff)) {
+        // be onsided except in the 'clear' case.
+        if (md.action !== "clear" && hasEntries(md.localDiff) && hasEntries(md.remoteDiff)) {
           // Not onesided.
           throw new Error('Invalid merge decision: ' + md);
         }


### PR DESCRIPTION
I don't know if this is the right fix, however looking at this check isolated it makes sense: if a 'clear' decision is encountered, there may exist local _and_ remote diffs that we have decided to ignore.