### PR TITLE
Improve support for JSON output type

### DIFF
--- a/nbdime-web/src/diff/model/string.ts
+++ b/nbdime-web/src/diff/model/string.ts
@@ -23,7 +23,7 @@ import {
 } from '../../chunking';
 
 import {
-  patchStringified, stringify
+  patchStringified, stringifyAndBlankNull
 } from '../../patch';
 
 import {
@@ -325,7 +325,6 @@ namespace StringDiffModel {
 }
 
 
-
 /**
  * Creates a StringDiffModel based on a patch operation.
  *
@@ -336,7 +335,7 @@ namespace StringDiffModel {
 export
 function createPatchStringDiffModel(base: string | JSONObject | JSONArray, diff: IDiffEntry[]) : StringDiffModel {
   console.assert(!!diff, 'Patch model needs diff.');
-  let baseStr = (typeof base === 'string') ? base : stringify(base);
+  let baseStr = stringifyAndBlankNull(base);
   let out = patchStringified(base, diff);
   return new StringDiffModel(baseStr, out.remote, out.additions, out.deletions);
 }
@@ -351,10 +350,8 @@ function createPatchStringDiffModel(base: string | JSONObject | JSONArray, diff:
  */
 export
 function createDirectStringDiffModel(base: JSONValue | null, remote: JSONValue | null): StringDiffModel {
-  let baseStr: string | null = (typeof base === 'string') ?
-    base : stringify(base);
-  let remoteStr: string | null = (typeof remote === 'string') ?
-    remote : stringify(remote);
+  let baseStr: string | null = stringifyAndBlankNull(base);
+  let remoteStr: string | null = stringifyAndBlankNull(remote);
   let additions: DiffRangeRaw[] = [];
   let deletions: DiffRangeRaw[] = [];
 

--- a/nbdime-web/src/diff/widget/cell.ts
+++ b/nbdime-web/src/diff/widget/cell.ts
@@ -51,7 +51,7 @@ const ADD_DEL_LABEL_CLASS = 'jp-Diff-label';
 /**
  * A list of MIME types that can be shown as string diff.
  */
-const stringDiffMimeTypes = ['text/html', 'text/plain'];
+const stringDiffMimeTypes = ['text/html', 'text/plain', 'application/json'];
 
 
 
@@ -156,14 +156,17 @@ class CellDiffWidget extends Panel {
         let key = model.hasMimeType(mt);
         if (key) {
           if (!renderable || valueIn(mt, stringDiffMimeTypes)) {
+            // 1.
             view = createNbdimeMergeView(model.stringify(key), editorClasses);
           } else if (renderable) {
+            // 2.
             view = new RenderableOutputView(model, editorClasses, rendermime);
           }
           break;
         }
       }
       if (!view) {
+        // 3.
         view = createNbdimeMergeView(model.stringify(), editorClasses);
       }
     } else {

--- a/nbdime-web/src/merge/model/common.ts
+++ b/nbdime-web/src/merge/model/common.ts
@@ -23,7 +23,7 @@ import {
 } from '../../chunking';
 
 import {
-  stringify, patchStringified
+  patchStringified, stringifyAndBlankNull
 } from '../../patch';
 
 import {
@@ -45,7 +45,7 @@ class DecisionStringDiffModel extends StringDiffModel {
               sourceModels: (IStringDiffModel | null)[],
               collapsible?: boolean, header?: string, collapsed?: boolean) {
     // Set up initial parameters for super call
-    let baseStr = (typeof base === 'string') ? base : stringify(base);
+    let baseStr = stringifyAndBlankNull(base);
     super(baseStr, '', [], [],
       collapsible, header, collapsed);
     this.rawBase = base;

--- a/nbdime-web/src/patch/index.ts
+++ b/nbdime-web/src/patch/index.ts
@@ -451,17 +451,35 @@ function patchString(base: string, diff: IDiffArrayEntry[] | null, level: number
 }
 
 /**
- * Ordered stringify. Wraps stableStringify(), but handles indentation, and
- * turns null input into empty string.
+ * Ordered stringify. Wraps stableStringify(), but handles indentation.
+ *
+ * indentFirst controls whether the first line is indented as well, and
+ * defaults to true.
  */
 export
 function stringify(values: JSONValue | null,
-                   level?: number, indentFirst?: boolean) : string {
-  let ret = (values === null) ? '' : stableStringify(values, {space: JSON_INDENT});
+                   level?: number,
+                   indentFirst: boolean = true) : string {
+  let ret = stableStringify(values, {space: JSON_INDENT});
   if (level) {
     ret = _indent(ret, level, indentFirst);
   }
   return ret;
+}
+
+
+/**
+ * Ensure value is string, if not stringify.
+ */
+export
+function stringifyAndBlankNull(value: JSONValue | null): string {
+  if (typeof value === 'string') {
+    return value;
+  } else if (value === null) {
+    return '';
+  } else {
+    return stringify(value);
+  }
 }
 
 
@@ -485,10 +503,9 @@ function _entriesAfter(remainingKeys: string[], ops: { [key: string]: IDiffEntry
 /**
  * Indent a (multiline) string with `JSON_INDENT` given number of times.
  *
- * indentFirst controls whether the first line is indented as well, and
- * defaults to true.
+ * indentFirst controls whether the first line is indented as well.
  */
-function _indent(str: string, levels: number, indentFirst?: boolean) : string {
+function _indent(str: string, levels: number, indentFirst: boolean) : string {
   indentFirst = indentFirst !== false;
   let lines = str.split('\n');
   let ret: string[] = new Array(lines.length);

--- a/nbdime-web/src/patch/index.ts
+++ b/nbdime-web/src/patch/index.ts
@@ -352,7 +352,7 @@ function patchStringifiedList(base: JSONArray, diff: IDiffArrayEntry[] | null, l
       // Delete a number of values by skipping
       let val = '';
       let len = e.length;
-      for (let i = 0; i < len; i++) {
+      for (let i = index; i < index + len; i++) {
         val += stringify(base[i], level + 1) + postfix;
       }
       let difflen = val.length;

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -141,7 +141,7 @@ def diff_single_outputs(a, b, path="/cells/*/output/*",
     else:
         return diff(a, b)
 
-_split_mimes = ('text/', 'image/svg+xml', 'application/javascript')
+_split_mimes = ('text/', 'image/svg+xml', 'application/javascript', 'application/json')
 
 
 def diff_mime_bundle(a, b, path=None):

--- a/nbdime/tests/files/single_cell_nb--json_output.ipynb
+++ b/nbdime/tests/files/single_cell_nb--json_output.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {
+      "collapsed": false
+     },
+     "data": {
+      "application/json": {
+       "json": {
+        "a": 54,
+        "c": [
+         "abc",
+         "def"
+        ],
+        "b": null
+       }
+      }
+     }
+    }
+   ],
+   "source": [
+    "def printit(x):\n",
+    "    print(x + 3)\n",
+    "printit(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/files/single_cell_nb--json_output_changed.ipynb
+++ b/nbdime/tests/files/single_cell_nb--json_output_changed.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {
+      "collapsed": false
+     },
+     "data": {
+      "application/json": {
+       "json": {
+        "c": [
+         "def",
+         "abc"
+        ],
+        "a": 54,
+        "b": null
+       }
+      }
+     }
+    }
+   ],
+   "source": [
+    "def printit(x):\n",
+    "    print(x + 3)\n",
+    "printit(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Tune the diffing algorithm to better handle JSON output types, and tune the text presentation of it (also fixing one or two bugs in web code). Web presentation will likely need to be revisited once JSON rendering support in Jupyterlab is included.