### PR TITLE
Improve  `attachments` cell field handling

### DIFF
--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -144,7 +144,8 @@ def diff_single_outputs(a, b, path="/cells/*/output/*",
 _split_mimes = ('text/', 'image/svg+xml', 'application/javascript', 'application/json')
 
 
-def diff_mime_bundle(a, b, path=None):
+def diff_mime_bundle(a, b, path=None,
+                     predicates=None, differs=None):
     di = MappingDiffBuilder()
 
     akeys = set(a.keys())
@@ -194,6 +195,8 @@ notebook_differs = defaultdict(lambda: diff, {
     "/cells/*": diff,
     "/cells/*/outputs": diff_sequence_multilevel,
     "/cells/*/outputs/*": diff_single_outputs,
+    "/cells/*/attachments": diff_sequence_multilevel,
+    "/cells/*/attachments/*": diff_mime_bundle,
     })
 
 

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -44,15 +44,17 @@ def autoresolve_notebook_conflicts(base, decisions, args):
             "/cells/*/outputs/*/execution_count"
         ])
     if args and args.merge_strategy == "mergetool":
+        # Mergetool strategy will prevent autoresolve from
+        # attempting to solve conflicts on these entries:
         strategies.update({
             "/cells/*/source": "mergetool",
             "/cells/*/outputs": "mergetool",
+            "/cells/*/attachments": "mergetool",
         })
     else:
         strategies.update({
             "/metadata": "record-conflict",
             "/cells/*/metadata": "record-conflict",
-            "/cells/*/source": "mergetool",
             "/cells/*/source": "inline-source",
             "/cells/*/outputs": "inline-outputs", # "clear", "join"
             # FIXME: Find a good way to handle strategies for both parent (outputs) and child (execution_count).

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -57,6 +57,7 @@ def autoresolve_notebook_conflicts(base, decisions, args):
             "/cells/*/metadata": "record-conflict",
             "/cells/*/source": "inline-source",
             "/cells/*/outputs": "inline-outputs", # "clear", "join"
+            # TODO: Add an inline strategy for attachments as well
             # FIXME: Find a good way to handle strategies for both parent (outputs) and child (execution_count).
             #        It might be that some strategies can be combined while others don't make sense, e.g. setting use-* on parent.
             #"/cells/*/outputs/*/execution_count": "clear",

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -115,6 +115,18 @@ def present_output(prefix, output):
     return pp
 
 
+def present_attachment(prefix, key, mime_bundle):
+    """Present an attachment (whole attachment add/delete)
+
+    Called by present_value
+    """
+    pp = []
+    pp.append(prefix + key + ':')
+    value_prefix = prefix + '  '
+    pp.extend(present_dict_no_markup(value_prefix, mime_bundle))
+    return pp
+
+
 def present_cell(prefix, cell):
     """Present a cell as a scalar (whole cell delete/add)
 
@@ -140,6 +152,11 @@ def present_cell(prefix, cell):
         pp.append(key_prefix + 'outputs:')
         for output in cell['outputs']:
             pp.extend(present_output(value_prefix, output))
+
+    if cell.get('attachments'):
+        pp.append(key_prefix + 'attachments:')
+        for key, mime_bundle in cell['attachments']:
+            pp.extend(present_attachment(value_prefix, key, mime_bundle))
 
     # present_value on anything we haven't special-cased yet
     pp.extend(present_dict_no_markup(key_prefix, cell,
@@ -172,6 +189,8 @@ def present_value(prefix, arg, path=None):
             return present_output(prefix, arg)
         elif starred == '/cells/*/outputs':
             return chain(*[ present_output(prefix + '  ', out) for out in arg ])
+        elif starred == '/cells/*/attachments':
+            return chain(*[ present_attachment(prefix + '  ', key, bundle) for (key, bundle) in arg.items() ])
 
     lines = pprint.pformat(arg).splitlines()
     return [prefix + line for line in lines]

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -72,9 +72,9 @@ def present_dict_no_markup(prefix, d, exclude_keys=None):
                 pp.append(prefix + key + ':')
                 pp.extend(present_value(value_prefix, value))
             else:
-                pp.append(prefix + '%s: %s' % (key, value))
+                pp.extend(present_value(prefix + key + ': ', value))
         else:
-            pp.append(prefix + '%s: %s' % (key,  value))
+            pp.extend(present_value(prefix + key + ': ', value))
     return pp
 
 

--- a/nbdime/tests/files/attachment--change_attachment.ipynb
+++ b/nbdime/tests/files/attachment--change_attachment.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a test notebook with only markdown cells\n",
+    " ![inline image](attachment:test.png)\n",
+    "======"
+   ],
+   "attachments" : {
+    "test.png": {
+     "image/png" : "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAUSURBVBhXY/j//39+fj6I4uTkBAA+xgdjMUPuuQAAAABJRU5ErkJggg=="
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/files/attachment--remove_attachment.ipynb
+++ b/nbdime/tests/files/attachment--remove_attachment.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a test notebook with only markdown cells\n",
+    " ![inline image](attachment:test.png)\n",
+    "======"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/files/attachment.ipynb
+++ b/nbdime/tests/files/attachment.ipynb
@@ -1,0 +1,40 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a test notebook with only markdown cells\n",
+    " ![inline image](attachment:test.png)\n",
+    "======"
+   ],
+   "attachments" : {
+    "test.png": {
+     "image/png" : "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAUSURBVBhXY1ixYkVraysDCDMwAAAtgAUX7HVO4wAAAABJRU5ErkJggg=="
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -89,7 +89,7 @@ def test_present_value_list():
 
 def test_present_stream_output():
     output = v4.new_output('stream', name='stdout', text='some\ntext')
-    lines = pp.present_value('+', output)
+    lines = pp.present_value('+', output, '/cells/0/outputs/3')
     assert lines == [
         '+output_type: stream',
         "+name: stdout",
@@ -103,7 +103,7 @@ def test_present_display_data():
         'text/plain': 'text',
         'image/png': b64text(1024),
     })
-    lines = pp.present_value('+', output)
+    lines = pp.present_value('+', output, '/cells/0/outputs/3')
     text = '\n'.join(lines)
     assert 'output_type: display_data' in text
     assert len(text) < 500
@@ -114,7 +114,7 @@ def test_present_display_data():
 
 def test_present_markdown_cell():
     cell = v4.new_markdown_cell(source='# Heading\n\n*some markdown*')
-    lines = pp.present_value('+', cell)
+    lines = pp.present_value('+', cell, '/cells/0')
     text = '\n'.join(lines)
     assert lines[0] == ''
     assert lines[1] == '+markdown cell:'
@@ -131,7 +131,7 @@ def test_present_code_cell():
             v4.new_output('display_data', {'text/plain': 'hello display'}),
         ]
     )
-    lines = pp.present_value('+', cell)
+    lines = pp.present_value('+', cell, '/cells/0')
     assert lines[0] == ''
     assert lines[1] == '+code cell:'
 

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -50,6 +50,7 @@ def join_path(*args):
 
 
 def star_path(path):
+    """Replace integers and numeric strings in a path with * """
     path = list(path)
     for i, p in enumerate(path):
         if isinstance(p, int):


### PR DESCRIPTION
Improves support for the `attachments` field in the python code (http://nbformat.readthedocs.io/en/latest/format_description.html#cell-attachments). Includes changes to the `prettyprint` code in order to detect attachments fields and apply base64 snipping to its mime data.

Support in the web-code will be added in a separate PR.