### PR TITLE
Prettyprint notebooks and decisions

### DIFF
--- a/nbdime/__main__.py
+++ b/nbdime/__main__.py
@@ -15,7 +15,9 @@ def main_dispatch(args=None):
     cmd = args[0]
     args = args[1:]
 
-    if cmd == "nbdiff":
+    if cmd == "nbshow":
+        from nbdime.nbshowapp import main
+    elif cmd == "nbdiff":
         from nbdime.nbdiffapp import main
     elif cmd == "nbmerge":
         from nbdime.nbmergeapp import main

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -89,6 +89,7 @@ def add_filename_args(parser, names):
     Helps getting consistent doc strings.
     """
     helps = {
+        "notebook": "The notebook filename.",
         "base":   "The base notebook filename.",
         "local":  "The local modified notebook filename.",
         "remote": "The remote modified notebook filename.",

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -15,19 +15,12 @@ def add_generic_args(parser):
         '--version',
         action="version",
         version="%(prog)s " + __version__)
-
-    if 0:  # TODO: Use verbose and quiet across nbdime and enable these:
-        qv_group = parser.add_mutually_exclusive_group()
-        qv_group.add_argument(
-            '-v', '--verbose',
-            default=False,
-            action="store_true",
-            help="increase verbosity of console output.")
-        qv_group.add_argument(
-            '-q', '--quiet',
-            default=False,
-            action="store_true",
-            help="silence console output.")
+    parser.add_argument(
+        '-l', '--log-level',
+        default='WARN',
+        choices=('DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'),
+        help="Set the log level by name."
+    )
 
 
 def add_web_args(parser, default_port=8888):
@@ -37,11 +30,6 @@ def add_web_args(parser, default_port=8888):
         "specify the port you want the server to run on. Default is %d%s." % (
             default_port, " (random)" if default_port == 0 else ""
         ))
-    parser.add_argument(
-        '-l', '--loglevel',
-        default='INFO',
-        help="Set the log level to use. One of: [CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET]"
-    )
     parser.add_argument(
         '-p', '--port',
         default=default_port,

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -10,6 +10,7 @@ from .decisions import apply_decisions
 from .autoresolve import autoresolve
 from ..diffing.notebooks import diff_notebooks
 from ..utils import Strategies
+from ..prettyprint import pretty_print_notebook_diff, pretty_print_merge_decisions, pretty_print_notebook
 
 
 # Strategies for handling conflicts  TODO: Implement these and refine further!
@@ -71,12 +72,30 @@ def decide_notebook_merge(base, local, remote, args=None):
     local_diffs = diff_notebooks(base, local)
     remote_diffs = diff_notebooks(base, remote)
 
+    if args and args.log_level == "DEBUG":
+        print("="*70)
+        print("In merge, base-local diff:")
+        pretty_print_notebook_diff("<base>", "<local>", base, local_diffs)
+        print("="*70)
+        print("In merge, base-remote diff:")
+        pretty_print_notebook_diff("<base>", "<remote>", base, remote_diffs)
+
     # Execute a generic merge operation
     decisions = decide_merge_with_diff(
         base, local, remote, local_diffs, remote_diffs)
 
+    if args and args.log_level == "DEBUG":
+        print("="*70)
+        print("In merge, initial decisions:")
+        pretty_print_merge_decisions(base, decisions)
+
     # Try to resolve conflicts based on behavioural options
     decisions = autoresolve_notebook_conflicts(base, decisions, args)
+
+    if args and args.log_level == "DEBUG":
+        print("="*70)
+        print("In merge, autoresolved decisions:")
+        pretty_print_merge_decisions(base, decisions)
 
     return decisions
 
@@ -86,5 +105,18 @@ def merge_notebooks(base, local, remote, args=None):
 
     Return new (partially) merged notebook and unapplied diffs from the local and remote side.
     """
+    if args and args.log_level == "DEBUG":
+        for (name, nb) in [("base", base), ("local", local), ("remote", remote)]:
+            print("%s In merge, input %s notebook:" % ("="*20, name))
+            pretty_print_notebook(nb)
+
     decisions = decide_notebook_merge(base, local, remote, args)
-    return apply_decisions(base, decisions), decisions
+
+    merged = apply_decisions(base, decisions)
+
+    if args and args.log_level == "DEBUG":
+        print("%s In merge, merged notebook:" % ("="*20,))
+        pretty_print_notebook(merged)
+        print("%s End merge" % ("="*20,))
+
+    return merged, decisions

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -130,7 +130,7 @@ def merge_notebooks(base, local, remote, args=None):
     if args and args.log_level == "DEBUG":
         _logger.debug("%s In merge, merged notebook:" % ("="*20,))
         buf = StringIO()
-        pretty_print_notebook(merged)
+        pretty_print_notebook(merged, None, buf)
         _logger.debug(buf.getvalue())
         _logger.debug("%s End merge" % ("="*20,))
 

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -5,12 +5,18 @@
 
 from __future__ import unicode_literals
 
+import logging
+from six import StringIO
+
 from .generic import decide_merge_with_diff
 from .decisions import apply_decisions
 from .autoresolve import autoresolve
 from ..diffing.notebooks import diff_notebooks
 from ..utils import Strategies
 from ..prettyprint import pretty_print_notebook_diff, pretty_print_merge_decisions, pretty_print_notebook
+
+
+_logger = logging.getLogger(__name__)
 
 
 # Strategies for handling conflicts  TODO: Implement these and refine further!
@@ -73,29 +79,34 @@ def decide_notebook_merge(base, local, remote, args=None):
     remote_diffs = diff_notebooks(base, remote)
 
     if args and args.log_level == "DEBUG":
-        print("="*70)
-        print("In merge, base-local diff:")
-        pretty_print_notebook_diff("<base>", "<local>", base, local_diffs)
-        print("="*70)
-        print("In merge, base-remote diff:")
-        pretty_print_notebook_diff("<base>", "<remote>", base, remote_diffs)
+        _logger.debug("In merge, base-local diff:")
+        buf = StringIO()
+        pretty_print_notebook_diff("<base>", "<local>", base, local_diffs, buf)
+        _logger.debug(buf.getvalue())
+
+        _logger.debug("In merge, base-remote diff:")
+        buf = StringIO()
+        pretty_print_notebook_diff("<base>", "<remote>", base, remote_diffs, buf)
+        _logger.debug(buf.getvalue())
 
     # Execute a generic merge operation
     decisions = decide_merge_with_diff(
         base, local, remote, local_diffs, remote_diffs)
 
     if args and args.log_level == "DEBUG":
-        print("="*70)
-        print("In merge, initial decisions:")
-        pretty_print_merge_decisions(base, decisions)
+        _logger.debug("In merge, initial decisions:")
+        buf = StringIO()
+        pretty_print_merge_decisions(base, decisions, buf)
+        _logger.debug(buf.getvalue())
 
     # Try to resolve conflicts based on behavioural options
     decisions = autoresolve_notebook_conflicts(base, decisions, args)
 
     if args and args.log_level == "DEBUG":
-        print("="*70)
-        print("In merge, autoresolved decisions:")
-        pretty_print_merge_decisions(base, decisions)
+        _logger.debug("In merge, autoresolved decisions:")
+        buf = StringIO()
+        pretty_print_merge_decisions(base, decisions, buf)
+        _logger.debug(buf.getvalue())
 
     return decisions
 
@@ -107,16 +118,20 @@ def merge_notebooks(base, local, remote, args=None):
     """
     if args and args.log_level == "DEBUG":
         for (name, nb) in [("base", base), ("local", local), ("remote", remote)]:
-            print("%s In merge, input %s notebook:" % ("="*20, name))
-            pretty_print_notebook(nb)
+            _logger.debug("%s In merge, input %s notebook:" % ("="*20, name))
+            buf = StringIO()
+            pretty_print_notebook(nb, None, buf)
+            _logger.debug(buf.getvalue())
 
     decisions = decide_notebook_merge(base, local, remote, args)
 
     merged = apply_decisions(base, decisions)
 
     if args and args.log_level == "DEBUG":
-        print("%s In merge, merged notebook:" % ("="*20,))
+        _logger.debug("%s In merge, merged notebook:" % ("="*20,))
+        buf = StringIO()
         pretty_print_notebook(merged)
-        print("%s End merge" % ("="*20,))
+        _logger.debug(buf.getvalue())
+        _logger.debug("%s End merge" % ("="*20,))
 
     return merged, decisions

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -37,16 +37,21 @@ def main_diff(args):
 
     d = diff_notebooks(a, b)
 
-    verbose = True
-    if verbose:
-        pretty_print_notebook_diff(afn, bfn, a, d)
-
     if dfn:
         with io.open(dfn, "w", encoding="utf8") as df:
             # Compact version:
             #json.dump(d, df)
             # Verbose version:
             json.dump(d, df, indent=2, separators=(",", ": "))
+    else:
+        # This printer is to keep the unit tests passing,
+        # some tests capture output with capsys which doesn't
+        # pick up on sys.stdout.write()
+        class Printer:
+            def write(self, text):
+                print(text, end="")
+        pretty_print_notebook_diff(afn, bfn, a, d, Printer())
+
     return 0
 
 

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -13,9 +13,10 @@ import argparse
 import nbformat
 import json
 
-from .diffing.notebooks import diff_notebooks
-from .prettyprint import pretty_print_notebook_diff
-from .args import add_generic_args, add_diff_args, add_filename_args
+import nbdime
+from nbdime.diffing.notebooks import diff_notebooks
+from nbdime.prettyprint import pretty_print_notebook_diff
+from nbdime.args import add_generic_args, add_diff_args, add_filename_args
 
 
 _description = "Compute the difference between two Jupyter notebooks."
@@ -75,10 +76,10 @@ def main(args=None):
         import colorama
         colorama.init()
     arguments = _build_arg_parser().parse_args(args)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     return main_diff(arguments)
 
 
 if __name__ == "__main__":
-    import nbdime.log
     nbdime.log.init_logging()
     main()

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -12,8 +12,11 @@ import argparse
 import json
 import nbformat
 import io
-from .patching import patch_notebook
-from .diff_format import to_diffentry_dicts
+
+import nbdime
+from nbdime.patching import patch_notebook
+from nbdime.diff_format import to_diffentry_dicts
+
 
 _description = "Apply patch from nbdiff to a Jupyter notebook."
 
@@ -65,10 +68,10 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     return main_patch(arguments)
 
 
 if __name__ == "__main__":
-    import nbdime.log
     nbdime.log.init_logging()
     main()

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -22,14 +22,13 @@ _description = "Show a Jupyter notebook in terminal."
 
 
 def main_show(args):
-    afn = args.base
 
-    for fn in (afn,):
-        if not os.path.exists(fn):
-            print("Missing file {}".format(fn))
-            return 1
+    fn = args.notebook
+    if not os.path.exists(fn):
+        print("Missing file {}".format(fn))
+        return 1
 
-    a = nbformat.read(afn, as_version=4)
+    nb = nbformat.read(fn, as_version=4)
 
     # This printer is to keep the unit tests passing,
     # some tests capture output with capsys which doesn't
@@ -37,7 +36,11 @@ def main_show(args):
     class Printer:
         def write(self, text):
             print(text, end="")
-    pretty_print_notebook(a, Printer())
+    if not any((args.sources, args.outputs, args.attachments, args.metadata, args.details)):
+        ppargs = None
+    else:
+        ppargs = args
+    pretty_print_notebook(nb, ppargs, Printer())
 
     return 0
 
@@ -49,9 +52,34 @@ def _build_arg_parser():
         add_help=True,
         )
     add_generic_args(parser)
-    add_filename_args(parser, ["base"])
+    add_filename_args(parser, ["notebook"])
 
-    # TODO: Options to show only important things: --compact, --source-only
+    # Things we can choose to show or not
+    parser.add_argument(
+        '-s', '--sources',
+        action="store_true",
+        default=False,
+        help="show sources.")
+    parser.add_argument(
+        '-o', '--outputs',
+        action="store_true",
+        default=False,
+        help="show outputs.")
+    parser.add_argument(
+        '-a', '--attachments',
+        action="store_true",
+        default=False,
+        help="show attachments.")
+    parser.add_argument(
+        '-m', '--metadata',
+        action="store_true",
+        default=False,
+        help="show metadata.")
+    parser.add_argument(
+        '-d', '--details',
+        action="store_true",
+        default=False,
+        help="show details not covered by other options.")
 
     return parser
 

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import io
+import os
+import sys
+import argparse
+import nbformat
+import json
+
+import nbdime
+from nbdime.prettyprint import pretty_print_notebook
+from nbdime.args import add_generic_args, add_filename_args
+
+
+_description = "Show a Jupyter notebook in terminal."
+
+
+def main_show(args):
+    afn = args.base
+
+    for fn in (afn,):
+        if not os.path.exists(fn):
+            print("Missing file {}".format(fn))
+            return 1
+
+    a = nbformat.read(afn, as_version=4)
+
+    # This printer is to keep the unit tests passing,
+    # some tests capture output with capsys which doesn't
+    # pick up on sys.stdout.write()
+    class Printer:
+        def write(self, text):
+            print(text, end="")
+    pretty_print_notebook(a, Printer())
+
+    return 0
+
+
+def _build_arg_parser():
+    """Creates an argument parser for the nbshow command."""
+    parser = argparse.ArgumentParser(
+        description=_description,
+        add_help=True,
+        )
+    add_generic_args(parser)
+    add_filename_args(parser, ["base"])
+
+    # TODO: Options to show only important things: --compact, --source-only
+
+    return parser
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    if sys.platform.startswith('win'):
+        import colorama
+        colorama.init()
+    arguments = _build_arg_parser().parse_args(args)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
+    return main_show(arguments)
+
+
+if __name__ == "__main__":
+    nbdime.log.init_logging()
+    main()

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -18,7 +18,10 @@ from nbdime.prettyprint import pretty_print_notebook
 from nbdime.args import add_generic_args, add_filename_args
 
 
-_description = "Show a Jupyter notebook in terminal."
+_description = """Show a Jupyter notebook in terminal.
+By default shows all notebook fields.
+Limit to specific fields by passing options.
+"""
 
 
 def main_show(args):

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -17,6 +17,7 @@ from subprocess import Popen, PIPE
 import tempfile
 from difflib import unified_diff
 from six import string_types
+import hashlib
 import colorama
 
 try:
@@ -35,9 +36,6 @@ from .diff_format import NBDiffFormatError, DiffOp
 from .patching import patch
 
 
-# Toggle indentation here
-with_indent = False
-
 # Change to enable/disable color print etc.
 _git_diff_print_cmd = 'git diff --no-index --color-words'
 
@@ -55,7 +53,15 @@ _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]
 def _trim_base64(s):
     """Trim base64 strings"""
     if len(s) > 64 and _base64.match(s.replace('\n', '')):
-        s = s[:16] + '...<snip base64>...' + s[-16:].strip()
+        # TODO: This approach will show that hashes differ
+        # when there are small changes in the middle of the
+        # string, use it always?
+        hash_base64_content = True
+        if hash_base64_content:
+            h = hashlib.md5(s).hexdigest()
+            s = '<base64 with md5=%s' % h
+        else:
+            s = s[:16] + '...<snip base64>...' + s[-16:].strip()
     return s
 
 

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -21,13 +21,6 @@ from difflib import unified_diff
 from six import string_types
 import hashlib
 
-#try:
-#    from textwrap import indent
-#except ImportError:
-#    def indent(text, prefix):
-#        """The relevant part of textwrap.indent for Python 2"""
-#        return prefix + text.replace('\n', '\n' + prefix)
-
 try:
     from shutil import which
 except ImportError:
@@ -38,8 +31,8 @@ from .patching import patch, patch_string
 from .utils import star_path, split_path, join_path
 
 # TODO: Make this configurable
-use_git = True
-use_diff = True
+use_git = False
+use_diff = False
 use_colors = True
 
 # Indentation offset in pretty-print
@@ -54,15 +47,18 @@ if use_colors:
     RED = colorama.Fore.RED
     GREEN = colorama.Fore.GREEN
     BLUE = colorama.Fore.BLUE
+    YELLOW = colorama.Fore.YELLOW
     RESET = colorama.Style.RESET_ALL
     _git_diff_print_cmd = 'git diff --no-index --color-words'
 else:
     RED = ''
     GREEN = ''
     BLUE = ''
+    YELLOW = ''
     RESET = ''
     _git_diff_print_cmd = 'git diff --no-index'
 
+KEEP     = '{color}   '.format(color='')
 REMOVE   = '{color}-  '.format(color=RED)
 ADD      = '{color}+  '.format(color=GREEN)
 INFO     = '{color}## '.format(color=BLUE)
@@ -98,8 +94,13 @@ def _builtin_diff_render(a, b):
             uni.append("%s%s%s" % (ADD, line[1:], RESET))
         elif line.startswith('-'):
             uni.append("%s%s%s" % (REMOVE, line[1:], RESET))
-        else:
+        elif line.startswith(' '):
+            uni.append("%s%s%s" % (KEEP, line[1:], RESET))
+        elif line.startswith('@'):
             uni.append(line)
+        else:
+            # Don't think this will happen?
+            uni.append("%s%s%s" % (KEEP, line[1:], RESET))
     if not a.endswith('\n'):
         uni.insert(-1, r'\ No newline at end of file')
     if not b.endswith('\n'):

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -185,15 +185,15 @@ def pretty_print_value(value, path, prefix="", out=sys.stdout):
     # Check if we can handle path with specific formatter
     if starred is not None:
         if starred == "/cells/*":
+            pretty_print_cell(None, value, prefix, out)
+        elif starred == "/cells":
             for cell in value:
                 pretty_print_cell(None, cell, prefix, out)
-        elif starred == "/cells":
-            pretty_print_cell(None, value, prefix, out)
         elif starred == "/cells/*/outputs/*":
+            pretty_print_output(None, value, prefix, out)
+        elif starred == "/cells/*/outputs":
             for output in value:
                 pretty_print_output(None, output, prefix, out)
-        elif starred == "/cells/*/outputs":
-            pretty_print_output(None, value, prefix, out)
         elif starred == "/cells/*/attachments":
             pretty_print_attachments(value, prefix, out)
         else:
@@ -460,11 +460,13 @@ def pretty_print_diff_entry(a, e, path, out=sys.stdout):
         pretty_print_value(e.value, nextpath, ADD, out)
 
     elif op == DiffOp.REPLACE:
-        pretty_print_diff_action("replaced", nextpath, out)
         aval = a[key]
         bval = e.value
-        # TODO: Quote string if the other is a number?
-        #if isinstance(aval, string_types) != isinstance(bval, string_types):
+        if type(aval) != type(bval):
+            typechange = " (type changed from %s to %s)" % (aval.__class__.__name__, bval.__class__.__name__)
+        else:
+            typechange = ""
+        pretty_print_diff_action("replaced" + typechange, nextpath, out)
         pretty_print_value(aval, nextpath, REMOVE, out)
         pretty_print_value(bval, nextpath, ADD, out)
 

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -246,7 +246,9 @@ def pretty_print_string_diff(a, di, path, out=sys.stdout):
     "Pretty-print a nbdime diff."
     out.write("{}modified {}:{}\n".format(INFO, path, RESET))
 
-    b = patch(a, di)
+    #import pdb; pdb.set_trace()
+    b = patch(a, di)  # FIXME: This fails in cli test, reproduce with py.test -k cli
+
     ta = _trim_base64(a)
     tb = _trim_base64(b)
 
@@ -336,7 +338,12 @@ def pretty_print_merge_decision(base, decision, out=sys.stdout):
             out.write("%s=== %s:%s\n" % (INFO, dkey, RESET))
             value = base
             for k in decision.common_path:
-                value = value[k]
+                #diff.op
+                if isinstance(value, string_types):
+                    value = value.splitlines(True)[k]
+                    break
+                else:
+                    value = value[k]
             pretty_print_diff(value, diff, path, out)
 
 
@@ -527,7 +534,7 @@ def pretty_print_cell(i, cell, prefix="", out=sys.stdout):
 
     # Write cell metadata
     known_cell_metadata_keys = {"collapsed", "autoscroll", "deletable", "format", "name", "tags"}
-    pretty_print_metadata(cell.metadata, key_prefix, out)
+    pretty_print_metadata(cell.metadata, known_cell_metadata_keys, key_prefix, out)
 
     # Write source
     source = cell.get("source")

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -31,8 +31,8 @@ from .patching import patch, patch_string
 from .utils import star_path, split_path, join_path
 
 # TODO: Make this configurable
-use_git = False
-use_diff = False
+use_git = True
+use_diff = True
 use_colors = True
 
 # Indentation offset in pretty-print

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -296,11 +296,24 @@ def pretty_print_notebook_diff(afn, bfn, a, di, out=sys.stdout):
         pretty_print_diff(a, di, path, out)
 
 
-def pretty_print_merge_decision(decision, prefix="", out=sys.stdout):
-    pretty_print_dict(decision, prefix, out)
+def pretty_print_merge_decision(base, decision, out=sys.stdout):
+    prefix = IND
+    diff_keys = ["diff", "local_diff", "remote_diff", "custom_diff"]
+    path = join_path(decision.common_path)
+    out.write("%s====== decision at %s:%s\n" % (INFO, path, RESET))
+    exclude_keys = set(diff_keys) | {"common_path"}
+    pretty_print_dict(decision, exclude_keys, prefix, out)
+    for dkey in diff_keys:
+        diff = decision.get(dkey)
+        if diff:
+            out.write("%s=== %s:%s\n" % (INFO, dkey, RESET))
+            value = base
+            for k in decision.common_path:
+                value = value[k]
+            pretty_print_diff(value, diff, path, out)
 
 
-def pretty_print_merge_decisions(base, decisions, prefix="", out=sys.stdout):
+def pretty_print_merge_decisions(base, decisions, out=sys.stdout):
     """Pretty-print notebook merge decisions
 
     Parameters
@@ -312,10 +325,10 @@ def pretty_print_merge_decisions(base, decisions, prefix="", out=sys.stdout):
         The list of merge decisions
     """
     conflicted = [d for d in decisions if d.conflict]
-    out.write("%s%d conflicted decisions of %d total:\n"
-              % (prefix, len(conflicted), len(decisions)))
+    out.write("%d conflicted decisions of %d total:\n"
+              % (len(conflicted), len(decisions)))
     for d in decisions:
-        pretty_print_merge_decision(d, prefix+IND, out)
+        pretty_print_merge_decision(base, d, out)
         out.write("\n")
     out.write("\n")
 
@@ -343,7 +356,7 @@ def pretty_print_notebook_merge(bfn, lfn, rfn, bnb, lnb, rnb, mnb, decisions, ou
     decisions: list
         The list of merge decisions including conflicts
     """
-    pretty_print_merge_decisions(bnb, decisions, "", out)
+    pretty_print_merge_decisions(bnb, decisions, out)
 
 
 def pretty_print_item(k, v, prefix="", out=sys.stdout):

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -136,15 +136,18 @@ def file_timestamp(filename):
     "Return modification time for filename as a string."
     t = os.path.getmtime(filename)
     dt = datetime.datetime.fromtimestamp(t)
-    return dt.isoformat(b" ")
+    return dt.isoformat(str(" "))
 
+
+def hash_string(s):
+    return hashlib.md5(s.encode("utf8")).hexdigest()
 
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$', re.MULTILINE|re.UNICODE)
 
 def _trim_base64(s):
     """Trim and hash base64 strings"""
     if len(s) > 64 and _base64.match(s.replace('\n', '')):
-        h = hashlib.md5(s).hexdigest()
+        h = hash_string(s)
         s =  '%s...<snip base64, md5=%s...>' % (s[:8], h[:16])
     return s
 

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -78,6 +78,9 @@ def _external_diff_render(cmd, a, b):
         p = Popen(cmd + ['before', 'after'], cwd=td, stdout=PIPE)
         out, _ = p.communicate()
         diff = out.decode('utf8')
+        r = re.compile(r"^\\ No newline at end of file\n?", flags=re.M)
+        diff, n = r.subn("", diff)
+        assert n <= 2
     finally:
         shutil.rmtree(td)
     return diff

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -203,11 +203,14 @@ def pretty_print_list_diff(a, di, path, out=sys.stdout):
 
 def pretty_print_string_diff(a, di, path, out=sys.stdout):
     "Pretty-print a nbdime diff."
-    if _base64.match(a):
-        out.write(prefix + '<base64 data changed>\n')
-        return
-
     b = patch(a, di)
+
+    if _base64.match(a):
+        ah = hashlib.md5(a).hexdigest()
+        bh = hashlib.md5(b).hexdigest()
+        out.write('%s<base64 data with md5=%s>\n' % (REMOVE, ah))
+        out.write('%s<base64 data with md5=%s>\n' % (ADD, bh))
+        return
 
     if which('git'):
         diff = _external_diff_render(_git_diff_print_cmd.split(), a, b)

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -350,7 +350,6 @@ def pretty_print_notebook_diff(afn, bfn, a, di, out=sys.stdout):
     out.write("\n")
 
 
-
 def pretty_print_merge_decision(decision, indent=0, out=sys.stdout):
     pretty_print_dict(decision, indent, out)
 

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -101,10 +101,10 @@ def _builtin_diff_render(a, b):
         else:
             # Don't think this will happen?
             uni.append("%s%s%s" % (KEEP, line[1:], RESET))
-    if not a.endswith('\n'):
-        uni.insert(-1, r'\ No newline at end of file')
-    if not b.endswith('\n'):
-        uni.append(r'\ No newline at end of file')
+    #if not a.endswith('\n'):
+    #    uni.insert(-1, r'\ No newline at end of file')
+    #if not b.endswith('\n'):
+    #    uni.append(r'\ No newline at end of file')
     diff = '\n'.join(uni)
     return diff
 

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -11,7 +11,7 @@ def nocolor(request):
     """Disable color printing for test"""
     import nbdime.prettyprint as pp
     patch = mock.patch.multiple(pp,
-        ADD='+', REMOVE='-', RESET='',
+        ADD='+', REMOVE='-', INFO='', RESET='',
         _git_diff_print_cmd=pp._git_diff_print_cmd.replace(' --color-words', ''),
     )
     patch.start()
@@ -20,15 +20,17 @@ def nocolor(request):
 @fixture
 def noindent(request):
     """Ensure indent is False"""
-    import nbdime.prettyprint as pp
-    patch = mock.patch.multiple(pp, with_indent=False)
-    patch.start()
-    request.addfinalizer(patch.stop)
+    #import nbdime.prettyprint as pp
+    #patch = mock.patch.multiple(pp, with_indent=False)
+    #patch.start()
+    #request.addfinalizer(patch.stop)
+    pass
 
 @fixture
 def indent(request):
     """Ensure indent is True"""
-    import nbdime.prettyprint as pp
-    patch = mock.patch.multiple(pp, with_indent=True)
-    patch.start()
-    request.addfinalizer(patch.stop)
+    #import nbdime.prettyprint as pp
+    #patch = mock.patch.multiple(pp, with_indent=True)
+    #patch.start()
+    #request.addfinalizer(patch.stop)
+    pass

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -16,26 +16,11 @@ def nocolor(request):
     """Disable color printing for test"""
     import nbdime.prettyprint as pp
     patch = mock.patch.multiple(pp,
-        ADD=pp.ADD.replace(pp.GREEN,''), REMOVE=pp.REMOVE.replace(pp.RED,''), INFO=pp.INFO.replace(pp.BLUE,''), RESET='',
+        ADD=pp.ADD.replace(pp.GREEN,''),
+        REMOVE=pp.REMOVE.replace(pp.RED,''),
+        INFO=pp.INFO.replace(pp.BLUE,''),
+        RESET='',
         _git_diff_print_cmd=pp._git_diff_print_cmd.replace(' --color-words', ''),
     )
     patch.start()
     request.addfinalizer(patch.stop)
-
-@fixture
-def noindent(request):
-    """Ensure indent is False"""
-    #import nbdime.prettyprint as pp
-    #patch = mock.patch.multiple(pp, with_indent=False)
-    #patch.start()
-    #request.addfinalizer(patch.stop)
-    pass
-
-@fixture
-def indent(request):
-    """Ensure indent is True"""
-    #import nbdime.prettyprint as pp
-    #patch = mock.patch.multiple(pp, with_indent=True)
-    #patch.start()
-    #request.addfinalizer(patch.stop)
-    pass

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 try:
     from unittest import mock
 except ImportError:
@@ -11,7 +16,7 @@ def nocolor(request):
     """Disable color printing for test"""
     import nbdime.prettyprint as pp
     patch = mock.patch.multiple(pp,
-        ADD='+', REMOVE='-', INFO='', RESET='',
+        ADD=pp.ADD.replace(pp.GREEN,''), REMOVE=pp.REMOVE.replace(pp.RED,''), INFO=pp.INFO.replace(pp.BLUE,''), RESET='',
         _git_diff_print_cmd=pp._git_diff_print_cmd.replace(' --color-words', ''),
     )
     patch.start()

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import unicode_literals
 

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -12,9 +12,18 @@ from argparse import Namespace
 from .fixtures import filespath
 
 import nbdime
+from nbdime.nbshowapp import main_show
 from nbdime.nbdiffapp import main_diff
 from nbdime.nbpatchapp import main_patch
 from nbdime.nbmergeapp import main_merge
+
+
+def test_nbshow_app():
+    p = filespath()
+    afn = os.path.join(p, "multilevel-test-base.ipynb")
+
+    args = nbdime.nbshowapp._build_arg_parser().parse_args([afn])
+    assert 0 == main_show(args)
 
 
 def test_nbdiff_app():

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -45,7 +45,7 @@ expected_output = """nbdiff {0} {1}
 """
 
 
-def test_git_diff_driver(capsys, noindent, nocolor):
+def test_git_diff_driver(capsys, nocolor):
     # Simulate a call from `git diff` to check basic driver functionality
     test_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -4,6 +4,10 @@
 # Distributed under the terms of the Modified BSD License.
 
 from __future__ import unicode_literals
+try:
+    from shutil import which
+except ImportError:
+    from backports.shutil_which import which
 
 import pytest
 import mock
@@ -40,7 +44,7 @@ expected_output = """nbdiff {0} {1}
 
 """
 
-
+@pytest.mark.skipif(not which('git'), reason="Missing git.")
 def test_git_diff_driver(capsys, nocolor):
     # Simulate a call from `git diff` to check basic driver functionality
     test_dir = os.path.abspath(os.path.dirname(__file__))

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
 
 from __future__ import unicode_literals
 
@@ -7,20 +11,18 @@ import os
 from os.path import join as pjoin
 
 from nbdime.gitdiffdriver import main as gdd_main
+from nbdime.prettyprint import file_timestamp
 
 
 # Expected output includes coloring characters
 expected_output = """nbdiff {0} {1}
---- a: {0}
-+++ b: {1}
+--- {0}  {2}
++++ {1}  {3}
+## modified /cells/0/outputs/0/data/text/plain:
+-  6
++  3
 
-patch a/cells/0/outputs/0/data/text/plain:
-@@ -1 +1 @@
--6
-\ No newline at end of file
-+3
-\ No newline at end of file
-patch a/cells/0/source:
+## modified /cells/0/source:
 @@ -1,3 +1,3 @@
 -def foe(x, y):
 +def foo(x, y):
@@ -29,7 +31,8 @@ patch a/cells/0/source:
 \ No newline at end of file
 +foo(1, 2)
 \ No newline at end of file
-patch a/cells/1/source:
+
+## modified /cells/1/source:
 @@ -1,3 +1,3 @@
 -def foo(x, y):
 +def foe(x, y):
@@ -38,21 +41,27 @@ patch a/cells/1/source:
 \ No newline at end of file
 +foe(1, 2)
 \ No newline at end of file
+
 """
 
 
 def test_git_diff_driver(capsys, noindent, nocolor):
     # Simulate a call from `git diff` to check basic driver functionality
     test_dir = os.path.abspath(os.path.dirname(__file__))
+
+    fn1 = pjoin(test_dir, 'files/foo--1.ipynb')
+    fn2 = pjoin(test_dir, 'files/foo--2.ipynb')
+    t1 = file_timestamp(fn1)
+    t2 = file_timestamp(fn2)
+
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff',
-        pjoin(test_dir, 'files/foo--1.ipynb'),
-        pjoin(test_dir, 'files/foo--1.ipynb'), 'invalid_mock_checksum', '100644',
-        pjoin(test_dir, 'files/foo--2.ipynb'), 'invalid_mock_checksum', '100644']
+        fn1,
+        fn1, 'invalid_mock_checksum', '100644',
+        fn2, 'invalid_mock_checksum', '100644']
+
     with mock.patch('sys.argv', mock_argv):
         r = gdd_main()
         assert r == 0
         cap_out = capsys.readouterr()[0]
-        assert cap_out == expected_output.format(
-            pjoin(test_dir, 'files/foo--1.ipynb'),
-            pjoin(test_dir, 'files/foo--2.ipynb'))
+        assert cap_out == expected_output.format(fn1, fn2, t1, t2)

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -28,9 +28,7 @@ expected_output = """nbdiff {0} {1}
 +def foo(x, y):
      return x + y
 -foe(3, 2)
-\ No newline at end of file
 +foo(1, 2)
-\ No newline at end of file
 
 ## modified /cells/1/source:
 @@ -1,3 +1,3 @@
@@ -38,9 +36,7 @@ expected_output = """nbdiff {0} {1}
 +def foe(x, y):
      return x * y
 -foo(1, 2)
-\ No newline at end of file
 +foe(1, 2)
-\ No newline at end of file
 
 """
 

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -207,6 +207,7 @@ def test_pretty_print_markdown_cell():
 
 def test_pretty_print_code_cell():
     cell = v4.new_code_cell(source='def foo():\n    return 4',
+        execution_count=3,
         outputs=[
             v4.new_output('stream', name='stdout', text='some\ntext'),
             v4.new_output('display_data', {'text/plain': 'hello display'}),
@@ -220,7 +221,7 @@ def test_pretty_print_code_cell():
 
     assert lines == [
         '+code cell:',
-        '+  execution_count: None',
+        '+  execution_count: 3',
         '+  source:',
         '+    def foo():',
         '+        return 4',

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -343,8 +343,8 @@ def test_pretty_print_string_diff_b64(nocolor):
     text = io.getvalue()
     lines = text.splitlines()
 
-    ha = hashlib.md5(a).hexdigest()
-    hb = hashlib.md5(b).hexdigest()
+    ha = pp.hash_string(a)
+    hb = pp.hash_string(b)
 
     assert lines == [
         '## modified /a/b:',

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -6,11 +6,14 @@ try:
 except ImportError:
     from base64 import encodestring as encodebytes
 import os
+from six import StringIO
 from pprint import pformat
 try:
     from unittest import mock
 except ImportError:
     import mock
+
+import hashlib
 
 from nbformat import v4
 
@@ -23,7 +26,7 @@ def b64text(nbytes):
     return encodebytes(os.urandom(nbytes)).decode('ascii')
 
 
-def test_present_dict_no_markup():
+def test_pretty_print_dict_complex():
     d = {
         'a': 5,
         'b': [1, 2, 3],
@@ -35,8 +38,11 @@ def test_present_dict_no_markup():
         'long': 'long\ntext',
     }
     prefix = '-'
-    lines = pp.present_dict_no_markup(prefix, d, exclude_keys={'d',})
-    text = '\n'.join(lines)
+
+    io = StringIO()
+    pp.pretty_print_dict(d, {'d'}, prefix, io)
+    text = io.getvalue()
+
     print(text)
     for key in d:
         if key != 'd':
@@ -46,65 +52,126 @@ def test_present_dict_no_markup():
     assert 'long:\n' in text
     assert 'd:' not in text
 
-def test_present_multiline_string_b64():
+
+def test_pretty_print_multiline_string_b64():
     ins = b64text(1024)
     prefix = '+'
-    lines = pp.present_multiline_string(prefix, ins)
+    io = StringIO()
+    pp.pretty_print_multiline(pp.format_value(ins), prefix, io)
+    text = io.getvalue()
+    lines = text.splitlines(True)
     assert len(lines) == 1
     line = lines[0]
     assert line.startswith(prefix)
     assert len(line) < 100
     assert 'snip base64' in line
 
-def test_present_multiline_string_short():
+
+def test_pretty_print_multiline_string_short():
     ins = 'short string'
     prefix = '+'
-    lines = pp.present_multiline_string(prefix, ins)
+    io = StringIO()
+    pp.pretty_print_multiline(pp.format_value(ins), prefix, io)
+    text = io.getvalue()
+    lines = text.splitlines(False)
     assert lines == [prefix + ins]
 
-def test_present_multiline_string_long():
+
+def test_pretty_print_multiline_string_long():
     ins = '\n'.join('line %i' % i for i in range(64))
     prefix = '+'
-    lines = pp.present_multiline_string(prefix, ins)
+    io = StringIO()
+    pp.pretty_print_multiline(pp.format_value(ins), prefix, io)
+    text = io.getvalue()
+    lines = text.splitlines(False)
     assert len(lines) == 64
     assert (prefix + 'line 32') in lines
 
-def test_present_value_int():
-    lines = pp.present_value('+', 5)
-    assert lines == ['+5']
 
-def test_present_value_str():
-    lines = pp.present_value('+', 'x')
-    assert lines == ['+x']
+def test_pretty_print_value_int():
+    v = 5
+    assert pp.format_value(v) == '5'
+    io = StringIO()
+    pp.pretty_print_value(v, "/dummypath", "+", io)
+    text = io.getvalue()
+    print("'%s'" % text)
+    assert "+5" in text
+    # path is only used for dispatching to special formatters
+    assert "dummypath" not in text
 
-def test_present_value_dict():
+
+def test_format_value_int():
+    assert pp.format_value(5) == "5"
+
+
+def test_format_value_str():
+    assert pp.format_value("xyz") == "xyz"
+
+
+def _pretty_print(value, prefix="+", path="/dummypath"):
+    io = StringIO()
+    pp.pretty_print_value(value, path, prefix, io)
+    text = io.getvalue()
+    return text
+
+
+def test_pretty_print_str():
+    assert _pretty_print("x", "+") == "+x\n"
+
+
+def test_pretty_print_dict():
     d = {'key': 5}
-    lines = pp.present_value('+', d)
-    assert '\n'.join(lines) == '+' + pformat(d)
+    text = _pretty_print(d, "+")
+    assert text == "+key: 5\n"
 
-def test_present_value_list():
+
+def test_pretty_print_dict_longstrings():
+    d = { "0": 'a\nb', "1": 'c\nd' }
+    text = _pretty_print(d, "+")
+    assert text == "+0:\n+  a\n+  b\n+1:\n+  c\n+  d\n"
+
+
+def test_pretty_print_list():
     lis = ['a', 'b']
-    lines = pp.present_value('+', lis)
-    assert '\n'.join(lines) == '+' + pformat(lis)
+    text = _pretty_print(lis, "+")
+    assert text == "+0: a\n+1: b\n"
 
-def test_present_stream_output():
+
+def test_pretty_print_list_longstrings():
+    lis = ['a\nb', 'c\nd']
+    text = _pretty_print(lis, "+")
+    assert text == "+0:\n+  a\n+  b\n+1:\n+  c\n+  d\n"
+
+
+def test_pretty_print_stream_output():
     output = v4.new_output('stream', name='stdout', text='some\ntext')
-    lines = pp.present_value('+', output, '/cells/0/outputs/3')
+
+    io = StringIO()
+    pp.pretty_print_output(None, output, "+", io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
     assert lines == [
-        '+output_type: stream',
-        "+name: stdout",
-        "+text:",
-        "+  some",
-        "+  text",
+        '+output:',
+        '+  output_type: stream',
+        "+  name: stdout",
+        "+  text:",
+        "+    some",
+        "+    text",
     ]
 
-def test_present_display_data():
+
+def test_pretty_print_display_data():
     output = v4.new_output('display_data', {
         'text/plain': 'text',
         'image/png': b64text(1024),
     })
-    lines = pp.present_value('+', output, '/cells/0/outputs/3')
-    text = '\n'.join(lines)
+
+    io = StringIO()
+    pp.pretty_print_output(None, output, "+", io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
     assert 'output_type: display_data' in text
     assert len(text) < 500
     assert 'snip base64' in text
@@ -112,73 +179,126 @@ def test_present_display_data():
     assert "text/plain: text" in text
     assert all(line.startswith('+') for line in lines if line)
 
-def test_present_markdown_cell():
+
+def test_pretty_print_markdown_cell():
     cell = v4.new_markdown_cell(source='# Heading\n\n*some markdown*')
-    lines = pp.present_value('+', cell, '/cells/0')
-    text = '\n'.join(lines)
-    assert lines[0] == ''
-    assert lines[1] == '+markdown cell:'
+
+    io = StringIO()
+    pp.pretty_print_cell(None, cell, "+", io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
+    assert lines[0] == '+markdown cell:'
     assert all(line.startswith('+') for line in lines if line)
     assert 'source:' in text
-    assert '# Heading' in text
-    assert '' in lines
-    assert '*some markdown*' in text
+    assert '+    # Heading' in text
+    assert '+    ' in lines
+    assert '+    *some markdown*' in text
 
-def test_present_code_cell():
-    cell = v4.new_code_cell(source='def foo()',
+
+def test_pretty_print_code_cell():
+    cell = v4.new_code_cell(source='def foo():\n    return 4',
         outputs=[
             v4.new_output('stream', name='stdout', text='some\ntext'),
             v4.new_output('display_data', {'text/plain': 'hello display'}),
         ]
     )
-    lines = pp.present_value('+', cell, '/cells/0')
-    assert lines[0] == ''
-    assert lines[1] == '+code cell:'
+
+    io = StringIO()
+    pp.pretty_print_cell(None, cell, "+", io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
+    assert lines == [
+        '+code cell:',
+        '+  execution_count: None',
+        '+  source:',
+        '+    def foo():',
+        '+        return 4',
+        '+  outputs:',
+        '+    output 0:',
+        '+      output_type: stream',
+        '+      name: stdout',
+        '+      text:',
+        '+        some',
+        '+        text',
+        '+    output 1:',
+        '+      output_type: display_data',
+        '+      data:',
+        '+        text/plain: hello display',
+    ]
 
 
-def test_present_dict_diff(nocolor):
+def test_pretty_print_dict_diff(nocolor):
     a = {'a': 1}
     b = {'a': 2}
     di = diff(a, b, path='x/y')
-    lines = pp.present_diff(a, di, path='x/y')
-    indent = '  ' if pp.with_indent else ''
-    assert lines == [ indent + line for line in [
-        'replace at x/y/a:',
+
+    io = StringIO()
+    pp.pretty_print_diff(a, di, 'x/y', io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
+    assert lines == [
+        'replaced x/y/a:',
         '-1',
         '+2',
-    ]]
+    ]
 
-def test_present_list_diff(nocolor):
+
+def test_pretty_print_list_diff(nocolor):
     a = [1]
     b = [2]
     path = 'a/b'
     di = diff(a, b, path=path)
-    lines = pp.present_diff(a, di, path=path)
-    indent = '  ' if pp.with_indent else ''
-    assert lines == [ indent + line for line in [
-        'insert before a/b/0:',
-        '+[2]',
-        'delete a/b/0:',
-        '-[1]',
-    ]]
 
-def test_present_string_diff():
+    io = StringIO()
+    pp.pretty_print_diff(a, di, path, io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
+    # TODO: Discuss if this formatting is what we want, maybe simplify for short lists?
+    assert lines == [
+        'inserted before a/b/0:',
+        '+0: 2',
+        'deleted a/b/0:',
+        '-0: 1',
+    ]
+
+
+def test_pretty_print_string_diff(nocolor):
     a = '\n'.join(['line 1', 'line 2', 'line 3', ''])
     b = '\n'.join(['line 1', 'line 3', 'line 4', ''])
     path = 'a/b'
     di = diff(a, b, path=path)
+
     with mock.patch('nbdime.prettyprint.which', lambda cmd: None):
-        lines = pp.present_diff(a, di, path=path)
+        io = StringIO()
+        pp.pretty_print_diff(a, di, path, io)
+        text = io.getvalue()
+        lines = text.splitlines()
+
     text = '\n'.join(lines)
     assert ('< line 2' in text) or ((pp.REMOVE + 'line 2' + pp.RESET) in text)
     assert ('> line 4' in text) or ((pp.ADD + 'line 4' + pp.RESET) in text)
 
-def test_present_string_diff_b64():
+
+def test_pretty_print_string_diff_b64(nocolor):
     a = b64text(1024)
-    b =  b64text(800)
+    b = b64text( 800)
     path = 'a/b'
     di = diff(a, b, path=path)
-    lines = pp.present_diff(a, di, path=path)
-    trim_header = int(not pp.with_indent)
-    indent = '  ' * pp.with_indent
-    assert lines[trim_header:] == [indent + '<base64 data changed>']
+
+    io = StringIO()
+    pp.pretty_print_diff(a, di, path, io)
+    text = io.getvalue()
+    lines = text.splitlines()
+
+    ha = hashlib.md5(a).hexdigest()
+    hb = hashlib.md5(b).hexdigest()
+
+    assert lines == [
+        'modified a/b:',
+        '-<base64 data with md5=%s>' % ha,
+        '+<base64 data with md5=%s>' % hb,
+        ]

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -64,7 +64,7 @@ def test_pretty_print_multiline_string_b64():
     ins = b64text(1024)
     prefix = '+'
     io = StringIO()
-    pp.pretty_print_multiline(pp.format_value(ins), prefix, io)
+    pp.pretty_print_value(ins, "no/addr", prefix, io)
     text = io.getvalue()
     lines = text.splitlines(True)
     assert len(lines) == 1
@@ -79,7 +79,7 @@ def test_pretty_print_multiline_string_short():
     prefix = '+'
 
     io = StringIO()
-    pp.pretty_print_multiline(pp.format_value(ins), prefix, io)
+    pp.pretty_print_value(ins, "no/addr", prefix, io)
     text = io.getvalue()
     lines = text.splitlines(False)
 
@@ -90,7 +90,7 @@ def test_pretty_print_multiline_string_long():
     ins = '\n'.join('line %i' % i for i in range(64))
     prefix = '+'
     io = StringIO()
-    pp.pretty_print_multiline(pp.format_value(ins), prefix, io)
+    pp.pretty_print_value(ins, "no/addr", prefix, io)
     text = io.getvalue()
     lines = text.splitlines(False)
     assert len(lines) == 64
@@ -156,7 +156,7 @@ def test_pretty_print_stream_output():
     output = v4.new_output('stream', name='stdout', text='some\ntext')
 
     io = StringIO()
-    pp.pretty_print_output(None, output, "+", io)
+    pp.pretty_print_value(output, "/cells/2/outputs/3", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -177,7 +177,7 @@ def test_pretty_print_display_data():
     })
 
     io = StringIO()
-    pp.pretty_print_output(None, output, "+", io)
+    pp.pretty_print_value(output, "/cells/1/outputs/2", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -193,7 +193,7 @@ def test_pretty_print_markdown_cell():
     cell = v4.new_markdown_cell(source='# Heading\n\n*some markdown*')
 
     io = StringIO()
-    pp.pretty_print_cell(None, cell, "+", io)
+    pp.pretty_print_value(cell, "/cells/0", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -215,7 +215,7 @@ def test_pretty_print_code_cell():
     )
 
     io = StringIO()
-    pp.pretty_print_cell(None, cell, "+", io)
+    pp.pretty_print_value(cell, "/cells/0", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -64,7 +64,7 @@ def test_pretty_print_multiline_string_b64():
     ins = b64text(1024)
     prefix = '+'
     io = StringIO()
-    pp.pretty_print_value(ins, "no/addr", prefix, io)
+    pp.pretty_print_value(ins, prefix, io)
     text = io.getvalue()
     lines = text.splitlines(True)
     assert len(lines) == 1
@@ -79,7 +79,7 @@ def test_pretty_print_multiline_string_short():
     prefix = '+'
 
     io = StringIO()
-    pp.pretty_print_value(ins, "no/addr", prefix, io)
+    pp.pretty_print_value_at(ins, "no/addr", prefix, io)
     text = io.getvalue()
     lines = text.splitlines(False)
 
@@ -90,7 +90,7 @@ def test_pretty_print_multiline_string_long():
     ins = '\n'.join('line %i' % i for i in range(64))
     prefix = '+'
     io = StringIO()
-    pp.pretty_print_value(ins, "no/addr", prefix, io)
+    pp.pretty_print_value(ins, prefix, io)
     text = io.getvalue()
     lines = text.splitlines(False)
     assert len(lines) == 64
@@ -101,7 +101,7 @@ def test_pretty_print_value_int():
     v = 5
     assert pp.format_value(v) == '5'
     io = StringIO()
-    pp.pretty_print_value(v, "/dummypath", "+", io)
+    pp.pretty_print_value(v, "+", io)
     text = io.getvalue()
     print("'%s'" % text)
     assert "+5" in text
@@ -119,7 +119,7 @@ def test_format_value_str():
 
 def _pretty_print(value, prefix="+", path="/dummypath"):
     io = StringIO()
-    pp.pretty_print_value(value, path, prefix, io)
+    pp.pretty_print_value_at(value, path, prefix, io)
     text = io.getvalue()
     return text
 
@@ -149,14 +149,14 @@ def test_pretty_print_list():
 def test_pretty_print_list_longstrings():
     lis = ['a\nb', 'c\nd']
     text = _pretty_print(lis, "+")
-    assert text == "+new[0]:\n+  a\n+  b\n+new[1]:\n+  c\n+  d\n"
+    assert text == "+item[0]:\n+  a\n+  b\n+item[1]:\n+  c\n+  d\n"
 
 
 def test_pretty_print_stream_output():
     output = v4.new_output('stream', name='stdout', text='some\ntext')
 
     io = StringIO()
-    pp.pretty_print_value(output, "/cells/2/outputs/3", "+", io)
+    pp.pretty_print_value_at(output, "/cells/2/outputs/3", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -177,7 +177,7 @@ def test_pretty_print_display_data():
     })
 
     io = StringIO()
-    pp.pretty_print_value(output, "/cells/1/outputs/2", "+", io)
+    pp.pretty_print_value_at(output, "/cells/1/outputs/2", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -193,7 +193,7 @@ def test_pretty_print_markdown_cell():
     cell = v4.new_markdown_cell(source='# Heading\n\n*some markdown*')
 
     io = StringIO()
-    pp.pretty_print_value(cell, "/cells/0", "+", io)
+    pp.pretty_print_value_at(cell, "/cells/0", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -215,7 +215,7 @@ def test_pretty_print_code_cell():
     )
 
     io = StringIO()
-    pp.pretty_print_value(cell, "/cells/0", "+", io)
+    pp.pretty_print_value_at(cell, "/cells/0", "+", io)
     text = io.getvalue()
     lines = text.splitlines()
 
@@ -293,22 +293,22 @@ def test_pretty_print_list_multilinestrings(nocolor):
         '## deleted /a/b/0-1:',
         #'-  ["ac\ndf", "qe\nry"]',
         #'-  b[0]:',
-        '-  new[0]:',
+        '-  item[0]:',
         '-    ac',
         '-    df',
         #'-  b[1]:',
-        '-  new[1]:',
+        '-  item[1]:',
         '-    qe',
         '-    ry',
         '',
         '## inserted before /a/b/3:',
         #'+  ["abc\ndef", "qwe\nrty"]',
         #'+  b[3+0]:',
-        '+  new[0]:',
+        '+  item[0]:',
         '+    abc',
         '+    def',
         #'+  b[3+1]:',
-        '+  new[1]:',
+        '+  item[1]:',
         '+    qwe',
         '+    rty',
         '',

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -56,7 +56,7 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
-    nbdime.log.set_nbdime_log_level(arguments.loglevel)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     port = arguments.port
     cwd = arguments.workdirectory
     base = arguments.base

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -55,7 +55,7 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
-    nbdime.log.set_nbdime_log_level(arguments.loglevel)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     port = arguments.port
     cwd = arguments.workdirectory
     base = arguments.base

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -289,7 +289,7 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
-    nbdime.log.set_nbdime_log_level(arguments.loglevel)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     return main_server(port=arguments.port, cwd=arguments.workdirectory)
 
 

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -62,7 +62,7 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args()
-    nbdime.log.set_nbdime_log_level(arguments.loglevel)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     port = arguments.port
     cwd = arguments.workdirectory
     base = arguments.base

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -63,7 +63,7 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
-    nbdime.log.set_nbdime_log_level(arguments.loglevel)
+    nbdime.log.set_nbdime_log_level(arguments.log_level)
     port = arguments.port
     cwd = arguments.workdirectory
     base = arguments.base

--- a/setup.py
+++ b/setup.py
@@ -246,6 +246,7 @@ if 'setuptools' in sys.modules:
     # force entrypoints with setuptools (needed for Windows, unconditional because of wheels)
     setup_args['entry_points'] = {
         'console_scripts': [
+            'nbshow = nbdime.nbshowapp:main',
             'nbdiff = nbdime.nbdiffapp:main',
             'nbdiff-web = nbdime.webapp.nbdiffweb:main',
             'nbpatch = nbdime.nbpatchapp:main',


### PR DESCRIPTION
Rework prettyprinting of diffs, used by `nbdiff` cli tool.

Besides refactoring, changes include a lot of formatting details,
showing md5 of differing base64 data instead of snippets,
and adding timestamp of files in diff header.

Add printing of merge decisions, used by `nbmerge` cli tool if no output filename provided.

Add a command `nbshow` to display notebook or just parts of it on terminal,
e.g. `nbshow -soa nb.ipynb` to display source, output and attachments.
This uses the same prettyprinting tools as nbdiff.