### PR TITLE
simplify conditions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ class bdist_egg_disabled(bdist_egg):
 
 
 cmdclass = dict(
-    build_ext  = js_prerelease(build_ext),
+    build_ext = js_prerelease(build_ext),
     sdist  = js_prerelease(sdist, strict=True),
     jsdeps = combine_commands(
         install_npm(pjoin(here, 'nbdime-web')),
@@ -218,6 +218,12 @@ cmdclass = dict(
     ),
     bdist_egg = bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
 )
+try:
+    from wheel.bdist_wheel import bdist_wheel
+    cmdclass['bdist_wheel'] = js_prerelease(bdist_wheel, strict=True)
+except ImportError:
+    pass
+
 
 setup_args['cmdclass'] = cmdclass
 

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,9 @@ def install_npm(path):
             return find_executable("npm")
 
         def run(self):
+            if (skip_npm):
+                log.info('Skipping npm-installation')
+                return
             log.info('Checking npm-installation:')
             has_npm = self.has_npm()
             if not has_npm:
@@ -194,23 +197,22 @@ setup_args = dict(
 )
 
 
-if not skip_npm:
-    cmdclass = dict(
-        build  = js_prerelease(build),
-        sdist  = js_prerelease(sdist, strict=True),
-        jsdeps = combine_commands(
-            install_npm(pjoin(here, 'nbdime-web')),
-            install_npm(pjoin(here, 'nbdime', 'webapp')),
-        ),
-    )
+cmdclass = dict(
+    build  = js_prerelease(build),
+    sdist  = js_prerelease(sdist, strict=True),
+    jsdeps = combine_commands(
+        install_npm(pjoin(here, 'nbdime-web')),
+        install_npm(pjoin(here, 'nbdime', 'webapp')),
+    ),
+)
 
-    if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
-        import setuptools
-        from setuptools.command.develop import develop
+if 'develop' in sys.argv or any(a.startswith('bdist') for a in sys.argv):
+    import setuptools
+    from setuptools.command.develop import develop
 
-        cmdclass['develop'] = js_prerelease(develop, strict=True)
+    cmdclass['develop'] = js_prerelease(develop, strict=True)
 
-    setup_args['cmdclass'] = cmdclass
+setup_args['cmdclass'] = cmdclass
 
 
 setuptools_args = {}


### PR DESCRIPTION
There should be fewer different circumstances to handle:

- always use setuptools
- disable implicit bdist_egg (this is the main reason to avoid setuptools)
- wrap build_ext instead of build & develop (build_ext is called before both)

- simplify skip_npm handling: perform the skip in the npm-using commands, rather than changing what commands exist.