### PR TITLE
Merge strategies CLI

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -94,26 +94,36 @@ and can take different actions based on the type of data with the conflict.
 The ``-m, --merge-strategy`` option lets you select a global strategy to use.
 The following options are currently implemented:
 
-TODO: make sure these are accurate, work:
-
 inline
     This is the default.
-    Conflicts in input and output are recorded with conflict markers on input and output,
-    Inline output merged with conflict-markers.
+    Conflicts in input and output are recorded with conflict markers, while
+    conflicts on metadata are stored in the appropriate metadata (actual
+    values are kept as their base values).
+
+TODO: Make a note about how it is stored (format, tag names, etc.)
+
     This gives you a valid notebook that you can open in your usual notebook editor
     and resolve conflicts, just like you might for a regular Python script.
 use-base
-    When a conflict is seen, pick the version in the base notebook.
+    When a conflict is encountered, use the value from the base notebook.
 use-local
-    When a conflict is seen, pick the version in the local notebook.
+    When a conflict is encountered, use the value from the local notebook.
 use-remote
-    When a conflict is seen, pick the version in the remote notebook.
-mergetool
-    Used by the merge tool, not for human consumption.
-fail
-    Don't try to resolve conflicts, just exit
-clear
-    TODO: Will we have this?
+    When a conflict is encountered, use the value from the remote notebook.
+union
+    When a conflict is encountered, include both the local and the remote
+    value, in that order (local then remote). Conflicts on non-sequence
+    types (anything not list or string) are left unresolved.
+
+.. note::
+
+    The union strategy might resolve to nonsensical values, while still marking
+    conflicts as resolved, so use this carefully.
+
+The ``--input-strategy`` and ``--output-strategy`` options lets you specify a
+strategy to use for conflicts on inputs and outputs, respecively. They accept
+the same values as the ``--merge-strategy`` option. If these are set, they will
+take precedence over ``--merge-strategy`` for inputs and/or outputs.
 
 To use nbmerge, pass it the three notebooks:
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -101,7 +101,7 @@ def add_merge_args(parser):
         dest='ignore_transients',
         action="store_false",
         default=True,
-        help="Allow deletion of transient data such as outputs and "
+        help="Disallow deletion of transient data such as outputs and "
              "execution counts in order to resolve conflicts.")
 
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -78,16 +78,29 @@ def add_diff_args(parser):
 def add_merge_args(parser):
     """Adds a set of arguments for commands that perform merges.
     """
-    from .merging.notebooks import generic_conflict_strategies
+    from .merging.notebooks import cli_conflict_strategies
     parser.add_argument(
         '-m', '--merge-strategy',
-        default="mergetool",
-        choices=generic_conflict_strategies,
+        default="inline",
+        choices=cli_conflict_strategies,
         help="Specify the merge strategy to use.")
     parser.add_argument(
-        '-i', '--ignore-transients',
-        action="store_true",
-        default=False,
+        '--input-strategy',
+        default=None,
+        choices=cli_conflict_strategies,
+        help="Specify the merge strategy to use for inputs "
+             "(overrides 'merge-strategy' for inputs).")
+    parser.add_argument(
+        '--output-strategy',
+        default=None,
+        choices=cli_conflict_strategies,
+        help="Specify the merge strategy to use for outputs "
+             "(overrides 'merge-strategy' for outputs).")
+    parser.add_argument(
+        '-i', '--no-ignore-transients',
+        dest='ignore_transients',
+        action="store_false",
+        default=True,
         help="Allow deletion of transient data such as outputs and "
              "execution counts in order to resolve conflicts.")
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -97,7 +97,7 @@ def add_merge_args(parser):
         help="Specify the merge strategy to use for outputs "
              "(overrides 'merge-strategy' for outputs).")
     parser.add_argument(
-        '-i', '--no-ignore-transients',
+        '--no-ignore-transients',
         dest='ignore_transients',
         action="store_false",
         default=True,

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -488,7 +488,8 @@ def autoresolve_decision(base, dec, strategies):
     elif isinstance(sub, list):
         decs = autoresolve_decision_on_list(dec, base, sub, strategies)
     elif isinstance(sub, string_types):
-        raise NotImplementedError()
+        sub = sub.splitlines(True)
+        decs = autoresolve_decision_on_list(dec, base, sub, strategies)
     else:
         raise RuntimeError("Expecting dict, list or string type, got " +
                            str(type(sub)))

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -347,7 +347,7 @@ def autoresolve_decision_on_list(dec, base, sub, strategies):
                 )
                 if conflict and strategies.fall_back:
                     decs.extend(strategy2action_list(
-                        d, strategies.fall_back))
+                        strategies.fall_back, d))
                 else:
                     decs.insert(i, d)
         elif lpatches or rpatches:
@@ -373,7 +373,7 @@ def autoresolve_decision_on_list(dec, base, sub, strategies):
                     if strategies.fall_back:
                         # Use fall-back
                         decs.extend(strategy2action_list(
-                            subdec, strategies.fall_back))
+                            strategies.fall_back, subdec))
                     else:
                         decs.append(subdec)
                     break
@@ -396,7 +396,7 @@ def autoresolve_decision_on_list(dec, base, sub, strategies):
             if strategies.fall_back:
                 # Use fall-back
                 decs.extend(strategy2action_list(
-                    subdec, strategies.fall_back))
+                    strategies.fall_back, subdec))
             else:
                 decs.append(subdec)
 

--- a/nbdime/merging/autoresolve.py
+++ b/nbdime/merging/autoresolve.py
@@ -230,7 +230,7 @@ def strategy2action_dict(local_base, le, re, strategy, path, dec):
         # Expecting never to get this kind of conflict, raise error
         raise RuntimeError("Not expecting a conflict at path {}.".format(path))
     # ... cases using changes from both sides to produce a new value
-    elif strategy == "join":
+    elif strategy == "union":
         dec.action = "local_then_remote"
         dec.conflict = False
     else:
@@ -267,7 +267,7 @@ def strategy2action_list(strategy, dec):
     elif strategy == "use-remote":
         dec.action = "remote"
         dec.conflict = False
-    elif strategy == "join":
+    elif strategy == "union":
         dec.action = "local_then_remote"
         dec.conflict = False
     elif strategy == "clear":

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -30,7 +30,7 @@ generic_conflict_strategies = (
     "record-conflict",  # Valid for metadata only: produce new metadata with conflicts recorded for external inspection
     "inline-source",    # Valid for source only: produce new source with inline diff markers
     "inline-outputs",   # Valid for outputs only: produce new outputs with inline diff markers
-    "join",             # Join values in case of conflict, don't insert new markers.
+    "union",             # Join values in case of conflict, don't insert new markers.
     )
 
 # Strategies that can be applied to an entire notebook
@@ -74,7 +74,7 @@ def autoresolve_notebook_conflicts(base, decisions, args):
             "/cells/*/outputs": "mergetool",
             "/cells/*/attachments": "mergetool",
         })
-    elif merge_strategy.startswith('use-'):
+    elif merge_strategy.startswith('use-') or merge_strategy == 'union':
         strategies.fall_back = args.merge_strategy
     else:
         strategies.update({

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -30,7 +30,7 @@ generic_conflict_strategies = (
     "record-conflict",  # Valid for metadata only: produce new metadata with conflicts recorded for external inspection
     "inline-source",    # Valid for source only: produce new source with inline diff markers
     "inline-outputs",   # Valid for outputs only: produce new outputs with inline diff markers
-    "union",             # Join values in case of conflict, don't insert new markers.
+    "union",            # Join values in case of conflict, don't insert new markers.
     )
 
 # Strategies that can be applied to an entire notebook
@@ -87,10 +87,14 @@ def autoresolve_notebook_conflicts(base, decisions, args):
             #        It might be that some strategies can be combined while others don't make sense, e.g. setting use-* on parent.
         })
     if input_strategy:
+        if input_strategy == 'inline':
+            input_strategy = 'inline-source'
         strategies.update({
             "/cells/*/source": input_strategy
         })
     if output_strategy:
+        if input_strategy == 'inline':
+            input_strategy = 'inline-outputs'
         strategies.update({
             "/cells/*/outputs": output_strategy
         })

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -22,7 +22,7 @@ _logger = logging.getLogger(__name__)
 # Strategies for handling conflicts  TODO: Implement these and refine further!
 generic_conflict_strategies = (
     "fail",             # Unexpected: crash and burn in case of conflict
-    "mergetool",        # Pass on diff to external difftool (TODO: store in global metadata at end instead of in separate diff dicts?)
+    "mergetool",        # Do not modify decision (but prevent processing at deeper path)
     "use-base",         # Keep base value in case of conflict
     "use-local",        # Use local value in case of conflict
     "use-remote",       # Use remote value in case of conflict
@@ -33,24 +33,40 @@ generic_conflict_strategies = (
     "join",             # Join values in case of conflict, don't insert new markers.
     )
 
+# Strategies that can be applied to an entire notebook
+cli_conflict_strategies = (
+    "use-base",         # Keep base value in case of conflict
+    "use-local",        # Use local value in case of conflict
+    "use-remote",       # Use remote value in case of conflict
+    "union",            # Take local value, then remote, in case of conflict
+    "inline",           # Inline source and outputs, and record metadata conflicts
+)
+
 
 def autoresolve_notebook_conflicts(base, decisions, args):
     strategies = Strategies({
         "/nbformat": "fail",
         # "/nbformat_minor": "fail",
-        "/cells/*/execution_count": "clear",
         "/cells/*/cell_type": "fail",
-        "/cells/*/outputs/*/execution_count": "clear",
-        },
-        transients=[
+        })
+
+    if not args or args.ignore_transients:
+        strategies.transients = [
             "/cells/*/execution_count",
             "/cells/*/outputs",
             "/cells/*/metadata/collapsed",
             "/cells/*/metadata/autoscroll",
             "/cells/*/metadata/scrolled",
             "/cells/*/outputs/*/execution_count"
-        ])
-    if args and args.merge_strategy == "mergetool":
+        ]
+        strategies.update({
+            "/cells/*/execution_count": "clear",
+            "/cells/*/outputs/*/execution_count": "clear",
+        })
+    merge_strategy = args.merge_strategy if args else "inline"
+    input_strategy = args.input_strategy if args else None
+    output_strategy = args.output_strategy if args else None
+    if merge_strategy == "mergetool":
         # Mergetool strategy will prevent autoresolve from
         # attempting to solve conflicts on these entries:
         strategies.update({
@@ -58,17 +74,25 @@ def autoresolve_notebook_conflicts(base, decisions, args):
             "/cells/*/outputs": "mergetool",
             "/cells/*/attachments": "mergetool",
         })
+    elif merge_strategy.startswith('use-'):
+        strategies.fall_back = args.merge_strategy
     else:
         strategies.update({
             "/metadata": "record-conflict",
             "/cells/*/metadata": "record-conflict",
             "/cells/*/source": "inline-source",
-            "/cells/*/outputs": "inline-outputs", # "clear", "join"
+            "/cells/*/outputs": "inline-outputs",
             # TODO: Add an inline strategy for attachments as well
             # FIXME: Find a good way to handle strategies for both parent (outputs) and child (execution_count).
             #        It might be that some strategies can be combined while others don't make sense, e.g. setting use-* on parent.
-            #"/cells/*/outputs/*/execution_count": "clear",
-            #"/cells/*/outputs/*/metadata": "record-conflict",
+        })
+    if input_strategy:
+        strategies.update({
+            "/cells/*/source": input_strategy
+        })
+    if output_strategy:
+        strategies.update({
+            "/cells/*/outputs": output_strategy
         })
     return autoresolve(base, decisions, strategies)
 

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -164,7 +164,10 @@ def sources_to_notebook(sources):
     assert isinstance(sources, list)
     assert len(sources) == 0 or isinstance(sources[0], list)
     nb = nbformat.v4.new_notebook()
-    nb.cells.extend(nbformat.v4.new_code_cell(source) for source in sources)
+    for source in sources:
+        if isinstance(source, list):
+            source = "".join(source)
+        nb.cells.append(nbformat.v4.new_code_cell(source))
     return nb
 
 

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -182,3 +182,23 @@ def notebook_to_sources(nb, as_str=True):
             source = source.splitlines(True)
         sources.append(source)
     return sources
+
+
+def outputs_to_notebook(outputs):
+    assert isinstance(outputs, list)
+    assert len(outputs) == 0 or isinstance(outputs[0], list)
+    nb = nbformat.v4.new_notebook()
+    for cell_outputs in outputs:
+        cell = nbformat.v4.new_code_cell()
+        nb.cells.append(cell)
+        for output in cell_outputs:
+            if isinstance(output, string_types):
+                output = nbformat.v4.new_output(
+                    output_type="display_data",
+                    data={
+                        "text/plain": output,
+                    }
+                )
+            assert isinstance(output, dict)
+            cell.outputs.append(output)
+    return nb

--- a/nbdime/tests/fixtures.py
+++ b/nbdime/tests/fixtures.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 from six.moves import xrange as range
+from six import string_types
 
 import io
 import pytest
@@ -177,7 +178,7 @@ def notebook_to_sources(nb, as_str=True):
         source = cell["source"]
         if as_str and isinstance(source, list):
             source = "\n".join([line.strip("\n") for line in source])
-        elif not as_str and isinstance(source, str):
+        elif not as_str and isinstance(source, string_types):
             source = source.splitlines(True)
         sources.append(source)
     return sources

--- a/nbdime/tests/test_autoresolve.py
+++ b/nbdime/tests/test_autoresolve.py
@@ -33,18 +33,18 @@ conflicted_decisions = decide_merge(base, local, remote)
 
 def test_autoresolve_dict_fail():
     """Check that "fail" strategy results in proper exception raised."""
-    strategies = {"/foo": "fail"}
+    strategies = Strategies({"/foo": "fail"})
     with pytest.raises(RuntimeError):
         autoresolve(base, conflicted_decisions, strategies)
 
     base2 = {"foo": {"bar": 1}}
     local2 = {"foo": {"bar": 2}}
     remote2 = {"foo": {"bar": 3}}
-    strategies = {"/foo/bar": "fail"}
+    strategies = Strategies({"/foo/bar": "fail"})
     decisions = decide_merge(base2, local2, remote2)
     with pytest.raises(RuntimeError):
         autoresolve(base2, decisions, strategies)
-    strategies = {"/foo": "fail"}
+    strategies = Strategies({"/foo": "fail"})
     with pytest.raises(RuntimeError):
         autoresolve(base2, decisions, strategies)
 
@@ -59,29 +59,29 @@ def test_autoresolve_dict_clear():
     assert apply_decisions(base2, decisions) == {"foo": [1, 2]}
     assert decisions[0].local_diff != []
     assert decisions[0].remote_diff != []
-    strategies = {"/foo": "clear-parent"}
+    strategies = Strategies({"/foo": "clear-parent"})
     resolved = autoresolve(base2, decisions, strategies)
     assert apply_decisions(base2, resolved) == {"foo": []}
     assert not any([d.conflict for d in resolved])
 
-    strategies = {"/foo": "clear"}
+    strategies = Strategies({"/foo": "clear"})
     resolved = autoresolve(base2, decisions, strategies)
     assert apply_decisions(base2, resolved) == {"foo": [1, None]}
     assert not any([d.conflict for d in resolved])
 
 
 def test_autoresolve_dict_use_one_side():
-    strategies = {"/foo": "use-base"}
+    strategies = Strategies({"/foo": "use-base"})
     decisions = autoresolve(base, conflicted_decisions, strategies)
     assert not any([d.conflict for d in decisions])
     assert apply_decisions(base, decisions) == {"foo": 1}
 
-    strategies = {"/foo": "use-local"}
+    strategies = Strategies({"/foo": "use-local"})
     decisions = autoresolve(base, conflicted_decisions, strategies)
     assert not any([d.conflict for d in decisions])
     assert apply_decisions(base, decisions) == {"foo": 2}
 
-    strategies = {"/foo": "use-remote"}
+    strategies = Strategies({"/foo": "use-remote"})
     decisions = autoresolve(base, conflicted_decisions, strategies)
     assert not any([d.conflict for d in decisions])
     assert apply_decisions(base, decisions) == {"foo": 3}
@@ -91,17 +91,17 @@ def test_autoresolve_dict_use_one_side():
     remote2 = {"foo": {"bar": 3}}
     conflicted_decisions2 = decide_merge(base2, local2, remote2)
 
-    strategies = {"/foo/bar": "use-base"}
+    strategies = Strategies({"/foo/bar": "use-base"})
     decisions = autoresolve(base2, conflicted_decisions2, strategies)
     assert not any([d.conflict for d in decisions])
     assert apply_decisions(base2, decisions) == {"foo": {"bar": 1}}
 
-    strategies = {"/foo/bar": "use-local"}
+    strategies = Strategies({"/foo/bar": "use-local"})
     decisions = autoresolve(base2, conflicted_decisions2, strategies)
     assert not any([d.conflict for d in decisions])
     assert apply_decisions(base2, decisions) == {"foo": {"bar": 2}}
 
-    strategies = {"/foo/bar": "use-remote"}
+    strategies = Strategies({"/foo/bar": "use-remote"})
     decisions = autoresolve(base2, conflicted_decisions2, strategies)
     assert not any([d.conflict for d in decisions])
     assert apply_decisions(base2, decisions) == {"foo": {"bar": 3}}
@@ -150,27 +150,27 @@ def test_autoresolve_list_conflicting_insertions_simple():
     r = [1, 3]
     decisions = decide_merge(b, l, r)
 
-    strategies = {"/*": "use-local"}
+    strategies = Strategies({"/*": "use-local"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == l
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "use-remote"}
+    strategies = Strategies({"/*": "use-remote"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == r
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "use-base"}
+    strategies = Strategies({"/*": "use-base"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == b
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "join"}
+    strategies = Strategies({"/*": "join"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == [1, 2, 3]
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "clear-parent"}
+    strategies = Strategies({"/*": "clear-parent"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == []
     assert not any(d.conflict for d in resolved)
@@ -185,7 +185,7 @@ def test_autoresolve_list_conflicting_insertions_mixed():
     decisions = decide_merge(b, l, r)
 
     # Check strategyless resolution
-    strategies = {}
+    strategies = Strategies({})
     resolved = autoresolve(b, decisions, strategies)
     expected_partial = [1, 9, 11]
     assert apply_decisions(b, resolved) == expected_partial
@@ -193,28 +193,28 @@ def test_autoresolve_list_conflicting_insertions_mixed():
     assert resolved[0].conflict
     assert not resolved[1].conflict
 
-    strategies = {"/*": "use-local"}
+    strategies = Strategies({"/*": "use-local"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == l
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "use-remote"}
+    strategies = Strategies({"/*": "use-remote"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == r
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "use-base"}
+    strategies = Strategies({"/*": "use-base"})
     resolved = autoresolve(b, decisions, strategies)
     # Strategy is only applied to conflicted decisions:
     assert apply_decisions(b, resolved) == expected_partial
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "join"}
+    strategies = Strategies({"/*": "join"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == [1, 2, 3, 9, 11]
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "clear-parent"}
+    strategies = Strategies({"/*": "clear-parent"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == []
     assert not any(d.conflict for d in resolved)
@@ -226,33 +226,33 @@ def test_autoresolve_list_conflicting_insertions_mixed():
     decisions = decide_merge(b, l, r)
 
     # Check strategyless resolution
-    strategies = {}
+    strategies = Strategies({})
     resolved = autoresolve(b, decisions, strategies)
     expected_partial = [1, 7, 9]
     assert apply_decisions(b, resolved) == expected_partial
     assert resolved == decisions  # Not able to resolve anything
 
-    strategies = {"/*": "use-local"}
+    strategies = Strategies({"/*": "use-local"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == l
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "use-remote"}
+    strategies = Strategies({"/*": "use-remote"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == r
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "use-base"}
+    strategies = Strategies({"/*": "use-base"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == expected_partial
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "join"}
+    strategies = Strategies({"/*": "join"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == [1, 2, 3, 7, 9]
     assert not any(d.conflict for d in resolved)
 
-    strategies = {"/*": "clear-parent"}
+    strategies = Strategies({"/*": "clear-parent"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == []
     assert not any(d.conflict for d in resolved)

--- a/nbdime/tests/test_autoresolve.py
+++ b/nbdime/tests/test_autoresolve.py
@@ -8,12 +8,14 @@ from __future__ import unicode_literals
 import pytest
 import operator
 from collections import defaultdict
+import argparse
 
 from nbdime import merge_notebooks, diff, decide_merge, apply_decisions
 
 from nbdime.merging.generic import decide_merge_with_diff
 from nbdime.merging.autoresolve import autoresolve
 from nbdime.utils import Strategies
+from nbdime.nbmergeapp import _build_arg_parser
 
 from .fixtures import db
 
@@ -29,6 +31,9 @@ base = {"foo": 1}
 local = {"foo": 2}
 remote = {"foo": 3}
 conflicted_decisions = decide_merge(base, local, remote)
+
+# Setup default args for merge app
+builder = _build_arg_parser()
 
 
 def test_autoresolve_dict_fail():
@@ -259,9 +264,6 @@ def test_autoresolve_list_conflicting_insertions_mixed():
 
 
 def test_autoresolve_dict_transients():
-    # For this test, we need to use a custom predicate to ensure alignment
-
-    common = {'id': 'This ensures alignment'}
     # Setup transient difference in base and local, deletion in remote
     b = {'a': {'transient': 22}}
     l = {'a': {'transient': 242}}
@@ -351,9 +353,8 @@ def test_autoresolve_inline_source_conflict(db):
     nbl = db["inline-conflict--2"]
     nbr = db["inline-conflict--3"]
 
-    args = None
-    #args = argparse.Namespace()
-    #args.fixme
+    args = builder.parse_args(["", "", ""])
+    args.merge_strategy = 'inline'
     merged, decisions = merge_notebooks(nbb, nbl, nbr, args)
 
     # Has conflicts

--- a/nbdime/tests/test_autoresolve.py
+++ b/nbdime/tests/test_autoresolve.py
@@ -170,7 +170,7 @@ def test_autoresolve_list_conflicting_insertions_simple():
     assert apply_decisions(b, resolved) == b
     assert not any(d.conflict for d in resolved)
 
-    strategies = Strategies({"/*": "join"})
+    strategies = Strategies({"/*": "union"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == [1, 2, 3]
     assert not any(d.conflict for d in resolved)
@@ -214,7 +214,7 @@ def test_autoresolve_list_conflicting_insertions_mixed():
     assert apply_decisions(b, resolved) == expected_partial
     assert not any(d.conflict for d in resolved)
 
-    strategies = Strategies({"/*": "join"})
+    strategies = Strategies({"/*": "union"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == [1, 2, 3, 9, 11]
     assert not any(d.conflict for d in resolved)
@@ -252,7 +252,7 @@ def test_autoresolve_list_conflicting_insertions_mixed():
     assert apply_decisions(b, resolved) == expected_partial
     assert not any(d.conflict for d in resolved)
 
-    strategies = Strategies({"/*": "join"})
+    strategies = Strategies({"/*": "union"})
     resolved = autoresolve(b, decisions, strategies)
     assert apply_decisions(b, resolved) == [1, 2, 3, 7, 9]
     assert not any(d.conflict for d in resolved)

--- a/nbdime/tests/test_autoresolve.py
+++ b/nbdime/tests/test_autoresolve.py
@@ -348,6 +348,72 @@ def test_autoresolve_notebook_ec():
     assert not any(d.conflict for d in decisions)
 
 
+def test_autoresolve_notebook_no_ignore():
+    args = builder.parse_args(["", "", ""])
+    args.ignore_transients = False
+
+    source = "def foo(x, y):\n    return x**y"
+    base = {"cells": [{
+        "source": source, "execution_count": 1, "cell_type": "code",
+        "outputs": None}]}
+    local = {"cells": [{
+        "source": source, "execution_count": 2, "cell_type": "code",
+        "outputs": None}]}
+    remote = {"cells": [{
+        "source": source, "execution_count": 3, "cell_type": "code",
+        "outputs": None}]}
+    merged, decisions = merge_notebooks(base, local, remote, args)
+    assert merged == {"cells": [{
+        "source": source, "execution_count": 1, "outputs": None,
+        "cell_type": "code"}]}
+    assert decisions[0].conflict is True
+    assert len(decisions) == 1
+
+
+def test_autoresolve_notebook_no_ignore_fallback():
+    args = builder.parse_args(["", "", ""])
+    args.ignore_transients = False
+    args.merge_strategy = 'use-remote'
+
+    source = "def foo(x, y):\n    return x**y"
+    base = {"cells": [{
+        "source": source, "execution_count": 1, "cell_type": "code",
+        "outputs": None}]}
+    local = {"cells": [{
+        "source": source, "execution_count": 2, "cell_type": "code",
+        "outputs": None}]}
+    remote = {"cells": [{
+        "source": source, "execution_count": 3, "cell_type": "code",
+        "outputs": None}]}
+    merged, decisions = merge_notebooks(base, local, remote, args)
+    assert merged == {"cells": [{
+        "source": source, "execution_count": 3, "outputs": None,
+        "cell_type": "code"}]}
+    assert not any(d.conflict for d in decisions)
+
+
+def test_autoresolve_notebook_ignore_fallback():
+    args = builder.parse_args(["", "", ""])
+    args.ignore_transients = True
+    args.merge_strategy = 'use-remote'
+
+    source = "def foo(x, y):\n    return x**y"
+    base = {"cells": [{
+        "source": source, "execution_count": 1, "cell_type": "code",
+        "outputs": None}]}
+    local = {"cells": [{
+        "source": source, "execution_count": 2, "cell_type": "code",
+        "outputs": None}]}
+    remote = {"cells": [{
+        "source": source, "execution_count": 3, "cell_type": "code",
+        "outputs": None}]}
+    merged, decisions = merge_notebooks(base, local, remote, args)
+    assert merged == {"cells": [{
+        "source": source, "execution_count": None, "outputs": None,
+        "cell_type": "code"}]}
+    assert not any(d.conflict for d in decisions)
+
+
 def test_autoresolve_inline_source_conflict(db):
     nbb = db["inline-conflict--1"]
     nbl = db["inline-conflict--2"]

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -185,8 +185,8 @@ def _check(base, local, remote, expected_partial, expected_conflicts, merge_args
 
     partial, decisions = merge_notebooks(base, local, remote, merge_args)
 
-    sources = [cell["source"] for cell in partial["cells"]]
-    expected_sources = [cell["source"] for cell in expected_partial["cells"]]
+    sources = [cell.pop("source") for cell in partial["cells"]]
+    expected_sources = [cell.pop("source") for cell in expected_partial["cells"]]
     assert sources == expected_sources
 
     assert partial == expected_partial

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -11,7 +11,7 @@ from six import string_types
 import nbformat
 
 from nbdime.diff_format import op_patch, op_addrange, op_removerange
-from .fixtures import sources_to_notebook, matching_nb_triplets
+from .fixtures import sources_to_notebook, matching_nb_triplets, outputs_to_notebook
 from nbdime.merging.autoresolve import (
     make_inline_source_value, autoresolve)
 from nbdime.nbmergeapp import _build_arg_parser
@@ -188,6 +188,29 @@ def _check_sources(base, local, remote, expected_partial, expected_conflicts, me
     sources = [cell.pop("source") for cell in partial["cells"]]
     expected_sources = [cell.pop("source") for cell in expected_partial["cells"]]
     assert sources == expected_sources
+
+    assert partial == expected_partial
+    conflicts = [d for d in decisions if d.conflict]
+    expected_conflicts = copy.copy(expected_conflicts)
+    assert len(conflicts) == len(expected_conflicts)
+    for e, d in zip(expected_conflicts, conflicts):
+        # Only check keys specified in expectation value
+        for k in e.keys():
+            assert d[k] == e[k]
+
+
+def _check_outputs(base, local, remote, expected_partial, expected_conflicts, merge_args=None):
+    base = outputs_to_notebook(base)
+    local = outputs_to_notebook(local)
+    remote = outputs_to_notebook(remote)
+    expected_partial = outputs_to_notebook(expected_partial)
+    merge_args = merge_args or args
+
+    partial, decisions = merge_notebooks(base, local, remote, merge_args)
+
+    outputs = [cell.pop("outputs") for cell in partial["cells"]]
+    expected_outputs = [cell.pop("outputs") for cell in expected_partial["cells"]]
+    assert outputs == expected_outputs
 
     assert partial == expected_partial
     conflicts = [d for d in decisions if d.conflict]

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -112,7 +112,7 @@ def test_merge_cell_sources_neighbouring_inserts():
             ])
         expected_conflicts = []
 
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 def test_merge_cell_sources_separate_inserts():
@@ -176,7 +176,7 @@ def src2nb(src):
     return src
 
 
-def _check(base, local, remote, expected_partial, expected_conflicts, merge_args=None):
+def _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args=None):
     base = src2nb(base)
     local = src2nb(local)
     remote = src2nb(remote)
@@ -208,7 +208,7 @@ def test_merge_simple_cell_source_no_change():
     remote = [["same"]]
     expected_partial = [["same"]]
     expected_conflicts = []
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 def test_merge_simple_cell_source_remote_change():
@@ -218,7 +218,7 @@ def test_merge_simple_cell_source_remote_change():
     remote = [["different"]]
     expected_partial = [["different"]]
     expected_conflicts = []
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 def test_merge_simple_cell_source_local_change():
@@ -228,7 +228,7 @@ def test_merge_simple_cell_source_local_change():
     remote = [["same"]]
     expected_partial = [["different"]]
     expected_conflicts = []
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 def test_merge_simple_cell_source_agreed_change():
@@ -238,7 +238,7 @@ def test_merge_simple_cell_source_agreed_change():
     remote = [["different"]]
     expected_partial = [["different"]]
     expected_conflicts = []
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 def test_merge_simple_cell_source_conflicting_edit_aligned():
@@ -260,7 +260,7 @@ def test_merge_simple_cell_source_conflicting_edit_aligned():
         }]
     merge_args = copy.deepcopy(args)
     merge_args.merge_strategy = "mergetool"
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_simple_cell_source_conflicting_insert():
@@ -283,7 +283,7 @@ def test_merge_simple_cell_source_conflicting_insert():
     else:  # Treat as non-conflict (insert both)
         expected_partial = [["base"], ["local"], ["remote"]]
         expected_conflicts = []
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 @pytest.mark.xfail
@@ -309,7 +309,7 @@ def test_merge_multiline_cell_source_conflict():
         "local_diff": [le],
         "remote_diff": [re]
     }]
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 def test_merge_insert_cells_around_conflicting_cell():
@@ -366,7 +366,7 @@ def test_merge_insert_cells_around_conflicting_cell():
             "remote_diff": [op_patch(0, [op_patch('source', [
                 op_addrange(len("".join(source)), "remote\n")])])]
         }]
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 @pytest.mark.xfail
@@ -401,7 +401,7 @@ def test_merge_interleave_cell_add_remove():
                         ["local 3"],
                         ["base 3"]]
     expected_conflicts = []
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 @pytest.mark.xfail
@@ -429,7 +429,7 @@ def test_merge_conflicts_get_diff_indices_shifted():
             op_addrange(1, ["right"]),
         ]
     }]
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
     # Trying to induce conflicts with shifting of diff indices
     source = [
@@ -460,7 +460,7 @@ def test_merge_conflicts_get_diff_indices_shifted():
             op_addrange(1, ["right"]),
         ]
     }]
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
 
 @pytest.mark.xfail
@@ -510,7 +510,7 @@ def bar(y):
             "remote_diff": [op_patch("cells", [op_addrange(0, [
                 nbformat.v4.new_code_cell(remote)]), op_removerange(0, 1)])]
         }]
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts)
 
     # Keep it failing
     assert False
@@ -525,7 +525,7 @@ def test_merge_input_strategy_local_source_conflict():
     expected_conflicts = []
     merge_args = copy.deepcopy(args)
     merge_args.input_strategy = "use-local"
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_input_strategy_remote_source_conflict():
@@ -537,7 +537,7 @@ def test_merge_input_strategy_remote_source_conflict():
     expected_conflicts = []
     merge_args = copy.deepcopy(args)
     merge_args.input_strategy = "use-remote"
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_input_strategy_base_source_conflict():
@@ -549,7 +549,7 @@ def test_merge_input_strategy_base_source_conflict():
     expected_conflicts = []
     merge_args = copy.deepcopy(args)
     merge_args.input_strategy = "use-base"
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_input_strategy_union_source_conflict():
@@ -561,7 +561,7 @@ def test_merge_input_strategy_union_source_conflict():
     expected_conflicts = []
     merge_args = copy.deepcopy(args)
     merge_args.input_strategy = "union"
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_input_strategy_inline_source_conflict():
@@ -607,7 +607,7 @@ def test_merge_input_strategy_inline_source_conflict():
     merge_args = copy.deepcopy(args)
     merge_args.merge_strategy = "use-base"
     merge_args.input_strategy = "inline"
-    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -633,5 +633,51 @@ def test_merge_input_strategy_inline_source_conflict():
     _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
+def test_merge_output_strategy_local_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\nsome other\nlines\nto align\n", "output2", "output3"]]
+    base = [["base\nsome other\nlines\nto align\n", "output2", "output3"]]
+    remote = [["remote\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_partial = [["local\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.output_strategy = "use-local"
+    _check_outputs(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
+def test_merge_output_strategy_remote_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\nsome other\nlines\nto align\n", "output2", "output3"]]
+    base = [["base\nsome other\nlines\nto align\n", "output2", "output3"]]
+    remote = [["remote\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_partial = [["remote\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.output_strategy = "use-remote"
+    _check_outputs(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+def test_merge_output_strategy_base_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\nsome other\nlines\nto align\n", "output2", "output3"]]
+    base = [["base\nsome other\nlines\nto align\n", "output2", "output3"]]
+    remote = [["remote\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_partial = [["base\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.output_strategy = "use-base"
+    _check_outputs(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+def test_merge_output_strategy_union_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\nsome other\nlines\nto align\n", "output2", "output3"]]
+    base = [["base\nsome other\nlines\nto align\n", "output2", "output3"]]
+    remote = [["remote\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_partial = [["local\nremote\nsome other\nlines\nto align\n", "output2", "output3"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.output_strategy = "union"
+    _check_outputs(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+# TODO: Make test for output_strategy == 'inline'

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -168,7 +168,7 @@ def src2nb(src):
     or a list (cells) of lists (lines) of singleline strings.
     """
     if isinstance(src, string_types):
-        src = [src.splitlines(True)]
+        src = [[src]]
     if isinstance(src, list):
         src = sources_to_notebook(src)
     assert isinstance(src, dict)
@@ -251,11 +251,11 @@ def test_merge_simple_cell_source_conflicting_edit_aligned():
         "common_path": ("cells", 0, "source"),
         "local_diff": [
             op_addrange(
-                0, [nbformat.v4.new_code_cell(source) for source in local]),
+                0, local[0][0:1]),
             op_removerange(0, 1)],
         "remote_diff": [
             op_addrange(
-                0, [nbformat.v4.new_code_cell(source) for source in remote]),
+                0, remote[0][0:1]),
             op_removerange(0, 1)]
         }]
     merge_args = copy.deepcopy(args)
@@ -274,10 +274,10 @@ def test_merge_simple_cell_source_conflicting_insert():
         expected_conflicts = [{
             "common_path": ("cells",),
             "local_diff": [op_addrange(
-                1, [nbformat.v4.new_code_cell(local[1])]),
+                1, [nbformat.v4.new_code_cell(local[1][0])]),
             ],
             "remote_diff": [op_addrange(
-                1, [nbformat.v4.new_code_cell(remote[1])]),
+                1, [nbformat.v4.new_code_cell(remote[1][0])]),
             ]
         }]
     else:  # Treat as non-conflict (insert both)

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -514,3 +514,101 @@ def bar(y):
 
     # Keep it failing
     assert False
+
+
+def test_merge_input_strategy_local_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    base = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    remote = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_partial = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.input_strategy = "use-local"
+    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+def test_merge_input_strategy_remote_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    base = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    remote = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_partial = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.input_strategy = "use-remote"
+    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+def test_merge_input_strategy_base_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    base = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    remote = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_partial = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.input_strategy = "use-base"
+    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+def test_merge_input_strategy_union_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    base = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    remote = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_partial = [["local\n", "remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_conflicts = []
+    merge_args = copy.deepcopy(args)
+    merge_args.input_strategy = "union"
+    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+def test_merge_input_strategy_inline_source_conflict():
+    # Conflicting cell inserts at same location as removing old cell
+    local = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    base = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    remote = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    # Ideal case:
+    # expected_partial = [[
+    #    "<<<<<<< local\n"
+    #    "local\n"
+    #    "||||||| base\n"
+    #    "base\n"
+    #    "=======\n"
+    #    "remote\n
+    #    ">>>>>>> remote\n"
+    #    "some other\nlines\nto align\n"]]
+    # Current case:
+    expected_partial = [[
+        "<<<<<<< local\n",
+        "local\nsome other\nlines\nto align\n",
+        "||||||| base\n",
+        "base\nsome other\nlines\nto align\n",
+        "=======\n",
+        "remote\nsome other\nlines\nto align\n",
+        ">>>>>>> remote"]]
+    expected_conflicts = [{
+        "common_path": ("cells", 0),
+        "local_diff": [
+            op_patch('source', [
+                op_addrange(
+                    0, local[0][0:1]),
+                op_removerange(0, 1)],
+            )],
+        "remote_diff": [
+            op_patch('source', [
+                op_addrange(
+                    0, remote[0][0:1]),
+                op_removerange(0, 1)],
+
+            )],
+        }]
+    merge_args = copy.deepcopy(args)
+    merge_args.merge_strategy = "use-base"
+    merge_args.input_strategy = "inline"
+    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
+
+
+
+

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -243,12 +243,12 @@ def test_merge_simple_cell_source_agreed_change():
 
 def test_merge_simple_cell_source_conflicting_edit_aligned():
     # Conflicting cell inserts at same location as removing old cell
-    local = [["local"]]
-    base = [["base"]]
-    remote = [["remote"]]
-    expected_partial = [["base"]]
+    local = [["local\n", "some other\n", "lines\n", "to align\n"]]
+    base = [["base\n", "some other\n", "lines\n", "to align\n"]]
+    remote = [["remote\n", "some other\n", "lines\n", "to align\n"]]
+    expected_partial = [["base\n", "some other\n", "lines\n", "to align\n"]]
     expected_conflicts = [{
-        "common_path": ("cells",),
+        "common_path": ("cells", 0, "source"),
         "local_diff": [
             op_addrange(
                 0, [nbformat.v4.new_code_cell(source) for source in local]),
@@ -258,7 +258,9 @@ def test_merge_simple_cell_source_conflicting_edit_aligned():
                 0, [nbformat.v4.new_code_cell(source) for source in remote]),
             op_removerange(0, 1)]
         }]
-    _check(base, local, remote, expected_partial, expected_conflicts)
+    merge_args = copy.deepcopy(args)
+    merge_args.merge_strategy = "mergetool"
+    _check(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_simple_cell_source_conflicting_insert():

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -199,7 +199,7 @@ def _check(base, local, remote, expected_partial, expected_conflicts, merge_args
             assert d[k] == e[k]
 
 
-def test_merge_simple_cell_sources():
+def test_merge_simple_cell_source_no_change():
     # A very basic test: Just checking changes to a single cell source,
 
     # No change
@@ -210,6 +210,8 @@ def test_merge_simple_cell_sources():
     expected_conflicts = []
     _check(base, local, remote, expected_partial, expected_conflicts)
 
+
+def test_merge_simple_cell_source_remote_change():
     # One sided change
     local = [["same"]]
     base = [["same"]]
@@ -218,6 +220,8 @@ def test_merge_simple_cell_sources():
     expected_conflicts = []
     _check(base, local, remote, expected_partial, expected_conflicts)
 
+
+def test_merge_simple_cell_source_local_change():
     # One sided change
     local = [["different"]]
     base = [["same"]]
@@ -226,6 +230,8 @@ def test_merge_simple_cell_sources():
     expected_conflicts = []
     _check(base, local, remote, expected_partial, expected_conflicts)
 
+
+def test_merge_simple_cell_source_agreed_change():
     # Same change on both sides
     local = [["different"]]
     base = [["same"]]
@@ -234,6 +240,8 @@ def test_merge_simple_cell_sources():
     expected_conflicts = []
     _check(base, local, remote, expected_partial, expected_conflicts)
 
+
+def test_merge_simple_cell_source_conflicting_edit_aligned():
     # Conflicting cell inserts at same location as removing old cell
     local = [["local"]]
     base = [["base"]]
@@ -252,6 +260,8 @@ def test_merge_simple_cell_sources():
         }]
     _check(base, local, remote, expected_partial, expected_conflicts)
 
+
+def test_merge_simple_cell_source_conflicting_insert():
     # Cell inserts at same location but no other modifications:
     # should this be accepted?
     local = [["base"], ["local"]]

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -68,6 +68,7 @@ class Strategies(dict):
     """
     def __init__(self, *args, **kwargs):
         self.transients = kwargs.get("transients", [])
+        self.fall_back = kwargs.get("fall_back", None)
         super(Strategies, self).__init__(*args, **kwargs)
 
     def get(self, k, d=None):


### PR DESCRIPTION
Refactor the CLI for merge strategies.
 - Limit applicable CLI merge strategies to "use-base", "use-local", "use-remote", "union",  or "inline".
 - Functions also accept "mergetool" as strategy.
 - Flag `--no-ignore-transients` : Disallow clearing/ignoring of transient data on conflicts.
 - Added `--input-strategy`/`--output-strategy`, that takes the same values as `--merge-strategy`, but will override strategy for source/outputs, respectively.

Fixes #19.


### TODO:
 - [x] Add tests for input/output strategies.
 - [x] Add tests for interplay between various flags and options (order of precedence).
 - [x] Document interface