### PR TITLE
Update documentation for installation and index intro

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ import recommonmark.parser
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.3'
+needs_sphinx = '1.4'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -111,7 +111,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+#html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -283,6 +283,3 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
-
-# TODO configuration - Remove this section or set to False after docs are stable
-todo_include_todos = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,34 +1,30 @@
-.. nbdime documentation master file, created by
-   sphinx-quickstart on Wed Dec  2 12:33:47 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 nbdime -- diffing and merging of Jupyter Notebooks
 ==================================================
 
 Version: |version|
 
+
+**nbdime** provides tools for diffing and merging `Jupyter notebooks <jupyter-notebook>`_.
+
 Abstract
 --------
 
-**nbdime** provides tools for diffing and merging `Jupyter notebooks <jupyter-notebook>`_.
-Notebooks are great, rich media documents stored in a plain text JSON format.
-This is relatively easy to parse, but primitive line-based diff and merge tools
-do not understand the structure of notebook documents, and do not behave well,
-yielding diffs like this:
+Jupyter notebooks are useful, rich media documents stored in a plain text JSON format.
+This format is relatively easy to parse. However, primitive line-based diff and merge tools
+do not handle well the logical structure of notebook documents. These tools
+yield diffs like this:
 
-TODO: screenshot of bad line-based diff.
+.. TODO:: screenshot of bad line-based diff.
 
-nbdime, on the other hand, understands notebook documents,
-and can make intelligent decisions when diffing and merging notebooks,
+**nbdime**, on the other hand, provides "content-aware" diffing and merging of
+Jupyter notebooks. It understands the structure of notebook documents.
+Therefore, it can make intelligent decisions when diffing and merging notebooks,
 such as:
 
 - eliding base64-encoded images for terminal output
-- use existing diff tools for inputs and outputs
-- render image diffs in a web view
-- auto-resolve conflicts on generated values such as execution counters
-
-
+- using existing diff tools for inputs and outputs
+- rendering image diffs in a web view
+- auto-resolving conflicts on generated values such as execution counters
 
 Quickstart
 ----------
@@ -37,34 +33,34 @@ To get started with nbdime, install with pip::
 
     pip install nbdime
 
-And you can be off to the races diffing notebooks in your terminal with::
+And you can be off to the races by diffing notebooks in your terminal with :command:`nbdiff`::
 
-    nbdiff notebook-1.ipynb notebook-2.ipynb
+    nbdiff notebook_1.ipynb notebook_2.ipynb
 
-or viewing a rich web-based rendering of the diff with::
+or viewing a rich web-based rendering of the diff with :command:`nbdiff-web`::
 
-    nbdiff-web notebook-1.ipynb notebook-2.ipynb
+    nbdiff-web notebook_1.ipynb notebook_2.ipynb
 
-For more on how you can use nbdime, see :doc:`cli`.
+For more information about nbdime's commands, see :doc:`cli`.
 
-Git quickstart
-**************
+Git integration quickstart
+**************************
 
-Many of us writing and sharing notebooks do so with git and GitHub.
+Many of us who are writing and sharing notebooks do so with git and GitHub.
 Git doesn't handle diffing and merging notebooks very well by default,
-but you can tell git to use nbdime and it will get a lot better.
+but you can configure git to use nbdime and it will get a lot better.
 
-To tell git to use nbdime to as a command-line driver to diff and merge notebooks::
+To configure git to use nbdime to as a command-line driver to diff and merge notebooks::
 
     git-nbdiffdriver config --enable --global
     git-nbmergedriver config --enable --global
 
-Now when you do :command:`git diff` or :command:`git merge` and notebooks are involved,
+Now when you do :command:`git diff` or :command:`git merge` with notebooks,
 you should see a nice diff view, like this:
 
-TODO: screenshot
+.. TODO:: screenshot
 
-To tell git to use the web-based GUI viewers of notebook diffs and merges::
+To configure git to use the web-based GUI viewers of notebook diffs and merges::
 
     git-nbdifftool config --enable --global
     git-nbmergetool config --enable --global
@@ -73,25 +69,29 @@ With these, you can trigger the :command:`tools` with::
 
     git difftool --tool nbdime [ref [ref]]
 
-TODO: screenshot of diff-web
+.. TODO:: screenshot of diff-web
 
-and
+and::
 
     git mergetool --tool nbdime
 
-TODO: screenshot of merge-web
+.. TODO:: screenshot of merge-web
 
 
 .. note::
 
-    :command:`git diffdriver` config overrides the ability to call :command:`git difftool` with notebooks.
-    You can still call `nbdiff-web` to diff files directly,
-    but getting those files from git refs is still on our TODO list.
+    Using :command:`git-nbdiffdriver config` overrides the ability to call
+    :command:`git difftool` with notebooks.
+
+    You can still call :command:`nbdiff-web` to diff files directly,
+    but getting the files from git refs is still on our TODO list.
+
 
 For more detailed information on integrating nbdime with version control, see :doc:`vcs`.
 
 Contents
 --------
+
 .. toctree::
    :maxdepth: 2
    :caption: Installation and usage
@@ -109,8 +109,7 @@ Contents
    usecases
    diffing
    merging
-   restapi.md
-
+   restapi
 
 .. links
 

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -37,7 +37,7 @@ and nbdime's web-based viewers depend on the following Node.js packages:
 Installing latest development version
 =====================================
 
-Installing a development version of nbdime requires `Nodejs <https://nodejs.org>`_.
+Installing a development version of nbdime requires `Node.js <https://nodejs.org>`_.
 
 Installing nbdime using :command:`pip` will install the Python package
 dependencies and
@@ -57,7 +57,7 @@ using ``nodeenv``::
     pip install nodeenv
     nodeenv -p
 
-With this environment active, you can install nbdime and its
+With this environment active, you can now install nbdime and its
 dependencies using :command:`pip`.
 
 For example with Python 3.5, the steps with output are::

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -85,7 +85,7 @@ virtualenv as shown here)::
     Installing collected packages: virtualenv
     Successfully installed virtualenv-15.1.0
     $ python2 -m virtualenv myenv
-    New python executable in /Users/carol/myenv/bin/python
+    New python executable in /Users/username/myenv/bin/python
     Installing setuptools, pip, wheel...done.
     $ source myenv/bin/activate
     (myenv) $ pip install nodeenv

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -52,7 +52,7 @@ The following steps will: create a virtualenv, named ``myenv``, in the current
 directory; activate the virtualenv; and install npm inside the virtualenv
 using ``nodeenv``::
 
-    virtualenv myenv
+    python3 -m venv myenv          # For Python 2: python2 -m virtualenv myenv
     source myenv/bin/activate
     pip install nodeenv
     nodeenv -p
@@ -75,8 +75,32 @@ For example with Python 3.5, the steps with output are::
      * Appending data to /Users/username/myenv/bin/activate
     (myenv) $
 
-Installing a development version
---------------------------------
+Using Python 2.7, the steps with output are (note: you may need to install
+virtualenv as shown here)::
+
+    $ python2 -m pip install virtualenv
+    Collecting virtualenv
+      Downloading virtualenv-15.1.0-py2.py3-none-any.whl (1.8MB)
+        100% |████████████████████████████████| 1.8MB 600kB/s
+    Installing collected packages: virtualenv
+    Successfully installed virtualenv-15.1.0
+    $ python2 -m virtualenv myenv
+    New python executable in /Users/carol/myenv/bin/python
+    Installing setuptools, pip, wheel...done.
+    $ source myenv/bin/activate
+    (myenv) $ pip install nodeenv
+    Collecting nodeenv
+      Downloading nodeenv-1.0.0.tar.gz
+    Installing collected packages: nodeenv
+      Running setup.py install for nodeenv ... done
+    Successfully installed nodeenv-1.0.0
+    (myenv) $ nodeenv -p
+     * Install prebuilt node (7.2.0) ..... done.
+     * Appending data to /Users/username/myenv/bin/activate
+    (myenv) $
+
+Install the development version
+-------------------------------
 
 Download and install directly from source::
 

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -5,25 +5,20 @@ Installation
 Installing nbdime
 =================
 
-To install latest release from pypi::
+To install the latest stable release using :command:`pip`::
 
     pip install --upgrade nbdime
-
 
 Dependencies
 ------------
 
-nbdime requires python version 2.7.1+, or 3.3 or higher.
+.. TODO:: do we want to bump these to 2.7.6 and 3.4?
 
-.. note::
+nbdime requires Python version 3.3 or higher. If you are using Python 2,
+nbdime requires 2.7.1 or higher.
 
-    Python 2.7.1 is required, not 2.7.0, this is
-    because 2.7.1 fixes a bug in :mod:`difflib <py3.difflib>` in an
-    interface-breaking way.
-
-
-nbdime depends the following python packages,
-which will be pulled in by :command:`pip`:
+nbdime depends on the following Python packages,
+which will be installed by :command:`pip`:
 
   - six
   - nbformat
@@ -31,7 +26,7 @@ which will be pulled in by :command:`pip`:
   - colorama
   - backports.shutil_which (on python 2.7)
 
-and its web-based viewers use the following npm packages:
+and nbdime's web-based viewers depend on the following Node.js packages:
 
   - codemirror
   - json-stable-stringify
@@ -39,43 +34,57 @@ and its web-based viewers use the following npm packages:
   - jupyterlab
   - phosphor
 
+Installing latest development version
+=====================================
 
-Installing latest development version of nbdime
-===============================================
+Installing a development version of nbdime requires `Nodejs <https://nodejs.org>`_.
 
-Installing a development version of nbdime requires nodejs.
+Installing nbdime using :command:`pip` will install the Python package
+dependencies and
+will automatically run ``npm`` to install the required Node.js packages.
 
-Installing nbdime using `standard pip options <https://pip.pypa.io/en/stable/>`_
-will automatically run npm to install the required node.js packages
-as well as the python package dependencies.
+Setting up a virtualenv with Node.js
+------------------------------------
 
+.. TODO:: review these instructions re virtualenv
 
-Setting up a virtualenv with node.js before installing nbdime
--------------------------------------------------------------
-
-The following steps will create a virtualenv in the current
-directory named 'myenv' and install npm inside the virtualenv::
+The following steps will: create a virtualenv, named ``myenv``, in the current
+directory; activate the virtualenv; and install npm inside the virtualenv
+using ``nodeenv``::
 
     virtualenv myenv
     source myenv/bin/activate
     pip install nodeenv
     nodeenv -p
 
-With this environment active you can install nbdime with all
-dependencies using pip as usual.
+With this environment active, you can install nbdime and its
+dependencies using :command:`pip`.
 
+For example with Python 3.5, the steps with output are::
 
-Doing a development install
----------------------------
+    $ python3 -m venv myenv
+    $ source myenv/bin/activate
+    (myenv) $ pip install nodeenv
+    Collecting nodeenv
+      Downloading nodeenv-1.0.0.tar.gz
+    Installing collected packages: nodeenv
+      Running setup.py install for nodeenv ... done
+    Successfully installed nodeenv-1.0.0
+    (myenv) $ nodeenv -p
+     * Install prebuilt node (7.2.0) ..... done.
+     * Appending data to /Users/username/myenv/bin/activate
+    (myenv) $
+
+Installing a development version
+--------------------------------
 
 Download and install directly from source::
 
     pip install -e git+https://github.com/jupyter/nbdime
 
 Or clone the `nbdime repository <https://github.com/jupyter/nbdime>`_
-and use pip to install::
+and use ``pip`` to install::
 
     git clone https://github.com/jupyter/nbdime
     cd nbdime
     pip install -e .
-


### PR DESCRIPTION
Pretty heavy edit of content in `index.rst` and `installation.rst` and minor edits to `conf.py`.

- `index.rst` mostly styling and grammar consistency for reader
- `installation.rst` updated installation instructions for virtualenv for Python 2 and Python 3

Do we want to revisit which versions of Python 2 and Python 3 are supported?