### PR TITLE
Fix autoresolve of addrange+patch vs addrange+patch conflicts

### DIFF
--- a/nbdime/tests/files/apap--1.ipynb
+++ b/nbdime/tests/files/apap--1.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ipsum lorem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png" : "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAUSURBVBhXY/j//39+fj6I4uTkBAA+xgdjMUPuuQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x106d1b198>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 403,
+       "width": 596
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Some lines\n",
+    "To help with\n",
+    "Alignment\n",
+    "Another one bites the dust\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/files/apap--2.ipynb
+++ b/nbdime/tests/files/apap--2.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Foo bar, foo bar, the quick brown fox:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png" : "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAUSURBVBhXY/j//39+fj6I4uTkBAA+xgdjMUPuuQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x106d1b198>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 403,
+       "width": 596
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Some lines\n",
+    "To help with\n",
+    "Alignment\n",
+    "Another one bites the dust\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/files/apap--3.ipynb
+++ b/nbdime/tests/files/apap--3.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Foo bar, foo bar, What is love, baby don't hurt me:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png" : "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAAZSURBVBhXY/4PBB8+fGhgfG9p///LoycMAHyNDHEXLXDWAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x106d1b198>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 403,
+       "width": 596
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Some lines\n",
+    "To help with\n",
+    "Alignment\n",
+    "War! What is it good for?\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbdime/tests/files/apap.ipynb
+++ b/nbdime/tests/files/apap.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png" : "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAUSURBVBhXY1ixYkVraysDCDMwAAAtgAUX7HVO4wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x106d1b198>"
+      ]
+     },
+     "metadata": {
+      "image/png": {
+       "height": 403,
+       "width": 596
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "Some lines\n",
+    "To help with\n",
+    "Alignment\n",
+    "Yeah\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
 - Adds some test files which gives AP/AP conflicts (with either differing or identical patch ops).
 - Fixes handling of such conflicts.

Note that the implemented handling of such conflicts for strings is a temporary fix in wait of a more complete overhaul of string diff chunking.