### PR TITLE
Web merge: Clear outputs

### DIFF
--- a/nbdime-web/src/common/collapsible.css
+++ b/nbdime-web/src/common/collapsible.css
@@ -1,6 +1,6 @@
 
 .jp-CollapsiblePanel {
-    border: #39f solid 1pt;
+    border: var(--jp-nbdime-output-color1) solid 1pt;
 }
 
 .jp-CollapsiblePanel-header-icon {
@@ -24,10 +24,10 @@
 .jp-CollapsiblePanel-header {
     padding-top: .2em;
     padding-bottom: .2em;
-    background-color: #adf;
+    background-color: var(--jp-nbdime-output-color3);
     padding-left: 2em;
     padding-right: 2em;
-    border-top: #39f solid 1pt;
+    border-top: var(--jp-nbdime-output-color1) solid 1pt;
 }
 
 .jp-CollapsiblePanel-container {

--- a/nbdime-web/src/common/dragpanel.ts
+++ b/nbdime-web/src/common/dragpanel.ts
@@ -31,6 +31,25 @@ import {
 } from 'phosphor/lib/dom/dragdrop';
 
 
+//TODO: Remove when fixed:
+/**
+ * Workaround for phosphor bug #165.
+ */
+class WorkaroundDrag extends Drag {
+}
+
+function _attachDragImage(clientX: number, clientY: number): void {
+  (Drag as any).prototype._attachDragImage.call(this, clientX + window.pageXOffset, clientY + window.pageYOffset);
+}
+function _moveDragImage(clientX: number, clientY: number): void {
+  (Drag as any).prototype._moveDragImage.call(this, clientX + window.pageXOffset, clientY + window.pageYOffset);
+}
+
+// monkeypatch:
+(WorkaroundDrag.prototype as any)._attachDragImage = _attachDragImage;
+(WorkaroundDrag.prototype as any)._moveDragImage = _moveDragImage;
+
+
 /**
  * The class name added to the DropPanel
  */
@@ -445,7 +464,7 @@ abstract class DragDropPanelBase extends DropPanel {
     let dragImage = this.getDragImage(handle);
 
     // Set up the drag event.
-    this.drag = new Drag({
+    this.drag = new WorkaroundDrag({
       dragImage: dragImage || undefined,
       mimeData: new MimeData(),
       supportedActions: 'all',

--- a/nbdime-web/src/diff/widget/cell.ts
+++ b/nbdime-web/src/diff/widget/cell.ts
@@ -27,7 +27,7 @@ import {
 } from '../../common/collapsiblepanel';
 
 import {
-  valueIn
+  valueIn, hasEntries
 } from '../../common/util';
 
 import {
@@ -126,7 +126,7 @@ class CellDiffWidget extends Panel {
       metadataView.addClass(METADATA_ROW_CLASS);
       this.addWidget(metadataView);
     }
-    if (model.outputs && model.outputs.length > 0) {
+    if (hasEntries(model.outputs)) {
       let container = new Panel();
       let changed = false;
       for (let o of model.outputs) {
@@ -189,11 +189,14 @@ class CellDiffWidget extends Panel {
       // 1) Text-type output: Show a MergeView with text diff.
       // 2) Renderable types: Side-by-side comparison.
       // 3) Unknown types: Stringified JSON diff.
+      // If the model is one-sided or unchanged, option 2) is preferred to 1)
       let renderable = RenderableOutputView.canRenderUntrusted(model);
       for (let mt of rendermime.order) {
         let key = model.hasMimeType(mt);
         if (key) {
-          if (!renderable || valueIn(mt, stringDiffMimeTypes)) {
+          if (!renderable ||
+              !(model.added || model.deleted || model.unchanged) &&
+              valueIn(mt, stringDiffMimeTypes)) {
             // 1.
             view = createNbdimeMergeView(model.stringify(key), editorClasses);
           } else if (renderable) {

--- a/nbdime-web/src/merge/model/cell.ts
+++ b/nbdime-web/src/merge/model/cell.ts
@@ -226,6 +226,52 @@ class CellMergeModel extends ObjectMergeModel<nbformat.ICell, CellDiffModel> {
   }
 
   /**
+   * Whether the cell has any conflicted decisions.
+   */
+  get conflicted(): boolean {
+    for (let dec of this.decisions) {
+      if (dec.conflict) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the cell has any conflicted decisions on a specific key.
+   */
+  hasConflictsOn(key: string) {
+    let decs = filterDecisions(this.decisions, [key], 2);
+    for (let dec of decs) {
+      if (dec.conflict) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Whether the cell has any conflicted decisions on source.
+   */
+  get sourceConflicted(): boolean {
+    return this.hasConflictsOn('source');
+  }
+
+  /**
+   * Whether the cell has any conflicted decisions on metadata.
+   */
+  get metadataConflicted(): boolean {
+    return this.hasConflictsOn('metadata');
+  }
+
+  /**
+   * Whether the cell has any conflicted decisions.
+   */
+  get outputsConflicted(): boolean {
+    return this.hasConflictsOn('outputs');
+  }
+
+  /**
    * Get the decision on `execution_count` field (should only be one).
    *
    * Returns null if no decision on `execution_count` was found.

--- a/nbdime-web/src/merge/widget/cell.ts
+++ b/nbdime-web/src/merge/widget/cell.ts
@@ -171,6 +171,7 @@ class CellMergeWidget extends Panel {
           model.local.added && model.agreedCell || // Identical additions
           model.local.deleted && model.remote.deleted   // Deletion on both
           ) {
+      CURR_CLASSES = CURR_CLASSES.slice(1, 3);
       // Add single view of source:
       let view = CellDiffWidget.createView(
         model.merged.source, model.merged, CURR_CLASSES, this._rendermime);
@@ -187,6 +188,18 @@ class CellMergeWidget extends Panel {
       }
       view.addClass(SOURCE_ROW_CLASS);
       this.addWidget(view);
+
+      if (hasEntries(model.merged.outputs)) {
+        // Add single view of rendered output
+        let container = new Panel();
+        for (let m of model.merged.outputs) {
+          view = CellDiffWidget.createView(
+            m, model.merged, CURR_CLASSES, this._rendermime);
+          container.addWidget(view);
+        }
+        container.addClass(OUTPUTS_ROW_CLASS);
+        this.addWidget(container);
+      }
     } else {
       // Setup full 4-way mergeview of source, metadata and outputs
       // as needed (if changed). Source/metadata/output are each a "row"

--- a/nbdime-web/src/merge/widget/cell.ts
+++ b/nbdime-web/src/merge/widget/cell.ts
@@ -31,6 +31,10 @@ import {
 } from '../../common/mergeview';
 
 import {
+  hasEntries
+} from '../../common/util';
+
+import {
   IStringDiffModel, StringDiffModel, IDiffModel, OutputDiffModel
 } from '../../diff/model';
 
@@ -248,7 +252,7 @@ class CellMergeWidget extends Panel {
         collapser.addClass(METADATA_ROW_CLASS);
         this.addWidget(collapser);
       }
-      if (outputsChanged || model.merged.outputs && model.merged.outputs.length > 0) {
+      if (outputsChanged || hasEntries(model.merged.outputs)) {
         // We know here that we have code cell
         // -> all have outputs !== null
         let baseOut = CellMergeWidget.getOutputs(model.local.outputs!, true);
@@ -281,9 +285,11 @@ class CellMergeWidget extends Panel {
     w.addClass(CELL_HEADER_TITLE_CLASS);
     header.addWidget(w);
 
-    // Add "clear outputs" checkbox
-    let clearOutputToggle = this._createClearOutputToggle();
-    header.addWidget(clearOutputToggle);
+    if (hasEntries(this.model.merged.outputs)) {
+      // Add "clear outputs" checkbox
+      let clearOutputToggle = this._createClearOutputToggle();
+      header.addWidget(clearOutputToggle);
+    }
 
     // Add "delete cell" checkbox
     let deleteToggle = this._createDeleteToggle();

--- a/nbdime-web/src/merge/widget/cell.ts
+++ b/nbdime-web/src/merge/widget/cell.ts
@@ -55,6 +55,7 @@ import {
 } from './output';
 
 import {
+  createCheckbox,
   ONEWAY_LOCAL_CLASS, ONEWAY_REMOTE_CLASS,
   TWOWAY_ADDITION_CLASS, TWOWAY_DELETION_CLASS,
   MERGE_CLASSES
@@ -107,22 +108,6 @@ class CellMergeWidget extends Panel {
       }
     }
     return raw;
-  }
-
-  protected static createCheckbox(value: boolean, text: string): {
-      checkbox: HTMLInputElement, widget: Widget } {
-    let checkbox = document.createElement('input');
-    checkbox.setAttribute('type', 'checkbox');
-    checkbox.checked = value;
-    // Create label for checkbox:
-    let widget = new Widget();
-    let label = document.createElement('label');
-    label.innerText = text;
-    // Combine checkbox and label:
-    label.insertBefore(checkbox, label.childNodes[0]);
-    // Add checkbox to header:
-    widget.node.appendChild(label);
-    return {checkbox, widget};
   }
 
   /**
@@ -314,7 +299,7 @@ class CellMergeWidget extends Panel {
   }
 
   private _createClearOutputToggle(): Widget {
-    let {checkbox, widget} = CellMergeWidget.createCheckbox(
+    let {checkbox, widget} = createCheckbox(
       this.model.clearOutputs, 'Clear outputs');
     if (this.model.clearOutputs) {
       this.addClass(MARKED_CLEAR_OUTPUTS);
@@ -334,7 +319,7 @@ class CellMergeWidget extends Panel {
   }
 
   private _createDeleteToggle(): Widget {
-    let {checkbox, widget} = CellMergeWidget.createCheckbox(
+    let {checkbox, widget} = createCheckbox(
       this.model.deleteCell, 'Delete cell');
     if (this.model.deleteCell) {
       this.addClass(MARKED_DELETE);

--- a/nbdime-web/src/merge/widget/cell.ts
+++ b/nbdime-web/src/merge/widget/cell.ts
@@ -11,10 +11,6 @@ import {
 } from 'jupyterlab/lib/notebook/notebook/nbformat';
 
 import {
-  DragPanel
-} from '../../common/dragpanel';
-
-import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -23,16 +19,16 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  createNbdimeMergeView
-} from '../../common/mergeview';
-
-import {
   CollapsiblePanel
 } from '../../common/collapsiblepanel';
 
 import {
-  CellMergeModel
-} from '../model';
+  DragPanel
+} from '../../common/dragpanel';
+
+import {
+  createNbdimeMergeView
+} from '../../common/mergeview';
 
 import {
   IStringDiffModel, StringDiffModel, IDiffModel, OutputDiffModel
@@ -45,6 +41,10 @@ import {
 import {
   FlexPanel
 } from '../../upstreaming/flexpanel';
+
+import {
+  CellMergeModel
+} from '../model';
 
 import {
   RenderableOutputsMergeView

--- a/nbdime-web/src/merge/widget/common.ts
+++ b/nbdime-web/src/merge/widget/common.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 'use strict';
 
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
 
 // Merge classes:
 export const ONEWAY_LOCAL_CLASS = 'jp-Merge-oneway-local';
@@ -15,4 +19,30 @@ const REMOTE_MERGE_CLASS = 'jp-Merge-remote';
 const MERGED_MERGE_CLASS = 'jp-Merge-merged';
 
 export const MERGE_CLASSES = [BASE_MERGE_CLASS, LOCAL_MERGE_CLASS,
-    REMOTE_MERGE_CLASS, MERGED_MERGE_CLASS];
+  REMOTE_MERGE_CLASS, MERGED_MERGE_CLASS];
+
+
+/**
+ * Create a widget containing a checkbox with a label.
+ *
+ * @export
+ * @param {boolean} value - The initial check state (true = checked)
+ * @param {string} text - The text of the label
+ * @returns {{checkbox: HTMLInputElement, widget: Widget }}
+ */
+export
+function createCheckbox(value: boolean, text: string, indeterminate=false): {checkbox: HTMLInputElement, widget: Widget } {
+  let checkbox = document.createElement('input');
+  checkbox.setAttribute('type', 'checkbox');
+  checkbox.checked = value;
+  checkbox.indeterminate = indeterminate;
+  // Create label for checkbox:
+  let widget = new Widget();
+  let label = document.createElement('label');
+  label.innerHTML = text;
+  // Combine checkbox and label:
+  label.insertBefore(checkbox, label.childNodes[0]);
+  // Add checkbox to header:
+  widget.node.appendChild(label);
+  return {checkbox, widget};
+}

--- a/nbdime-web/src/merge/widget/output.ts
+++ b/nbdime-web/src/merge/widget/output.ts
@@ -40,6 +40,7 @@ import {
 
 
 const REORDERABLE_OUTPUT_CLASS = 'jp-Merge-reorder-outputs';
+const REORDERABLE_OUTPUT_DRAGIMAGE_CLASS = 'jp-Merge-dragimage-output';
 const DELETE_DROP_ZONE_CLASS = 'jp-Merge-output-drop-delete';
 
 
@@ -364,6 +365,7 @@ class RenderableOutputsMergeView extends DragDropPanel {
     if (target) {
       let image = target.cloneNode(true) as HTMLElement;
       image.style.width = target.offsetWidth.toString() + 'px';
+      image.classList.add(REORDERABLE_OUTPUT_DRAGIMAGE_CLASS)
       return image;
     }
     return null;

--- a/nbdime-web/src/merge/widget/output.ts
+++ b/nbdime-web/src/merge/widget/output.ts
@@ -19,8 +19,8 @@ import {
 } from 'jupyterlab/lib/notebook/notebook/nbformat';
 
 import {
-  DragDropPanel, DragPanel, findChild
-} from '../../common/dragpanel';
+  DropAction, IDragEvent
+} from 'phosphor/lib/dom/dragdrop';
 
 import {
   Widget
@@ -31,9 +31,16 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
+  DragDropPanel, DropPanel, DragPanel, findChild, MIME_INDEX
+} from '../../common/dragpanel';
+
+import {
   FlexPanel
 } from '../../upstreaming/flexpanel';
 
+
+const REORDERABLE_OUTPUT_CLASS = 'jp-Merge-reorder-outputs';
+const DELETE_DROP_ZONE_CLASS = 'jp-Merge-output-drop-delete';
 
 
 /**
@@ -54,6 +61,10 @@ class ReorderableOutputModel extends OutputAreaModel {
     // like the `add` method in parent class.
     this.list.move(fromIndex, toIndex);
   }
+
+  remove(index: number): OutputAreaModel.Output | null {
+    return this.list.removeAt(index);
+  }
 }
 
 /**
@@ -66,15 +77,18 @@ class ReorderableOutputWidget extends OutputAreaWidget {
   model: ReorderableOutputModel;
 
   protected onModelStateChanged(sender: OutputAreaModel, args: IListChangedArgs<nbformat.IOutput>) {
+    let layout = this.layout as PanelLayout;
     switch (args.type) {
     case 'add':
       // Children are NOT always added at the end.
       this.addChild(args.newIndex);
       break;
     case 'move':
-      let layout = this.layout as PanelLayout;
       layout.insertWidget(args.newIndex,
         layout.widgets.at(args.oldIndex));
+      break;
+    case 'remove':
+      layout.removeWidgetAt(args.oldIndex);
       break;
     default:
       return super.onModelStateChanged(sender, args);
@@ -95,6 +109,29 @@ class ReorderableOutputWidget extends OutputAreaWidget {
   }
 }
 
+
+class DisconnectedDropTarget extends DropPanel {
+  constructor() {
+    super({acceptDropsFromExternalSource: true});
+  }
+
+  protected findDropTarget(input: HTMLElement): HTMLElement | null  {
+    if (input === this.node || this.node.contains(input)) {
+      return this.node;
+    }
+    return null;
+  }
+
+  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
+    if (this.callback) {
+      this.callback(dropTarget, event);
+    }
+  };
+
+  callback: ((dropTarget: HTMLElement, event: IDragEvent) => void) | null = null;
+}
+
+
 /**
  * Widget for showing side by side comparison and picking of merge outputs
  */
@@ -108,6 +145,21 @@ class RenderableOutputsMergeView extends DragDropPanel {
     }
   }
 
+  private static get deleteDrop(): DisconnectedDropTarget {
+    if (!RenderableOutputsMergeView._deleteDrop) {
+      let widget = new DisconnectedDropTarget();
+      widget.addClass(DELETE_DROP_ZONE_CLASS);
+      let icon = document.createElement('i');
+      icon.className = 'fa fa-lg fa-trash-o';
+      icon.setAttribute('aria-hidden', 'true');
+      widget.node.appendChild(icon);
+      widget.node.style.position = 'absolute';
+      RenderableOutputsMergeView._deleteDrop = widget;
+    }
+    return RenderableOutputsMergeView._deleteDrop;
+  }
+  private static _deleteDrop: DisconnectedDropTarget | null = null;
+
   /**
    *
    */
@@ -116,6 +168,7 @@ class RenderableOutputsMergeView extends DragDropPanel {
               base: nbformat.IOutput[] | null, remote: nbformat.IOutput[] | null,
               local: nbformat.IOutput[] | null) {
     super();
+    this.addClass(REORDERABLE_OUTPUT_CLASS);
 
     if (!base !== !remote || !base !== !local) {
       // Assert that either none, or all of base/remote/local are given
@@ -175,6 +228,7 @@ class RenderableOutputsMergeView extends DragDropPanel {
       this.addWidget(row);
       row = new FlexPanel({direction: 'left-to-right', evenSizes: true});
     }
+
     this.mergePane = new ReorderableOutputWidget({rendermime: this.rendermime});
     this.mergePane.addClass(classes[3]);
     this.mergePane.model = this.merged;
@@ -271,8 +325,38 @@ class RenderableOutputsMergeView extends DragDropPanel {
    * Returns null if no valid drop target was found.
    */
   protected findDropTarget(node: HTMLElement): HTMLElement | null {
+    if (node === this.mergePane.node && this.mergePane.model.length === 0) {
+      // If empty, use pane as target
+      return this.mergePane.node;
+    }
     // Only valid drop target is in merge pane!
     return findChild(this.mergePane.node, node);
+  }
+
+  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
+    if (dropTarget === RenderableOutputsMergeView.deleteDrop.node) {
+      // Simply remove output
+      let [paneIdx, outputIdx] = event.mimeData.getData(MIME_INDEX) as number[];
+      if (this.panes[paneIdx] !== this.mergePane) {
+        // Shouldn't happen if drop target code is correct...
+        return;
+      }
+      this.mergePane.model.remove(outputIdx);
+      // Event cleanup
+      event.preventDefault();
+      event.stopPropagation();
+      event.dropAction = 'move';
+    } else if (dropTarget === this.mergePane.node && this.mergePane.model.length === 0) {
+      // Dropping on empty merge pane
+      let sourceKey = event.mimeData.getData(MIME_INDEX) as number[];
+      this.move(sourceKey, [this.panes.indexOf(this.mergePane), 0]);
+      // Event cleanup
+      event.preventDefault();
+      event.stopPropagation();
+      event.dropAction = 'copy';
+    } else {
+      super.processDrop(dropTarget, event);
+    }
   }
 
   protected getDragImage(handle: HTMLElement) {
@@ -283,6 +367,31 @@ class RenderableOutputsMergeView extends DragDropPanel {
       return image;
     }
     return null;
+  }
+
+  protected startDrag(handle: HTMLElement, clientX: number, clientY: number): void {
+    super.startDrag(handle, clientX, clientY);
+    // After starting drag, show delete drop-zone ('trash')
+    if (findChild(this.mergePane.node, handle)) {
+      let dd = RenderableOutputsMergeView.deleteDrop;
+      dd.callback = this.processDrop.bind(this);
+      // Calculate position and size:
+      let ourRect = this.mergePane.node.getBoundingClientRect();
+      dd.node.style.left = '0';
+      dd.node.style.width = (ourRect.left + window.pageXOffset).toString() + 'px';
+      dd.node.style.top = (ourRect.top + window.pageYOffset).toString() + 'px';
+      dd.node.style.height = ourRect.height.toString() + 'px';
+      // Attach to document
+      Widget.attach(dd, document.body);
+    }
+  }
+
+  protected onDragComplete(action: DropAction) {
+    super.onDragComplete(action);
+    // After finishing drag, hide delete drop-zone ('trash')
+    if (RenderableOutputsMergeView.deleteDrop.isAttached) {
+      Widget.detach(RenderableOutputsMergeView.deleteDrop);
+    }
   }
 
   base: OutputAreaModel | null = null;

--- a/nbdime-web/src/styles/diff.css
+++ b/nbdime-web/src/styles/diff.css
@@ -60,7 +60,7 @@
 
 .jp-Notebook-diff .jp-Diff-added .jp-Cellrow-outputs,
 .jp-Notebook-diff .jp-Diff-deleted .jp-Cellrow-outputs {
-  border-top: #39f solid 1pt;
+  border-top: var(--jp-nbdime-output-color1) solid 1pt;
 }
 
 .jp-Notebook-diff .jp-Diff-added .jp-Diff-unchanged {

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -53,6 +53,15 @@
   border: solid gray thin;
 }
 
+.jp-Merge-output-drop-delete {
+  border: 3px dashed var(--jp-nbdime-output-color2);
+  border-radius: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
 .jp-Notebook-merge .CodeMirror-merge-pane-deleted,
 .jp-Notebook-merge .CodeMirror-merge-pane-added {
   width: 100%;

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -213,7 +213,7 @@
 
 .jp-Notebook-merge .jp-Merge-oneway-local .jp-Cellrow-outputs,
 .jp-Notebook-merge .jp-Merge-oneway-remote .jp-Cellrow-outputs {
-  border-top: #39f solid 1pt;
+  border-top: var(--jp-nbdime-output-color1) solid 1pt;
 }
 
 .jp-Notebook-merge .jp-Output:first-child {

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -194,3 +194,16 @@
 .jp-Notebook-merge .jp-Cellrow-outputs .p-FlexPanel:last-of-type .jp-OutputArea {
   margin-top: 5px;
 }
+
+.jp-Notebook-merge .jp-Diff-renderedOuput .jp-Merge-local {
+  background-color: var(--jp-merge-local-color2);
+}
+
+.jp-Notebook-merge .jp-Diff-renderedOuput .jp-Merge-remote {
+  background-color: var(--jp-merge-remote-color2);
+}
+
+.jp-Notebook-merge .jp-Merge-oneway-local .jp-Cellrow-outputs,
+.jp-Notebook-merge .jp-Merge-oneway-remote .jp-Cellrow-outputs {
+  border-top: #39f solid 1pt;
+}

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -229,3 +229,20 @@
   margin-top: 0;
 }
 
+.jp-Merge-notebook-controls {
+  justify-content: flex-end;
+  margin-bottom: 10px;
+  padding: 5px;
+  background-color: var(--jp-layout-color2);
+  border: solid 1px var(--jp-ui-font-color2);
+}
+
+.jp-Merge-notebook-controls:empty {
+  display: none;
+}
+
+.jp-Notebook-merge label[disabled] {
+  color: var(--jp-ui-font-color3);
+}
+
+

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -43,7 +43,7 @@
   flex-grow: 1;
 }
 
-.jp-Notebook-merge .jp-DragWidget-dragHandle {
+.jp-Notebook-merge .jp-DragPanel-dragHandle {
   height: 18px;
   width: 12px;
 }
@@ -166,8 +166,12 @@
   background-color: var(--jp-merge-both-color2);
 }
 
-.jp-Notebook-merge .CodeMirror-merge-pane.jp-mod-missing {
-  background-color: var(--jp-merge-both-color2);
+.jp-Notebook-merge .CodeMirror-merge-pane.CodeMirror-merge-pane-local.jp-mod-missing {
+  background-color: var(--jp-merge-local-color2);
+}
+
+.jp-Notebook-merge .CodeMirror-merge-pane.CodeMirror-merge-pane-remote.jp-mod-missing {
+  background-color: var(--jp-merge-remote-color2);
 }
 
 .jp-Notebook-merge .jp-Cell-merge.jp-mod-todelete > .p-Widget:not(.jp-Merge-cellHeader) {

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -179,7 +179,9 @@
   background-color: var(--jp-merge-both-color2);
 }
 
-
+.jp-Cell-merge.jp-mod-clearoutputs .jp-Cellrow-outputs {
+  display: none;
+}
 
 .jp-Notebook-merge .jp-Cellrow-outputs .jp-OutputArea {
   border: #666 solid 1pt;

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -48,10 +48,20 @@
   width: 12px;
 }
 
-.jp-Notebook-merge .jp-Output.p-mod-drag-image {
-  background-color: white;
+.jp-Merge-dragimage-output {
+  background-color: var(--jp-layout-color1);
   border: solid gray thin;
+  max-width: 33%;
 }
+
+.jp-Cell-merge.p-mod-drag-image {
+  background-color: var(--jp-layout-color1);
+}
+
+.jp-Cell-merge.p-mod-drag-image .jp-Merge-cellHeader {
+  display: none;
+}
+
 
 .jp-Merge-output-drop-delete {
   border: 3px dashed var(--jp-nbdime-output-color2);

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -203,7 +203,20 @@
   background-color: var(--jp-merge-remote-color2);
 }
 
+.jp-Notebook-merge .jp-Cellrow-outputs .jp-OutputArea {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-wrap: nowrap;
+  min-height: 2em;
+}
+
 .jp-Notebook-merge .jp-Merge-oneway-local .jp-Cellrow-outputs,
 .jp-Notebook-merge .jp-Merge-oneway-remote .jp-Cellrow-outputs {
   border-top: #39f solid 1pt;
 }
+
+.jp-Notebook-merge .jp-Output:first-child {
+  margin-top: 0;
+}
+

--- a/nbdime-web/src/styles/variables.css
+++ b/nbdime-web/src/styles/variables.css
@@ -1,8 +1,12 @@
 
 :root {
-  --codemirror-border: 1px solid #ddd;
+  --codemirror-border-color: #ddd;
+  --codemirror-border: 1px solid var(--codemirror-border-color);
   --codemirror-gutter-background: #f8f8f8;
 
+  --jp-nbdime-output-color1: #39f;
+  --jp-nbdime-output-color2: #7bf;
+  --jp-nbdime-output-color3: #adf;
 
   --jp-diff-added-color1: #a6f3a6;
   --jp-diff-added-color2: #dbffdb;

--- a/nbdime/webapp/src/app/diff.css
+++ b/nbdime/webapp/src/app/diff.css
@@ -10,11 +10,11 @@
 .nbdime-Diff-tool #nbdime-header-base {
   display: inline-block;
   width: 50%;
-  background-color: #f8cbcb
+  background-color: var(--jp-diff-deleted-color1);
 }
 
 .nbdime-Diff-tool #nbdime-header-remote {
   display: inline-block;
   width: 49%;
-  background-color: #a6f3a6;
+  background-color: var(--jp-diff-added-color1);
 }

--- a/nbdime/webapp/src/app/merge.css
+++ b/nbdime/webapp/src/app/merge.css
@@ -15,7 +15,7 @@
 }
 
 .nbdime-Merge-tool #nbdime-header-local {
-  background-color: #cbcbf8;
+  background-color: var(--jp-merge-local-color1);
 }
 
 .nbdime-Merge-tool #nbdime-header-base {
@@ -23,5 +23,5 @@
 }
 
 .nbdime-Merge-tool #nbdime-header-remote {
-  background-color: #beb;
+  background-color: var(--jp-merge-remote-color1);
 }

--- a/nbdime/webapp/templates/diff.html
+++ b/nbdime/webapp/templates/diff.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>

--- a/nbdime/webapp/templates/difftool.html
+++ b/nbdime/webapp/templates/difftool.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>

--- a/nbdime/webapp/templates/index.html
+++ b/nbdime/webapp/templates/index.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>

--- a/nbdime/webapp/templates/merge.html
+++ b/nbdime/webapp/templates/merge.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>

--- a/nbdime/webapp/templates/mergetool.html
+++ b/nbdime/webapp/templates/mergetool.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <meta charset="utf-8"/>
+    <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>


### PR DESCRIPTION
Fixes #120.

 - Added "clear outputs" checkbox on merged cells with outputs.
 - "Trash can" drop zone appears when dragging output from merged outputs.
 - Adjust styling/rendering of outputs in merge view

### TODO
 - [x] Add checkbox "Clear all outputs" on notebook level
 - [x] Add checkbox "Clear all conflicted outputs" on notebook level