### PR TITLE
normalize newlines in external_merge_render

### DIFF
--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -88,7 +88,8 @@ def external_merge_render(cmd, b, l, r):
         assert all(fn in cmd for fn in ['local', 'base', 'remote'])
         p = Popen(cmd, cwd=td, stdout=PIPE)
         output, _ = p.communicate()
-        output = output.decode('utf8')
+        # normalize newlines
+        output = output.decode('utf8').replace('\r\n', '\n')
     finally:
         shutil.rmtree(td)
     return output

--- a/nbdime/tests/test_autoresolve.py
+++ b/nbdime/tests/test_autoresolve.py
@@ -18,6 +18,7 @@ from nbdime.utils import Strategies
 from nbdime.nbmergeapp import _build_arg_parser
 
 from .fixtures import db
+from .conftest import have_git
 
 # FIXME: Extend tests to more merge situations!
 
@@ -414,6 +415,7 @@ def test_autoresolve_notebook_ignore_fallback():
     assert not any(d.conflict for d in decisions)
 
 
+@pytest.mark.skipif(not have_git, reason="Missing git.")
 def test_autoresolve_inline_source_conflict(db):
     nbb = db["inline-conflict--1"]
     nbl = db["inline-conflict--2"]


### PR DESCRIPTION
should avoid introducing `\r\n` into notebooks when inlining conflicts on Windows