### PR TITLE
remove `-l` option from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 testpaths=nbdime/tests
-addopts=-l
 norecursedirs=node_modules


### PR DESCRIPTION
it adds loads of noise if on by default.

it can still be used on request if needed.