### PR TITLE
Enhance CLI help message

### DIFF
--- a/nbdime/__main__.py
+++ b/nbdime/__main__.py
@@ -9,19 +9,26 @@ from __future__ import print_function
 import sys
 from subprocess import call
 
+from ._version import __version__
+
 try:
     from shutil import which
 except ImportError:
     from backports.shutil_which import which
 
 COMMANDS = ["show", "diff", "merge", "diff-web", "merge-web", "mergetool"]
-
+HELP_MESSAGE_VERBOSE = ("Usage: nbdime [OPTIONS]\n\n"
+                       "OPTIONS: -h, --version, COMMANDS{%s}\n\n"
+                       "Examples: nbdime --version\n"
+                       "          nbdime show -h\n"
+                       "          nbdime merge-web\n\n"
+                       "Documentation: https://nbdime.readthedocs.io" % ", ".join(COMMANDS))
 
 def main_dispatch(args=None):
     if args is None:
         args = sys.argv[1:]
     if len(args) < 1:
-        sys.exit("Command missing, expecting one of: \n%s" % ", ".join(COMMANDS))
+        sys.exit("Option missing.\n\n%s" % HELP_MESSAGE_VERBOSE)
 
     cmd = args[0]
     args = args[1:]
@@ -42,10 +49,13 @@ def main_dispatch(args=None):
         to_call = 'git mergetool --tool=nbdimeweb *.ipynb'.split()
         return call(to_call)
     else:
-        sys.exit(
-            "Unrecognized command '%s', expecting one of:\n%s." %
-            (cmd, ", ".join(COMMANDS)))
-
+        if cmd == '--version':
+            sys.exit(__version__)
+        if cmd == '-h' or cmd == '--help':
+            sys.exit(HELP_MESSAGE_VERBOSE)
+        else:
+            sys.exit("Unrecognized command '%s'\n\n%s." %
+                     (cmd, HELP_MESSAGE_VERBOSE))
     return main(args)
 
 


### PR DESCRIPTION
Closes #182 

Adds a user friendly, verbose CLI help message when user enters any of the following:
- `nbdime -h`
- `nbdime` with no additional options
- `nbdime kjlkjlj` incorrect command

For `nbdime --version`, version is returned.

<img width="663" alt="screen shot 2016-12-02 at 11 53 04 am" src="https://cloud.githubusercontent.com/assets/2680980/20848383/bc68c9da-b886-11e6-83f0-89a74501df2f.png">
