### PR TITLE
Fix picking vs hidden unchanged stretches

### DIFF
--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -17,7 +17,7 @@
 
 .jp-Notebook-merge .CodeMirror-merge-pane-local,
 .jp-Notebook-merge .CodeMirror-merge-pane-remote,
-.jp-Notebook-merge .CodeMirror-merge-pane-base {
+.jp-Notebook-merge .CodeMirror-merge-pane-base:not(.CodeMirror-merge-pane-unchanged) {
   width: 33%;
 }
 


### PR DESCRIPTION
Previously, using a mergeview picker (arrows on side of local/base/remote), would uncollapse merged view. This change ensures that unchanged areas stay collapsed.