### PR TITLE
Lock typescript version to 2.0.x

### DIFF
--- a/nbdime-web/package.json
+++ b/nbdime-web/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^2.5.4",
     "style-loader": "^0.13.1",
     "ts-loader": "^1.2.1",
-    "typescript": "^2.0.3",
+    "typescript": "~2.0.3",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1"
   },


### PR DESCRIPTION
Typescript 2.1 is out, and current code base does not build on it. Narrow the range of valid typescript versions for now, as some issues in TS 2.1 should be fixed before transitioning.