### PR TITLE
Fix typescript lock to 2.0.x

### DIFF
--- a/nbdime/webapp/package.json
+++ b/nbdime/webapp/package.json
@@ -21,7 +21,7 @@
     "source-map-loader": "^0.1.5",
     "style-loader": "^0.13.1",
     "ts-loader": "^1.2.1",
-    "typescript": "^2.0.3",
+    "typescript": "~2.0.3",
     "url-loader": "^0.5.7",
     "watch": "^1.0.1",
     "webpack": "^1.13.1"


### PR DESCRIPTION
Missing change to #200, should fix #201.