### PR TITLE
Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,11 @@
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 
+# scripts that are called at very beginning, before repo cloning
+init:
+  - ps: (new-object net.webclient).DownloadFile('https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe', 'C:\\git-setup.exe')
+  - cmd: START /WAIT C:\\git-setup.exe /VERYSILENT
+
 # environment variables
 environment:
   nodejs_version: "6.9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,15 @@ skip_branch_with_pr: true
 # environment variables
 environment:
   nodejs_version: "6.9"
-  PYTHON: "C:\\Python35-x64"
-  PYTHON_VERSION: "3.5.x"
-  PYTHON_MAJOR: 3
-  PYTHON_ARCH: "64"
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_MAJOR: 3
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_MAJOR: 2
+      PYTHON_ARCH: "32"
 
 # build cache to preserve files/folders between builds
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# environment variables
+environment:
+  nodejs_version: "6.9"
+  PYTHON: "C:\\Python35-x64"
+  PYTHON_VERSION: "3.5.x"
+  PYTHON_MAJOR: 3
+  PYTHON_ARCH: "64"
+
+# build cache to preserve files/folders between builds
+cache:
+  - nbdime/webapp/node_modules # NPM packages
+  - nbdime-web/node_modules # NPM packages
+
+# scripts that run after cloning repository
+install:
+  # Install node:
+  - ps: Install-Product node $env:nodejs_version
+  # Ensure python scripts are from right version:
+  - 'SET "PATH=%PYTHON%\\Scripts;%PATH%"'
+  # Install our package:
+  - 'pip install --upgrade -e ".[test]"'
+
+build: off
+
+# scripts to run before tests
+before_test:
+  - git config --global user.email appveyor@fake.com
+  - git config --global user.name "AppVeyor CI"
+
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - 'py.test -l'
+
+on_success:
+  # Do not cache our own packages
+  - rd /s /q .\\nbdime\\webapp\\node_modules\\nbdime


### PR DESCRIPTION
Adds a configuration for running CI on appveyor.

Includes #203 as it would otherwise be prevented from running tests.

TODO:
 - [x] Enable project on appveyor (which account should it run on? This affects who can clear/rebuild etc.)
 - [x] What tests should be included? Currently, it `pip install`s (builds js deps), and runs python tests on python 3.5 (x64) with node 6.9. I'm in favor of keeping it simple, as appveyor does not support parallell jobs on free accounts.
 - [x] Fix any test errors revealed (tests on my appveyor account reveal one error with git merge driver).