### PR TITLE
Fix JS testing instructions

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -30,6 +30,7 @@ options.
 
 To run javascript/typescript tests, enter::
 
+    cd nbdime-web/
     npm test
 
 from the ``nbdime-web`` folder.


### PR DESCRIPTION
You have to run JS tests from `nbdime-web` directory, not the root directory.