### PR TITLE
Adjust web diff styles

### DIFF
--- a/nbdime-web/src/diff/widget/cell.ts
+++ b/nbdime-web/src/diff/widget/cell.ts
@@ -53,6 +53,7 @@ const PROMPT_CLASS = 'jp-Cell-prompt';
 
 const CELLDIFF_CLASS = 'jp-Cell-diff';
 
+const EXECUTIONCOUNT_ROW_CLASS = 'jp-Cellrow-executionCount';
 const SOURCE_ROW_CLASS = 'jp-Cellrow-source';
 const METADATA_ROW_CLASS = 'jp-Cellrow-metadata';
 const OUTPUTS_ROW_CLASS = 'jp-Cellrow-outputs';
@@ -168,6 +169,7 @@ class CellDiffWidget extends Panel {
       container.addWidget(w);
       FlexPanel.setGrow(w, 1);
     }
+    container.addClass(EXECUTIONCOUNT_ROW_CLASS);
     return container;
   }
 

--- a/nbdime-web/src/styles/diff.css
+++ b/nbdime-web/src/styles/diff.css
@@ -14,6 +14,22 @@
   width: 100%;
 }
 
+/* Match input border of unchanged cell source */
+.jp-Notebook-diff .jp-Diff-unchanged .CodeMirror-merge-pane-unchanged {
+  border: var(--jp-border-width) solid var(--jp-private-notebook-cell-editor-border);
+}
+
+/* Do not use border between unchanged cells */
+.jp-Notebook-diff .jp-Diff-unchanged + .jp-Diff-unchanged {
+    border: none;
+}
+
+/* We can float prompt left when unchanged */
+.jp-Notebook-diff .jp-Diff-unchanged .jp-Cellrow-executionCount {
+  float: left;
+}
+
+
 .jp-Notebook-diff .jp-Metadata-diff {
   margin-bottom: 20px;
   border: solid black thin;

--- a/nbdime/webapp/src/app/common.css
+++ b/nbdime/webapp/src/app/common.css
@@ -3,6 +3,8 @@
 body {
   --jp-layout-color3: white;
   overflow: scroll !important;
+
+  font-family: sans-serif;
 }
 
 


### PR DESCRIPTION
 - Switch to using sans-serif font to match jupyterlab/notebook
 - Float input prompt to the left for unchanged cells
 - Remove border between consecutive unchanged cells
 - Add border around source block of unchanged cells, similar to that of jupyterlab

Fixes #212.