### PR TITLE
Fix nbdime mergetool

### DIFF
--- a/nbdime/__main__.py
+++ b/nbdime/__main__.py
@@ -29,7 +29,7 @@ HELP_MESSAGE_VERBOSE = ("Usage: nbdime [OPTIONS]\n\n"
 def main_mergetool(args):
     if not which('git'):
         sys.exit("Cannot use \"nbdime mergetool\" alias as git is not preset on path")
-    to_call = 'git mergetool --tool=nbdimeweb'.split()
+    to_call = 'git mergetool --tool=nbdime'.split()
 
     if args:
         paths = [a for a in args if a.endswith(".ipynb")]
@@ -39,7 +39,7 @@ def main_mergetool(args):
         paths = ["*.ipynb"]
     to_call.extend(paths)
 
-    nbdime.log.info("Calling 'git mergetool --tool=nbdimeweb' on files {}".format(paths))
+    nbdime.log.info("Calling 'git mergetool --tool=nbdime' on files {}".format(paths))
 
     return call(to_call)
 

--- a/nbdime/gitdifftool.py
+++ b/nbdime/gitdifftool.py
@@ -17,7 +17,7 @@ import sys
 from subprocess import check_call, check_output, CalledProcessError
 
 import nbdime.log
-from .args import add_filename_args, add_generic_args
+from .args import add_generic_args
 from .webapp import nbdifftool
 
 
@@ -45,7 +45,7 @@ def disable(global_=False, *args):
     except CalledProcessError:
         pass
     else:
-        if tool in ('nbdime', 'nbdimeweb'):
+        if tool == 'nbdime':
             try:
                 check_call(cmd + ['--unset', 'diff.guitool'])
             except CalledProcessError:

--- a/nbdime/gitmergetool.py
+++ b/nbdime/gitmergetool.py
@@ -12,11 +12,11 @@ Use with:
     git mergetool [<commit> [<commit>]]
 """
 import sys
-from subprocess import check_call, check_output, CalledProcessError
+from subprocess import check_call, CalledProcessError
 
 import nbdime.log
 from .webapp import nbmergetool
-from .args import add_filename_args, add_generic_args
+from .args import add_generic_args
 
 
 def enable(global_=False, set_default=False):


### PR DESCRIPTION
Fixes the `nbdime mergetool` command, which previously pointed to the wrong tool name.

Also removes some unused imports.