### PR TITLE
Download merge button

### DIFF
--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -53,10 +53,14 @@ class NbdimeApiHandler(web.RequestHandler):
 
     def base_args(self):
         fn = self.params.get("outputfilename", None)
-        return {
+        base = {
             "closable": self.params["closable"],
             "savable": fn is not None
         }
+        if fn:
+            # For reference, e.g. if user wants to download file
+            base["outputfilename"] = fn
+        return base
 
     def get_notebook_argument(self, argname):
         # Assuming a request on the form "{'argname':arg}"

--- a/nbdime/webapp/src/app/common.css
+++ b/nbdime/webapp/src/app/common.css
@@ -28,7 +28,7 @@ body {
   margin-top: 10px;
 }
 
-.nbdime-header-button{
+.nbdime-header-button {
   display: inline-block;
   margin-right: 10px;
 }

--- a/nbdime/webapp/src/app/common.css
+++ b/nbdime/webapp/src/app/common.css
@@ -32,3 +32,7 @@ body {
   display: inline-block;
   margin-right: 10px;
 }
+
+.nbdime-Diff .nbdime-header-buttonrow {
+  display: none;
+}

--- a/nbdime/webapp/src/app/compare.ts
+++ b/nbdime/webapp/src/app/compare.ts
@@ -18,6 +18,9 @@ import {
 
 const ERROR_COMPARE_NUMBER = 'Need two or more values to compare!';
 
+const DIFF_LOCAL_BASE_CLASS = 'jp-mod-local-base';
+const DIFF_LOCAL_REMOTE_CLASS = 'jp-mod-local-remote';
+
 let hasMerge = false;
 
 /**
@@ -52,8 +55,10 @@ function compare(b: string, c: string, r: string, pushHistory: boolean | 'replac
       count += 1;
     }
   }
+  let header = document.getElementById('nbdime-header')!;
   if (b && c && r) {
     // All values present, do merge
+    header.className = 'nbdime-Merge';
     getMerge(b, c, r);
     if (pushHistory) {
       let uri = window.location.pathname;
@@ -68,18 +73,21 @@ function compare(b: string, c: string, r: string, pushHistory: boolean | 'replac
     throw new Error(ERROR_COMPARE_NUMBER);
   } else {
     // Two values, figure out which
+    header.className = 'nbdime-Diff';
     let base: string;
     let remote: string;
     if (b) {
       base = b;
       if (c) {
         remote = c;
+        header.classList.add(DIFF_LOCAL_BASE_CLASS);
       } else {
         remote = r;
       }
     } else {
       base = c;
       remote = r;
+      header.classList.add(DIFF_LOCAL_REMOTE_CLASS);
     }
     getDiff(base, remote);
     if (pushHistory) {

--- a/nbdime/webapp/src/app/compare.ts
+++ b/nbdime/webapp/src/app/compare.ts
@@ -8,7 +8,7 @@ import {
 } from './diff';
 
 import {
-  getMerge, closeMerge, saveMerged
+  getMerge, closeMerge, saveMerged, downloadMerged
 } from './merge';
 
 import {
@@ -160,5 +160,13 @@ function initializeCompare() {
   let saveBtn = document.getElementById('nbdime-save') as HTMLButtonElement;
   if (saveBtn) {
     saveBtn.onclick = saveMerged;
+  }
+  let downloadBtn = document.getElementById('nbdime-download') as HTMLButtonElement;
+  if (hasMerge) {
+    downloadBtn.onclick = downloadMerged;
+    downloadBtn.style.display = 'initial';
+  } else {
+    downloadBtn.onclick = null!;
+    downloadBtn.style.display = 'none';
   }
 }

--- a/nbdime/webapp/src/app/diff.css
+++ b/nbdime/webapp/src/app/diff.css
@@ -7,14 +7,44 @@
   z-index: 0;
 }
 
-.nbdime-Diff-tool #nbdime-header-base {
+/* Comparing base vs remote, default */
+.nbdime-Diff #nbdime-header-base {
   display: inline-block;
   width: 50%;
   background-color: var(--jp-diff-deleted-color1);
 }
 
-.nbdime-Diff-tool #nbdime-header-remote {
+.nbdime-Diff #nbdime-header-remote {
   display: inline-block;
   width: 49%;
   background-color: var(--jp-diff-added-color1);
+}
+
+.nbdime-Diff #nbdime-header-local {
+  display: none;
+  width: 49%;
+}
+
+/* Comparing local vs remote */
+.nbdime-Diff.jp-mod-local-remote #nbdime-header-base {
+  display: none;
+}
+
+.nbdime-Diff.jp-mod-local-remote #nbdime-header-local {
+  display: inline-block;
+  background-color: var(--jp-diff-deleted-color1);
+}
+
+/* Comparing local vs base */
+.nbdime-Diff.jp-mod-local-base #nbdime-header-base {
+  background-color: var(--jp-diff-added-color1);
+}
+
+.nbdime-Diff.jp-mod-local-base #nbdime-header-local {
+  display: inline-block;
+  background-color: var(--jp-diff-deleted-color1);
+}
+
+.nbdime-Diff.jp-mod-local-base #nbdime-header-remote {
+  display: none;
 }

--- a/nbdime/webapp/src/app/merge.css
+++ b/nbdime/webapp/src/app/merge.css
@@ -7,21 +7,21 @@
   z-index: 0;
 }
 
-.nbdime-Merge-tool #nbdime-header-base,
-.nbdime-Merge-tool #nbdime-header-remote,
-.nbdime-Merge-tool #nbdime-header-local {
+.nbdime-Merge #nbdime-header-base,
+.nbdime-Merge #nbdime-header-remote,
+.nbdime-Merge #nbdime-header-local {
   display: inline-block;
   width: 33%;
 }
 
-.nbdime-Merge-tool #nbdime-header-local {
+.nbdime-Merge #nbdime-header-local {
   background-color: var(--jp-merge-local-color1);
 }
 
-.nbdime-Merge-tool #nbdime-header-base {
+.nbdime-Merge #nbdime-header-base {
   background-color: #eee;
 }
 
-.nbdime-Merge-tool #nbdime-header-remote {
+.nbdime-Merge #nbdime-header-remote {
   background-color: var(--jp-merge-remote-color1);
 }

--- a/nbdime/webapp/templates/diff.html
+++ b/nbdime/webapp/templates/diff.html
@@ -15,22 +15,26 @@
   <!-- TODO: make nbdime.init() setup the forms/input user interface? -->
 
   <body> <!-- onload="nbdime.init()" -->
-    <div id="nbdime-header">
+    <div id="nbdime-header" class="nbdime-Diff">
       <h3>Notebook Diff</h3>
       Enter notebook filenames or URLs in the form below to get started.
 
       <form id="nbdime-diff-form" class="nbdime-forms">
         <fieldset>
           <legend>Please input filenames/URLs of notebooks to diff:</legend>
-          Base:
+          <label>Base:</label>
           <input id="diff-base" type="text" name="base" value="{{ escape(config_data['base']) }}" />
-          Remote:
+          <label>Remote:</label>
           <input id="diff-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-diff" type="submit" name="diff" value="Diff files" />
         </fieldset>
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+      </div>
+      <div id=nbdime-header-banner>
+        <span id="nbdime-header-base">Base</span>
+        <span id="nbdime-header-remote">Remote</span>
       </div>
     </div> <!-- ndime-header -->
 

--- a/nbdime/webapp/templates/difftool.html
+++ b/nbdime/webapp/templates/difftool.html
@@ -13,7 +13,7 @@
   </head>
 
   <body> <!-- onload="nbdime.init()" -->
-    <div id="nbdime-header" class="nbdime-Diff-tool">
+    <div id="nbdime-header" class="nbdime-Diff">
       <h3>Notebook Diff</h3>
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>

--- a/nbdime/webapp/templates/index.html
+++ b/nbdime/webapp/templates/index.html
@@ -29,6 +29,7 @@
           <label>Remote:</label>
           <input id="compare-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-compare" type="submit" name="auto" value="Compare files" />
+          <button id="nbdime-download" class="nbdime-header-button" style="display: none" type="button">Download</button>
         </fieldset>
       </form> <!-- nbdime-forms -->
       <div id=nbdime-header-banner>

--- a/nbdime/webapp/templates/index.html
+++ b/nbdime/webapp/templates/index.html
@@ -22,15 +22,20 @@
       <form id="nbdime-compare-form" class="nbdime-forms">
         <fieldset>
           <legend>Please input filenames of notebooks to compare:</legend>
-          Local:
+          <label>Local:</label>
           <input id="compare-local" type="text" name="local" value="{{ escape(config_data['local']) }}" />
-          Base:
+          <label>Base:</label>
           <input id="compare-base" type="text" name="base" value="{{ escape(config_data['base']) }}" />
-          Remote:
+          <label>Remote:</label>
           <input id="compare-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-compare" type="submit" name="auto" value="Compare files" />
         </fieldset>
       </form> <!-- nbdime-forms -->
+      <div id=nbdime-header-banner>
+        <span id="nbdime-header-local">Local</span>
+        <span id="nbdime-header-base">Base</span>
+        <span id="nbdime-header-remote">Remote</span>
+      </div>
     </div> <!-- ndime-header -->
       <div id="nbdime-root">
     </div>

--- a/nbdime/webapp/templates/merge.html
+++ b/nbdime/webapp/templates/merge.html
@@ -15,18 +15,18 @@
   <!-- TODO: make nbdime.init() setup the forms/input user interface? -->
 
   <body> <!-- onload="nbdime.init()" -->
-    <div id="nbdime-header">
+    <div id="nbdime-header" class="nbdime-Merge">
       <h3>Notebook Merge</h3>
       Enter notebook filenames or URLs in the form below to get started.
 
       <form id="nbdime-merge-form" class="nbdime-forms">
         <fieldset>
           <legend>Please input filenames/URLs of notebooks to merge:</legend>
-          Local:
+          <label>Local:</label>
           <input id="merge-local" type="text" name="local" value="{{ escape(config_data['local']) }}" />
-          Base:
+          <label>Base:</label>
           <input id="merge-base" type="text" name="base" value="{{ escape(config_data['base']) }}" />
-          Remote:
+          <label>Remote:</label>
           <input id="merge-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-merge" type="submit" name="merge" value="Merge files" />
         </fieldset>
@@ -34,6 +34,11 @@
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+      </div>
+      <div id=nbdime-header-banner>
+        <span id="nbdime-header-local">Local</span>
+        <span id="nbdime-header-base">Base</span>
+        <span id="nbdime-header-remote">Remote</span>
       </div>
     </div> <!-- ndime-header -->
 

--- a/nbdime/webapp/templates/merge.html
+++ b/nbdime/webapp/templates/merge.html
@@ -29,6 +29,7 @@
           <label>Remote:</label>
           <input id="merge-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-merge" type="submit" name="merge" value="Merge files" />
+          <button id="nbdime-download" class="nbdime-header-button" style="display: none" type="button">Download</button>
         </fieldset>
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">

--- a/nbdime/webapp/templates/mergetool.html
+++ b/nbdime/webapp/templates/mergetool.html
@@ -13,7 +13,7 @@
   </head>
 
   <body> <!-- onload="nbdime.init()" -->
-    <div id="nbdime-header" class="nbdime-Merge-tool">
+    <div id="nbdime-header" class="nbdime-Merge">
       <h3>Notebook Merge</h3>
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>

--- a/nbdime/webapp/templates/mergetool.html
+++ b/nbdime/webapp/templates/mergetool.html
@@ -17,6 +17,7 @@
       <h3>Notebook Merge</h3>
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
+        <button id="nbdime-download" class="nbdime-header-button" style="display: none">Download</button>
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
       </div>
       <div id=nbdime-header-banner>


### PR DESCRIPTION
Adds a button to the web merge interfaces, which allows the user to download (strictly: save from local javascript state) the merge result.

A possible improvement on the current behavior is to also treat directories correctly, although that will require the server to expose the current directory. I am not sure about the security implications of that.

Resolves #121.