### PR TITLE
Fix default location of global gitattributes file

### DIFF
--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -145,7 +145,7 @@ def locate_gitattributes(global_=False):
             if os.environ.get('XDG_CONFIG_HOME'):
                 gitattributes = os.path.expandvars('$XDG_CONFIG_HOME/git/attributes')
             else:
-                gitattributes = os.path.expandvars('$HOME/.config/git/attributes')
+                gitattributes = os.path.expanduser('~/.config/git/attributes')
     else:
         # find .gitattributes in current dir
         path = os.path.abspath('.')

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -142,7 +142,10 @@ def locate_gitattributes(global_=False):
             bpath = check_output(['git', 'config', '--global', 'core.attributesfile'])
             gitattributes = os.path.expanduser(bpath.decode('utf8', 'replace').strip())
         except CalledProcessError:
-            gitattributes = os.path.expanduser('~/.gitattributes')
+            if os.environ.get('XDG_CONFIG_HOME'):
+                gitattributes = os.path.expandvars('$XDG_CONFIG_HOME/git/attributes')
+            else:
+                gitattributes = os.path.expandvars('$HOME/.config/git/attributes')
     else:
         # find .gitattributes in current dir
         path = os.path.abspath('.')


### PR DESCRIPTION
Git's default location for the attributes file is not `~/.gitattributes`. Update nbdime's default to reflect the one described [here](https://git-scm.com/docs/gitattributes). Addresses #219.