### PR TITLE
Render error tracebacks

### DIFF
--- a/nbdime-web/src/diff/model/output.ts
+++ b/nbdime-web/src/diff/model/output.ts
@@ -46,6 +46,8 @@ class OutputDiffModel extends RenderableDiffModel<nbformat.IOutput> {
     if (outputs.output_type === 'stream' &&
           mimetype === 'application/vnd.jupyter.console-text') {
       return 'text';
+    } else if (outputs.output_type === 'error') {
+      return 'traceback';
     } else if (outputs.output_type === 'execute_result' || outputs.output_type === 'display_data') {
       let data = outputs.data;
       if (mimetype in data) {
@@ -65,7 +67,7 @@ class OutputDiffModel extends RenderableDiffModel<nbformat.IOutput> {
    */
   protected innerMimeType(key: string) : string {
     let t = (this.base || this.remote!).output_type;
-    if (t === 'stream' && key === 'text') {
+    if (t === 'stream' && key === 'text' || t === 'error' && key === 'traceback') {
       // TODO: 'application/vnd.jupyter.console-text'?
       return 'text/plain';
     } else if ((t === 'execute_result' || t === 'display_data') &&

--- a/nbdime-web/src/diff/widget/output.ts
+++ b/nbdime-web/src/diff/widget/output.ts
@@ -63,8 +63,8 @@ class RenderableOutputView extends RenderableDiffView<nbformat.IOutput> {
           return false;
         }
       } else if (valueIn(o.output_type, ['stream', 'error'])) {
-        // Unknown output type
-        return false;
+        // We "render" the text output, in terms of converting ANSI codes
+        return true;
       }
     }
     return true;


### PR DESCRIPTION
Adds missing wiring for rendering error outputs. Previously error outputs were simply shown as raw JSON.