### PR TITLE
Add `--system` flag for git config commands

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -33,6 +33,35 @@ def add_generic_args(parser):
     )
 
 
+def add_git_config_subcommand(subparsers, enable, disable, subparser_help, enable_help, disable_help):
+    # Add subparser
+    config = subparsers.add_parser('config',
+        description=subparser_help)
+
+    # Option for git scope (global/system):
+    scope = config.add_mutually_exclusive_group()
+    scope.add_argument('--global', action='store_const', dest='scope',
+        const='global',
+        help="configure your global git config instead of the current repo"
+    )
+    scope.add_argument('--system', action='store_const', dest='scope',
+        const='system',
+        help="configure your system git config instead of the current repo"
+    )
+
+    # Add enable/disable flags
+    enable_disable = config.add_mutually_exclusive_group(required=True)
+    enable_disable.add_argument('--enable', action='store_const',
+        dest='config_func', const=enable,
+        help=enable_help
+    )
+    enable_disable.add_argument('--disable', action='store_const',
+        dest='config_func', const=disable,
+        help=disable_help
+    )
+    return config
+
+
 def add_web_args(parser, default_port=8888):
     """Adds a set of arguments common to all commands that show a web gui.
     """

--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -37,7 +37,8 @@ def enable(scope=None):
     check_call(cmd + ['diff.jupyternotebook.command', 'git-nbdiffdriver diff'])
     gitattributes = locate_gitattributes(scope)
     if gitattributes is None:
-        print("No .git directory in %s, skipping git attributes" % gitattributes, file=sys.stderr)
+        assert scope is None, "No gitattributes found for scope: %s" % scope
+        print("No .git directory in %s, skipping git attributes" % os.curdir, file=sys.stderr)
         return
 
     if os.path.exists(gitattributes):

--- a/nbdime/gitmergedriver.py
+++ b/nbdime/gitmergedriver.py
@@ -42,7 +42,8 @@ def enable(scope=None):
 
     gitattributes = locate_gitattributes(scope)
     if gitattributes is None:
-        print("No .git directory in %s, skipping git attributes" % gitattributes, file=sys.stderr)
+        assert scope is None, "No gitattributes found for scope: %s" % scope
+        print("No .git directory in %s, skipping git attributes" % os.curdir, file=sys.stderr)
         return
 
     if os.path.exists(gitattributes):

--- a/nbdime/tests/test_utils.py
+++ b/nbdime/tests/test_utils.py
@@ -3,7 +3,17 @@ import os
 import shutil
 import tempfile
 
-from nbdime.utils import strings_to_lists, revert_strings_to_lists, is_in_repo
+try:
+    from shutil import which
+except ImportError:
+    from backports.shutil_which import which
+
+import pytest
+
+from nbdime.utils import (
+    strings_to_lists, revert_strings_to_lists, is_in_repo,
+    locate_gitattributes
+)
 
 def test_string_to_lists():
     obj = {"c": [{"s": "ting\ntang", "o": [{"ot": "stream"}]}]}
@@ -35,3 +45,21 @@ def test_is_repo():
 
     finally:
         shutil.rmtree(tmpdir)
+
+
+def test_locate_gitattributes_local(git_repo):
+    gitattr = locate_gitattributes(scope=None)
+    assert gitattr is not None
+
+
+@pytest.mark.skipif(not which('git'), reason="Missing git.")
+def test_locate_gitattributes_global():
+    gitattr = locate_gitattributes(scope='global')
+    assert gitattr is not None
+
+
+@pytest.mark.skipif(not which('git'), reason="Missing git.")
+def test_locate_gitattributes_system():
+    gitattr = locate_gitattributes(scope='system')
+    assert gitattr is not None
+

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -171,7 +171,7 @@ def locate_gitattributes(scope=None):
             # Default to most likely case of empty $(prefix)
             # Sanity check:
             if not os.path.exists('/etc'):
-                raise EnvironmentError('Could not find system gitattribute location!')
+                raise EnvironmentError('Could not find system gitattributes location!')
             gitattributes = os.path.join(['etc', 'gitattributes'])
     else:
         # find .gitattributes in current dir

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -3,8 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import unicode_literals
-
 import errno
 import os
 import re

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -142,8 +142,8 @@ def ensure_dir_exists(path):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-				
-				
+
+
 @contextlib.contextmanager
 def set_env(**environ):
     """
@@ -189,7 +189,8 @@ def locate_gitattributes(scope=None):
         try:
             with set_env(GIT_EDITOR='echo'):
                 bpath = check_output(['git', 'config', '--system', '-e'])
-                gitattributes = bpath.decode('utf8', 'replace').strip()
+                gitconfig = bpath.decode('utf8', 'replace').strip()
+                gitattributes = os.path.join(os.path.dirname(gitconfig), 'gitattributes')
         except CalledProcessError:
             # Default to most likely case of empty $(prefix)
             # Sanity check:


### PR DESCRIPTION
Resolves #225.

Adds `--system` flag to `config` subcommand of gitdiffdriver, gitdifftool, gitmergedriver and gitmergetool. 

It extracts the shared parts of the `config` subcommand to `args.py` for ease of maintenance, although this leads to somewhat large function calls.