### PR TITLE
[WIP] Optimize approx text comparison

### DIFF
--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -33,7 +33,7 @@ def default_differs():
     return defaultdict(lambda: diff)
 
 
-def compare_strings_approximate(x, y, threshold=0.7, autojunk=False):
+def compare_strings_approximate(x, y, threshold=0.7, quick=False):
     "Compare to strings with approximate heuristics."
     # TODO: Add configuration framework
     # TODO: Tune threshold with realistic sources
@@ -63,14 +63,19 @@ def compare_strings_approximate(x, y, threshold=0.7, autojunk=False):
 
     # So the heavy ratio function is only used for close calls.
     # s = difflib.SequenceMatcher(lambda c: c in (" ", "\t"), x, y, autojunk=False)
-    s = difflib.SequenceMatcher(None, x, y, autojunk=autojunk)
+    s = difflib.SequenceMatcher(None, x, y, autojunk=False)
 
     # Use only the fast ratio approximations first
     if s.real_quick_ratio() < threshold:
         return False
     if s.quick_ratio() < threshold:
         return False
-    return s.ratio() > threshold
+
+    # Skip slower and stricter check unless if quick is set
+    if quick:
+        return True
+    else:
+        return s.ratio() > threshold
 
 
 def diff(a, b, path="", predicates=None, differs=None):

--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -33,7 +33,7 @@ def default_differs():
     return defaultdict(lambda: diff)
 
 
-def compare_strings_approximate(x, y, threshold=0.7, quick=False):
+def compare_strings_approximate(x, y, threshold=0.7):
     "Compare to strings with approximate heuristics."
     # TODO: Add configuration framework
     # TODO: Tune threshold with realistic sources
@@ -70,12 +70,7 @@ def compare_strings_approximate(x, y, threshold=0.7, quick=False):
         return False
     if s.quick_ratio() < threshold:
         return False
-
-    # Skip slower and stricter check unless if quick is set
-    if quick:
-        return True
-    else:
-        return s.ratio() > threshold
+    return s.ratio() > threshold
 
 
 def diff(a, b, path="", predicates=None, differs=None):

--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -33,7 +33,7 @@ def default_differs():
     return defaultdict(lambda: diff)
 
 
-def compare_strings_approximate(x, y, threshold=0.7):
+def compare_strings_approximate(x, y, threshold=0.7, autojunk=False):
     "Compare to strings with approximate heuristics."
     # TODO: Add configuration framework
     # TODO: Tune threshold with realistic sources
@@ -63,7 +63,7 @@ def compare_strings_approximate(x, y, threshold=0.7):
 
     # So the heavy ratio function is only used for close calls.
     # s = difflib.SequenceMatcher(lambda c: c in (" ", "\t"), x, y, autojunk=False)
-    s = difflib.SequenceMatcher(None, x, y, autojunk=False)
+    s = difflib.SequenceMatcher(None, x, y, autojunk=autojunk)
 
     # Use only the fast ratio approximations first
     if s.real_quick_ratio() < threshold:

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -53,17 +53,11 @@ _split_mimes = (
 #       an argument instead of separate functions.
 
 
-def compare_text(x, y, strict):
-    if strict:
-        return compare_strings_approximate(x, y, threshold=0.95)
-    else:
-        return compare_strings_approximate(x, y, threshold=0.7, quick=False)
-
 def compare_text_approximate(x, y):
-    return compare_text(x, y, strict=False)
+    return compare_strings_approximate(x, y, threshold=0.7, quick=True)
 
 def compare_text_strict(x, y):
-    return compare_text(x, y, strict=True)
+    return compare_strings_approximate(x, y, threshold=0.95)
 
 
 def compare_base64_strict(x, y):

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -54,7 +54,8 @@ _split_mimes = (
 
 
 def compare_text_approximate(x, y):
-    return compare_strings_approximate(x, y, threshold=0.7, quick=True)
+    return compare_strings_approximate(x, y, threshold=0.7)
+
 
 def compare_text_strict(x, y):
     return compare_strings_approximate(x, y, threshold=0.95)

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -69,7 +69,7 @@ def compare_text_approximate(x, y):
     if nx < shortlen and ny < shortlen:
         return True
 
-    return compare_strings_approximate(x, y, threshold=0.7)
+    return compare_strings_approximate(x, y, threshold=0.7, autojunk=True)
 
 
 def compare_text_strict(x, y):


### PR DESCRIPTION
Previously, base64 strings embedded in e.g. HTML outputs could blow up the diff time (>1 min, compared to < 10 sec after this PR). To side-step this issue, the `autojunk` feature of `difflib.SequenceMatcher` is enabled.

@martinal Is there a good rational for the autojunk feature being turned off previously? Or was this just a cautionary choice? I'm not entirely sure of the side effects of this, but I'm only enabling it for approximate comparison (not diffing), and it didn't break any test :)

I've also added some of the profiling helpers I used to diagnose this, with a helper text.