### PR TITLE
Packaging / bugfix: Fix Typo in setup.py ``package_data`` entries.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,7 @@ package_data = {
     'nbdime': [
         'tests/files/*.*',
         '*.schema.json',
-        'webapp/static/**/*.*',
+        'webapp/static/*.*',
         'webapp/templates/*.*',
         'webapp/testnotebooks/*.*',
     ]


### PR DESCRIPTION
Closes #247. (Hopefully! Works for me.)

It's unclear if this was a typo or misunderstanding, but AFAICT
python's glob implementation does not properly support double-star
(``**``) globbing.

At any rate, you can test this easily:

    ipython -c "import glob; glob.glob('nbdime/webapp/static/**/*.*')"
    Out[1]: []

    ipython -c "import glob; glob.glob('nbdime/webapp/static/*.*')"
    Out[1]:
    ['nbdime/webapp/static/nbdime.js',
     'nbdime/webapp/static/1.nbdime.js.map',
     'nbdime/webapp/static/1.nbdime.js',
     'nbdime/webapp/static/nbdime.js.map',
     'nbdime/webapp/static/fa396483b7ade73b4727bad6aa027a35.html']

Edited to add: Note that the static files **were** getting included in the sdist, thanks to the ``graft nbdime/webapp`` in MANIFEST.in. But that only guarantees inclusion in the tarball - they have to be properly listed under package_data to get installed under site-packages. File under 'fun times with historical quirks of python packaging'.