### PR TITLE
Remove appveyor install of explicit git version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
     - nbdime/webapp/node_modules # NPM packages
     - nbdime-web/node_modules # NPM packages
 before_install:
+  - pip install -U pip setuptools
   - nvm install 6
   - |
     if [[ $GROUP == python ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,6 @@
 # Do not build feature branch with open Pull Requests
 skip_branch_with_pr: true
 
-# scripts that are called at very beginning, before repo cloning
-init:
-  - ps: (new-object net.webclient).DownloadFile('https://github.com/git-for-windows/git/releases/download/v2.11.0.windows.1/Git-2.11.0-64-bit.exe', 'C:\\git-setup.exe')
-  - cmd: START /WAIT C:\\git-setup.exe /VERYSILENT
-
 # environment variables
 environment:
   nodejs_version: "6.9"


### PR DESCRIPTION
Git should be updated in appveyor/ci#1214, so no longer need to manually perform installation step.