### PR TITLE
Add `--ip` option to web entries

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -79,6 +79,10 @@ def add_web_args(parser, default_port=8888):
         default=None,
         type=str,
         help="specify the browser to use, to override the system default.")
+    parser.add_argument(
+        '--ip',
+        default='127.0.0.1',
+        help="specify the interface to listen to for the web server")
     cwd = os.path.abspath(os.path.curdir)
     parser.add_argument(
         '-w', '--workdirectory',

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -82,7 +82,9 @@ def add_web_args(parser, default_port=8888):
     parser.add_argument(
         '--ip',
         default='127.0.0.1',
-        help="specify the interface to listen to for the web server")
+        help="specify the interface to listen to for the web server. "
+        "NOTE: Setting this to anything other than 127.0.0.1/localhost "
+        "might comprimise the security of your computer. Use with care!")
     cwd = os.path.abspath(os.path.curdir)
     parser.add_argument(
         '-w', '--workdirectory',

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -6,17 +6,12 @@ from __future__ import unicode_literals
 
 import sys
 from argparse import ArgumentParser
-import webbrowser
-import logging
-import threading
 
 from ..args import add_generic_args, add_diff_args
 from ..args import add_web_args, add_filename_args
 from .nbdimeserver import main_server as run_server
+from .webutil import browse
 import nbdime.log
-
-
-_logger = logging.getLogger(__name__)
 
 
 # TODO: Tool server is passed a (mandatory?) single-use access token, which is
@@ -40,21 +35,6 @@ def build_arg_parser(parser=None):
     return parser
 
 
-def browse(port, browsername):
-    try:
-        browser = webbrowser.get(browsername)
-    except webbrowser.Error as e:
-        _logger.warning('No web browser found: %s.', e)
-        browser = None
-
-    url = "http://127.0.0.1:%s/difftool" % port
-    nbdime.log.info("URL: " + url)
-    if browser:
-        def launch_browser():
-            browser.open(url, new=2)
-        threading.Thread(target=launch_browser).start()
-
-
 def main_parsed(opts):
     """Main function called after parsing CLI options
 
@@ -62,15 +42,16 @@ def main_parsed(opts):
     """
     nbdime.log.init_logging(level=opts.log_level)
     port = opts.port
+    ip = opts.ip
     cwd = opts.workdirectory
     base = opts.local
     remote = opts.remote
     browsername = opts.browser
     return run_server(
-        port=port, cwd=cwd,
+        port=port, cwd=cwd, ip=ip,
         closable=True,
         difftool_args=dict(base=base, remote=remote),
-        on_port=lambda port: browse(port, browsername))
+        on_port=lambda port: browse(ip, port, browsername, 'difftool'))
 
 def main(args=None):
     if args is None:

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -51,7 +51,11 @@ def main_parsed(opts):
         port=port, cwd=cwd, ip=ip,
         closable=True,
         difftool_args=dict(base=base, remote=remote),
-        on_port=lambda port: browse(ip, port, browsername, 'difftool'))
+        on_port=lambda port: browse(
+            port=port,
+            browsername=browsername,
+            rel_url='difftool',
+            ip=ip))
 
 def main(args=None):
     if args is None:

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -6,9 +6,10 @@ from __future__ import unicode_literals
 
 import sys
 from argparse import ArgumentParser
+import warnings
 
 from .nbdimeserver import main_server as run_server
-from .webutil import browse
+from .webutil import browse as browse_util
 from ..args import add_generic_args, add_web_args, add_diff_args, add_filename_args
 import nbdime.log
 
@@ -30,6 +31,18 @@ def build_arg_parser():
     return parser
 
 
+def browse(port, base, remote, browser):
+    browse_util(port=port,
+                browsername=browser,
+                rel_url='diff',
+                base=base,
+                remote=remote)
+    warnings.warn(
+        'This function is deprecated. '
+        'Use nbdime.webapp.webutil.browse() instead.',
+        DeprecationWarning)
+
+
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
@@ -44,7 +57,7 @@ def main(args=None):
     return run_server(
         port=port, cwd=cwd, ip=ip,
         closable=True,
-        on_port=lambda port: browse(
+        on_port=lambda port: browse_util(
             port=port,
             browsername=browsername,
             rel_url='diff',

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -45,7 +45,10 @@ def main(args=None):
         port=port, cwd=cwd, ip=ip,
         closable=True,
         on_port=lambda port: browse(
-            ip, port, browsername, 'diff',
+            port=port,
+            browsername=browsername,
+            rel_url='diff',
+            ip=ip,
             base=base, remote=remote))
 
 

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -297,7 +297,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
-    return main_server(port=arguments.port, cwd=arguments.workdirectory)
+    return main_server(port=arguments.port, ip=arguments.ip, cwd=arguments.workdirectory)
 
 
 if __name__ == "__main__":

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -263,7 +263,7 @@ def main_server(on_port=None, closable=False, **params):
     _logger.debug("Using params: %s" % params)
     params.update({"closable": closable})
     port = params.pop("port")
-    ip = params.pop("ip")
+    ip = params.pop("ip", "127.0.0.1")
     app = make_app(**params)
     if port != 0 or on_port is None:
         app.listen(port, address=ip)

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -263,11 +263,12 @@ def main_server(on_port=None, closable=False, **params):
     _logger.debug("Using params: %s" % params)
     params.update({"closable": closable})
     port = params.pop("port")
+    ip = params.pop("ip")
     app = make_app(**params)
     if port != 0 or on_port is None:
-        app.listen(port, address='127.0.0.1')
+        app.listen(port, address=ip)
     else:
-        sockets = netutil.bind_sockets(0, '127.0.0.1')
+        sockets = netutil.bind_sockets(0, ip)
         server = httpserver.HTTPServer(app)
         server.add_sockets(sockets)
         for s in sockets:

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -6,17 +6,12 @@ from __future__ import unicode_literals
 
 import sys
 from argparse import ArgumentParser
-import webbrowser
-import logging
-import threading
 
 from ..args import add_generic_args, add_filename_args
 from ..args import add_diff_args, add_merge_args, add_web_args
 from .nbdimeserver import main_server as run_server
+from .webutil import browse
 import nbdime.log
-
-
-_logger = logging.getLogger(__name__)
 
 
 # TODO: Tool server is passed a (mandatory?) single-use access token, which is
@@ -46,21 +41,6 @@ def build_arg_parser(parser=None):
     return parser
 
 
-def browse(port, browsername):
-    try:
-        browser = webbrowser.get(browsername)
-    except webbrowser.Error as e:
-        _logger.warning('No web browser found: %s.', e)
-        browser = None
-
-    url = "http://127.0.0.1:%s/mergetool" % port
-    nbdime.log.info("URL: " + url)
-    if browser:
-        def launch_browser():
-            browser.open(url, new=2)
-        threading.Thread(target=launch_browser).start()
-
-
 def main_parsed(opts):
     """Main function called after parsing CLI options
 
@@ -68,17 +48,18 @@ def main_parsed(opts):
     """
     nbdime.log.init_logging(level=opts.log_level)
     port = opts.port
+    ip = opts.ip
     cwd = opts.workdirectory
     base = opts.base
     local = opts.local
     remote = opts.remote
     merged = opts.merged
     browsername = opts.browser
-    return run_server(port=port, cwd=cwd,
+    return run_server(port=port, cwd=cwd, ip=ip,
                       closable=True,
                       mergetool_args=dict(base=base, local=local, remote=remote),
                       outputfilename=merged,
-                      on_port=lambda port: browse(port, browsername))
+                      on_port=lambda port: browse(ip, port, browsername, 'mergetool'))
 
 
 def main(args=None):

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -55,11 +55,16 @@ def main_parsed(opts):
     remote = opts.remote
     merged = opts.merged
     browsername = opts.browser
-    return run_server(port=port, cwd=cwd, ip=ip,
-                      closable=True,
-                      mergetool_args=dict(base=base, local=local, remote=remote),
-                      outputfilename=merged,
-                      on_port=lambda port: browse(ip, port, browsername, 'mergetool'))
+    return run_server(
+        port=port, cwd=cwd, ip=ip,
+        closable=True,
+        mergetool_args=dict(base=base, local=local, remote=remote),
+        outputfilename=merged,
+        on_port=lambda port: browse(
+            port=port,
+            browsername=browsername,
+            rel_url='mergetool',
+            ip=ip))
 
 
 def main(args=None):

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -55,7 +55,10 @@ def main(args=None):
         closable=True,
         outputfilename=output,
         on_port=lambda port: browse(
-            ip, port, browsername, 'merge',
+            port=port,
+            browsername=browsername,
+            rel_url='merge',
+            ip=ip,
             base=base, local=local, remote=remote))
 
 

--- a/nbdime/webapp/webutil.py
+++ b/nbdime/webapp/webutil.py
@@ -11,7 +11,7 @@ from tornado.httputil import url_concat
 _logger = logging.getLogger(__name__)
 
 
-def browse(port, browsername=None, rel_url='diff', ip='127.0.0.1', **url_args):
+def browse(port, browsername=None, rel_url='', ip='127.0.0.1', **url_args):
     try:
         browser = webbrowser.get(browsername)
     except webbrowser.Error as e:
@@ -20,7 +20,7 @@ def browse(port, browsername=None, rel_url='diff', ip='127.0.0.1', **url_args):
 
     if ip == '0.0.0.0':
         ip = '127.0.0.1'
-    elif ip in('::', '0:0:0:0:0:0:0:0'):
+    elif ip in ('::', '0:0:0:0:0:0:0:0'):
         ip = '::1'
 
     url = url_concat("http://%s:%s/%s" % (ip, port, rel_url), url_args)

--- a/nbdime/webapp/webutil.py
+++ b/nbdime/webapp/webutil.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+from __future__ import print_function
+
+import logging
+import threading
+import webbrowser
+from tornado.httputil import url_concat
+
+_logger = logging.getLogger(__name__)
+
+
+def browse(ip, port, browsername, rel_url, **url_args):
+    try:
+        browser = webbrowser.get(browsername)
+    except webbrowser.Error as e:
+        _logger.warning('No web browser found: %s.', e)
+        browser = None
+
+    if ip == '0.0.0.0':
+        ip = '127.0.0.1'
+    elif ip in('::', '0:0:0:0:0:0:0:0'):
+        ip = '::1'
+
+    url = url_concat("http://%s:%s/%s" % (ip, port, rel_url), url_args)
+    _logger.info("URL: " + url)
+    if browser:
+        def launch_browser():
+            browser.open(url, new=2)
+        threading.Thread(target=launch_browser).start()

--- a/nbdime/webapp/webutil.py
+++ b/nbdime/webapp/webutil.py
@@ -11,7 +11,7 @@ from tornado.httputil import url_concat
 _logger = logging.getLogger(__name__)
 
 
-def browse(ip, port, browsername, rel_url, **url_args):
+def browse(port, browsername=None, rel_url='diff', ip='127.0.0.1', **url_args):
     try:
         browser = webbrowser.get(browsername)
     except webbrowser.Error as e:


### PR DESCRIPTION
Adds an argument `--ip` to all web entry points (and similarly, `nbdimeserver` accepts an `ip` keyword), such that the listening interface can be specified.

Resolves #244.

Security note: As nbdime has no authentication built in, this might lead to exposing parts of your file system to an outsider, so this option should be used with care.