### PR TITLE
Web: Export static diff

### DIFF
--- a/nbdime-web/src/common/mergeview.ts
+++ b/nbdime-web/src/common/mergeview.ts
@@ -84,7 +84,20 @@ type DiffClasses = {
 };
 
 
+export
 class EditorWidget extends CodeMirrorWidget {
+  /**
+   * Store all editor instances for operations that
+   * need to loop over all instances.
+   */
+  constructor(options?: CodeMirror.EditorConfiguration | undefined) {
+    super(options);
+    EditorWidget.editors.push(this.editor);
+  }
+
+  public static editors: CodeMirror.Editor[] = [];
+
+
   /**
    * A message handler invoked on an `'resize'` message.
    */

--- a/nbdime/webapp/package.json
+++ b/nbdime/webapp/package.json
@@ -14,6 +14,7 @@
     "@types/json-stable-stringify": "^1.0.29",
     "@types/node": "6.0.50",
     "@types/sanitizer": "0.0.28",
+    "@types/filesaver": "0.0.30",
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
     "json-loader": "^0.5.4",
@@ -29,6 +30,7 @@
   "dependencies": {
     "@jupyterlab/services": "^0.34.2",
     "alertify.js": "^1.0.12",
+    "file-saver": "^1.3.3",
     "jupyterlab": "~0.11.3",
     "nbdime": "file:../../nbdime-web",
     "phosphor": "~0.7.0"

--- a/nbdime/webapp/src/app/common.css
+++ b/nbdime/webapp/src/app/common.css
@@ -33,6 +33,22 @@ body {
   margin-right: 10px;
 }
 
-.nbdime-Diff .nbdime-header-buttonrow {
-  display: none;
+#nbdime-header-buttonrow .nbdime-spinner {
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  border-width: 3px;
+}
+
+.nbdime-spinner {
+    border: 16px solid #eee;
+    border-top-color: #999;
+    border-bottom-color: #999;
+    border-radius: 50%;
+    animation: spin 1.3s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }

--- a/nbdime/webapp/src/app/common.ts
+++ b/nbdime/webapp/src/app/common.ts
@@ -55,6 +55,28 @@ function getConfigOption(name: string): any {
   return configData[name];
 }
 
+const spinner = document.createElement('div');
+spinner.className = 'nbdime-spinner';
+/**
+ * Turn spinner (loading indicator) on/off
+ */
+export
+function toggleSpinner(state?: boolean) {
+  let header = document.getElementById('nbdime-header-buttonrow')!;
+  // Figure out current state
+  let current = header.contains(spinner);
+  if (state === undefined) {
+    state = !current;
+  } else if (state === current) {
+    return;  // Nothing to do
+  }
+  if (state) {
+    header.appendChild(spinner);
+  } else {
+    header.removeChild(spinner);
+  }
+}
+
 
 export let toolClosed = false;
 /**

--- a/nbdime/webapp/src/app/compare.ts
+++ b/nbdime/webapp/src/app/compare.ts
@@ -12,7 +12,7 @@ import {
 } from './merge';
 
 import {
-  getConfigOption, closeTool
+  getConfigOption, closeTool, toggleSpinner
 } from './common';
 
 
@@ -49,6 +49,7 @@ function onCompare(e: Event) {
 };
 
 function compare(b: string, c: string, r: string, pushHistory: boolean | 'replace') {
+  toggleSpinner(true);
   let count = 0;
   for (let v of [b, c, r]) {
     if (v) {

--- a/nbdime/webapp/src/app/diff.ts
+++ b/nbdime/webapp/src/app/diff.ts
@@ -45,7 +45,7 @@ import {
 } from 'nbdime/lib/request';
 
 import {
-  getConfigOption
+  getConfigOption, toggleSpinner
 } from './common';
 
 import {
@@ -112,6 +112,7 @@ function onDiff(e: Event) {
 
 
 function compare(base: string, remote: string, pushHistory: boolean | 'replace') {
+  toggleSpinner(true);
   getDiff(base, remote);
   if (pushHistory) {
     let uri = window.location.pathname;
@@ -148,6 +149,7 @@ function onDiffRequestCompleted(data: any) {
   layoutWork.then(() => {
     let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;
     exportBtn.style.display = 'initial';
+    toggleSpinner(false);
   });
 }
 
@@ -161,6 +163,7 @@ function onDiffRequestFailed(response: string) {
     throw new Error('Missing root element "nbidme-root"');
   }
   root.innerHTML = '<pre>' + response + '</pre>';
+  toggleSpinner(false);
 }
 
 

--- a/nbdime/webapp/src/app/diff.ts
+++ b/nbdime/webapp/src/app/diff.ts
@@ -48,11 +48,16 @@ import {
   getConfigOption
 } from './common';
 
+import {
+  exportDiff
+} from './staticdiff';
+
+
 
 /**
  * Show the diff as represented by the base notebook and a list of diff entries
  */
-function showDiff(data: {base: nbformat.INotebookContent, diff: IDiffEntry[]}) {
+function showDiff(data: {base: nbformat.INotebookContent, diff: IDiffEntry[]}): Promise<void> {
   const transformers = [
     new JavascriptRenderer(),
     new MarkdownRenderer(),
@@ -90,6 +95,7 @@ function showDiff(data: {base: nbformat.INotebookContent, diff: IDiffEntry[]}) {
   work.then(() => {
     window.onresize = () => { panel.update(); };
   });
+  return work;
 }
 
 /**
@@ -137,7 +143,12 @@ function getDiff(base: string, remote: string) {
  * Callback for a successfull diff request
  */
 function onDiffRequestCompleted(data: any) {
-  showDiff(data);
+  let layoutWork = showDiff(data);
+
+  layoutWork.then(() => {
+    let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;
+    exportBtn.style.display = 'initial';
+  });
 }
 
 /**
@@ -190,4 +201,7 @@ function initializeDiff() {
   if (base && remote) {
     compare(base, remote, 'replace');
   }
+
+  let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;
+  exportBtn.onclick = exportDiff;
 }

--- a/nbdime/webapp/src/app/staticdiff.ts
+++ b/nbdime/webapp/src/app/staticdiff.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+'use strict';
+
+import {
+  saveAs
+} from 'file-saver';
+
+import {
+  EditorWidget
+} from 'nbdime/lib/common/mergeview';
+
+
+
+const collapsiblePanelExportJS =
+`<script>
+var headers = document.getElementsByClassName("jp-CollapsiblePanel-header");
+for (var i=0;i<headers.length;++i){
+  var header=headers[i];
+  var slider = header.parentNode.getElementsByClassName("jp-CollapsiblePanel-slider")[0];
+  header.onclick = function(slider){ return function() {
+    if (slider.className.indexOf("opened") !== -1) {
+      slider.className = slider.className.replace(/opened/g, "closed");
+    } else {
+      slider.className = slider.className.replace(/closed/g, "opened");
+    }
+  }; }(slider);
+}
+</script>`;
+
+const codeMirrorEllipsisExportStyle =
+`<style type="text/css">
+.jp-Notebook-diff .CodeMirror-merge-collapsed-widget {
+  cursor: initial;
+}
+
+.CodeMirror-gutters {
+  height: auto !important;
+}
+
+.CodeMirror-sizer, .CodeMirror-scroll {
+  margin-bottom: 0 !important;
+  padding-bottom: 0 !important;
+  margin-right: 0 !important;
+  padding-right: 0 !important;
+}
+
+.CodeMirror-hscrollbar, .CodeMirror-vscrollbar,
+.CodeMirror-merge-scrolllock, .CodeMirror-sizer + div {
+  display: none !important;
+}
+
+.CodeMirror-scroll {
+  overflow: auto !important;
+}
+</style>`;
+
+
+function ensureRendered(callback: () => void): void {
+  for (let e of EditorWidget.editors) {
+    e.setOption('viewportMargin', Infinity);
+  }
+  window.requestAnimationFrame(() => {
+    // Assume entire viewport has been rendered now
+    callback();
+    for (let e of EditorWidget.editors) {
+      // Reset to default according to docs
+      e.setOption('viewportMargin', 10);
+    }
+  });
+}
+
+
+/**
+ * Download diff as static HTML
+ */
+export
+function exportDiff(): void {
+  let prefix = '<!DOCTYPE html>\n<html>\n<head>';
+  prefix += document.head.innerHTML;
+  prefix += codeMirrorEllipsisExportStyle + '\n</head><body>';
+  let postfix = collapsiblePanelExportJS + '\n</body></html>';
+
+  ensureRendered(() => {
+    let rootNode = document.getElementById('nbdime-root')!;
+    let content = rootNode.outerHTML;
+    // Strip hover text of CM ellipses
+    content = content.replace(/title="Identical text collapsed. Click to expand."/g, '');
+    let blob = new Blob([prefix + content + postfix], {type: 'text/html;charset=utf-8'});
+
+    saveAs(blob, 'diff.html');
+  });
+}

--- a/nbdime/webapp/templates/diff.html
+++ b/nbdime/webapp/templates/diff.html
@@ -31,6 +31,7 @@
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+        <button id="nbdime-export" class="nbdime-header-button" style="display: none">Export diff</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-base">Base</span>

--- a/nbdime/webapp/templates/difftool.html
+++ b/nbdime/webapp/templates/difftool.html
@@ -17,6 +17,7 @@
       <h3>Notebook Diff</h3>
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+        <button id="nbdime-export" class="nbdime-header-button" style="display: none">Export diff</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-base">Base</span>

--- a/nbdime/webapp/templates/index.html
+++ b/nbdime/webapp/templates/index.html
@@ -32,6 +32,12 @@
           <button id="nbdime-download" class="nbdime-header-button" style="display: none" type="button">Download</button>
         </fieldset>
       </form> <!-- nbdime-forms -->
+      <div id="nbdime-header-buttonrow">
+        <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
+        <button id="nbdime-download" class="nbdime-header-button" style="display: none">Download</button>
+        <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+        <button id="nbdime-export" class="nbdime-header-button" style="display: none">Export diff</button>
+      </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-local">Local</span>
         <span id="nbdime-header-base">Base</span>

--- a/nbdime/webapp/templates/merge.html
+++ b/nbdime/webapp/templates/merge.html
@@ -34,6 +34,7 @@
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">
         <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
+        <button id="nbdime-download" class="nbdime-header-button" style="display: none">Download</button>
         <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
       </div>
       <div id=nbdime-header-banner>


### PR DESCRIPTION
Adds a button "Export" to web-diff views (once it has completed rendering the entire diff), which will download a self-containing HTML page of the diff view. This can then be shared with others that do not have nbdime installed.

Also now shows a spinner while loading/rendering diff/merge.

Related to #251.