### PR TITLE
Handle null files (/dev/null | nul)

### DIFF
--- a/nbdime/gitdifftool.py
+++ b/nbdime/gitdifftool.py
@@ -61,7 +61,6 @@ def show_diff(before, after, opts):
     If we are diffing a notebook, show the diff via nbdiff-web.
     Otherwise, call out to `git diff`.
     """
-    # TODO: handle /dev/null (Windows equivalent?) for new or deleted files
     if before.endswith('.ipynb') or after.endswith('ipynb'):
         return nbdifftool.main_parsed(opts)
     else:

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -17,7 +17,7 @@ import nbdime
 from nbdime.diffing.notebooks import diff_notebooks
 from nbdime.prettyprint import pretty_print_notebook_diff
 from nbdime.args import add_generic_args, add_diff_args, add_filename_args
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook_or_empty
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
 
 
 _description = "Compute the difference between two Jupyter notebooks."

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -17,6 +17,7 @@ import nbdime
 from nbdime.diffing.notebooks import diff_notebooks
 from nbdime.prettyprint import pretty_print_notebook_diff
 from nbdime.args import add_generic_args, add_diff_args, add_filename_args
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook_or_empty
 
 
 _description = "Compute the difference between two Jupyter notebooks."
@@ -28,12 +29,14 @@ def main_diff(args):
     dfn = args.output
 
     for fn in (afn, bfn):
-        if not os.path.exists(fn):
+        if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:
             print("Missing file {}".format(fn))
             return 1
+    # Both files cannot be missing
+    assert not (afn == EXPLICIT_MISSING_FILE and bfn == EXPLICIT_MISSING_FILE)
 
-    a = nbformat.read(afn, as_version=4)
-    b = nbformat.read(bfn, as_version=4)
+    a = read_notebook(afn, on_null='empty')
+    b = read_notebook(bfn, on_null='empty')
 
     d = diff_notebooks(a, b)
 

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -17,7 +17,7 @@ import nbdime
 import nbdime.log
 from nbdime.merging import merge_notebooks
 from nbdime.prettyprint import pretty_print_merge_decisions
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook_or_minimal
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
 
 _description = ('Merge two Jupyter notebooks "local" and "remote" with a '
                 'common ancestor "base".')

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -17,7 +17,7 @@ import nbdime
 import nbdime.log
 from nbdime.merging import merge_notebooks
 from nbdime.prettyprint import pretty_print_merge_decisions
-from .merging import merge_notebooks
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook_or_minimal
 
 _description = ('Merge two Jupyter notebooks "local" and "remote" with a '
                 'common ancestor "base".')
@@ -30,13 +30,20 @@ def main_merge(args):
     mfn = args.output
 
     for fn in (bfn, lfn, rfn):
-        if not os.path.exists(fn):
+        if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:
             nbdime.log.error("Cannot find file '{}'".format(fn))
             return 1
 
-    b = nbformat.read(bfn, as_version=4)
-    l = nbformat.read(lfn, as_version=4)
-    r = nbformat.read(rfn, as_version=4)
+    if lfn == rfn == EXPLICIT_MISSING_FILE:
+        # Deleted both locally and remotely
+        # Special case not well solved by routines below
+        handle_agreed_deletion(bfn, mfn, args.decisions)
+        # Agreed on deletion = no conflics = return 0
+        return 0
+
+    b = read_notebook(bfn, on_null='minimal')
+    l = read_notebook(lfn, on_null='minimal')
+    r = read_notebook(rfn, on_null='minimal')
 
     merged, decisions = merge_notebooks(b, l, r, args)
     conflicted = [d for d in decisions if d.conflict]
@@ -52,7 +59,7 @@ def main_merge(args):
         # Print merge decisions (including unconflicted)
         out = io.StringIO()
         pretty_print_merge_decisions(b, decisions, out=out)
-        nbdime.log.warning("Conflicts:\n%s", out.getvalue())
+        nbdime.log.warning("Decisions:\n%s", out.getvalue())
     elif mfn:
         # Write partial or fully completed merge to given foo.ipynb filename
         with io.open(mfn, "w", encoding="utf8") as mf:
@@ -62,6 +69,32 @@ def main_merge(args):
         # Write merged notebook to terminal
         nbformat.write(merged, sys.stdout)
     return returncode
+
+
+def handle_agreed_deletion(base_fn, output_fn, print_decisions=False):
+    """Handle merge when file has been deleted both locally and remotely"""
+    assert base_fn != EXPLICIT_MISSING_FILE
+    b = read_notebook(base_fn, on_null='minimal')
+    if print_decisions:
+        # Print merge decision (delete all)
+        from nbdime.diffing.notebooks import diff_notebooks
+        from nbdime.merging.decisions import MergeDecisionBuilder
+        # Build diff for deleting all content:
+        diff = diff_notebooks(b, {})
+        # Make agreed decision from diff:
+        bld = MergeDecisionBuilder()
+        bld.agreement([], local_diff=diff, remote_diff=diff)
+        decisions = bld.validated(b)
+        # Print decition
+        out = io.StringIO()
+        pretty_print_merge_decisions(b, decisions, out=out)
+        nbdime.log.warning("Decisions:\n%s", out.getvalue())
+
+    elif output_fn:
+        # Delete file if existing, if not do nothing
+        if os.path.exists(output_fn):
+            os.remove(output_fn)
+            nbdime.log.info("Output file deleted: %s" % output_fn)
 
 
 def _build_arg_parser():

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -16,7 +16,7 @@ import io
 import nbdime
 from nbdime.patching import patch_notebook
 from nbdime.diff_format import to_diffentry_dicts
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook_or_empty
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
 from nbdime.prettyprint import pretty_print_notebook
 
 

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -16,6 +16,8 @@ import io
 import nbdime
 from nbdime.patching import patch_notebook
 from nbdime.diff_format import to_diffentry_dicts
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook_or_empty
+from nbdime.prettyprint import pretty_print_notebook
 
 
 _description = "Apply patch from nbdiff to a Jupyter notebook."
@@ -23,16 +25,16 @@ _description = "Apply patch from nbdiff to a Jupyter notebook."
 
 def main_patch(args):
     base_filename = args.base
-    path_filename = args.patch
+    patch_filename = args.patch
     output_filename = args.output
 
-    for fn in (base_filename, path_filename):
-        if not os.path.exists(fn):
+    for fn in (base_filename, patch_filename):
+        if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:
             print("Missing file {}".format(fn))
             return 1
 
-    before = nbformat.read(base_filename, as_version=4)
-    with io.open(path_filename, encoding="utf8") as patch_file:
+    before = read_notebook(base_filename, on_null='empty')
+    with io.open(patch_filename, encoding="utf8") as patch_file:
         diff = json.load(patch_file)
     diff = to_diffentry_dicts(diff)
 
@@ -41,7 +43,13 @@ def main_patch(args):
     if output_filename:
         nbformat.write(after, output_filename)
     else:
-        print(after)
+        try:
+            nbformat.validate(after, version=4)
+        except nbformat.ValidationError:
+            print("Patch result is not a valid notebook, printing as JSON:")
+            json.dump(after, sys.stdout)
+        else:
+            pretty_print_notebook(after)
 
     return 0
 

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -8,7 +8,37 @@ import os
 import re
 from subprocess import check_output, CalledProcessError
 
+import nbformat
 from six import string_types, text_type
+
+if os.name == 'nt':
+    EXPLICIT_MISSING_FILE = 'nul'
+else:
+    EXPLICIT_MISSING_FILE = '/dev/null'
+
+
+def read_notebook(filename, on_null):
+    """Read and return notebook json from filename
+
+    Parameters:
+        filename: The filename to read from or null filename
+            ("/dev/null" on *nix, "nul" on Windows)
+        on_null: What to return when filename null
+            "empty": return empty dict
+            "minimal": return miminal valid notebook
+    """
+    if filename == EXPLICIT_MISSING_FILE:
+        if on_null == 'empty':
+            return {}
+        elif on_null == 'minimal':
+            return nbformat.v4.new_notebook()
+        else:
+            raise ValueError(
+                'Not valid value for `on_null`: "%s". Valid values '
+                'are "empty" or "minimal"', on_null)
+    else:
+        return nbformat.read(filename, as_version=4)
+
 
 def as_text(text):
     if isinstance(text, list):


### PR DESCRIPTION
Adds handling of explicitly non-existing files, e.g. for when a file has been added/deleted. On *nix this is marked by "/dev/null" while on Windows this is marked by "nul" (reserved name).

Fixes #259.