### PR TITLE
Fix Travis JS/TS stale caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,12 @@ script:
     elif [[ $GROUP == js ]]; then
       npm test
     fi
-after_success:
-    - 'if [[ $GROUP == js ]]; then cd ..; fi'
-    - codecov
 before_cache:
   # Do not cache our own package
-  - rm -rf nbdime/webapp/node_modules/nbdime
-  - rm -rf nbdime/webapp/node_modules/nbdime-webapp
-  - rm -rf nbdime-web/node_modules/nbdime
+  - |
+    if [[ $GROUP == js ]]; then cd ..; fi
+    rm -rf nbdime/webapp/node_modules/nbdime
+    rm -rf nbdime/webapp/node_modules/nbdime-webapp
+    rm -rf nbdime-web/node_modules/nbdime
+after_success:
+    - codecov


### PR DESCRIPTION
It seems Travis runs `before_cache` before `after_success`! Therefore, the cache cleanup happened before the `cd..` to the expected directory.