### PR TITLE
escape encoding errors when presenting diffs/output

### DIFF
--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -80,12 +80,9 @@ def _build_arg_parser():
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
-    if sys.platform.startswith('win'):
-        import colorama
-        colorama.init()
+    setup_std_streams()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
-    setup_std_streams()
     return main_diff(arguments)
 
 

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -17,7 +17,7 @@ import nbdime
 from nbdime.diffing.notebooks import diff_notebooks
 from nbdime.prettyprint import pretty_print_notebook_diff
 from nbdime.args import add_generic_args, add_diff_args, add_filename_args
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 
 
 _description = "Compute the difference between two Jupyter notebooks."
@@ -85,6 +85,7 @@ def main(args=None):
         colorama.init()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
+    setup_std_streams()
     return main_diff(arguments)
 
 

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -127,10 +127,10 @@ def _build_arg_parser():
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
+    setup_std_streams()
     nbdime.log.init_logging()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
-    setup_std_streams()
     return main_merge(arguments)
 
 

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -17,7 +17,7 @@ import nbdime
 import nbdime.log
 from nbdime.merging import merge_notebooks
 from nbdime.prettyprint import pretty_print_merge_decisions
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 
 _description = ('Merge two Jupyter notebooks "local" and "remote" with a '
                 'common ancestor "base".')
@@ -130,6 +130,7 @@ def main(args=None):
     nbdime.log.init_logging()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
+    setup_std_streams()
     return main_merge(arguments)
 
 

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -75,9 +75,9 @@ def _build_arg_parser():
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
+    setup_std_streams()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
-    setup_std_streams()
     return main_patch(arguments)
 
 

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -17,7 +17,7 @@ import nbdime
 from nbdime.patching import patch_notebook
 from nbdime.diff_format import to_diffentry_dicts
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
-from nbdime.prettyprint import pretty_print_notebook
+from nbdime.prettyprint import pretty_print_notebook, setup_std_streams
 
 
 _description = "Apply patch from nbdiff to a Jupyter notebook."
@@ -77,6 +77,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
+    setup_std_streams()
     return main_patch(arguments)
 
 

--- a/nbdime/nbpatchapp.py
+++ b/nbdime/nbpatchapp.py
@@ -16,8 +16,8 @@ import io
 import nbdime
 from nbdime.patching import patch_notebook
 from nbdime.diff_format import to_diffentry_dicts
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook
-from nbdime.prettyprint import pretty_print_notebook, setup_std_streams
+from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
+from nbdime.prettyprint import pretty_print_notebook
 
 
 _description = "Apply patch from nbdiff to a Jupyter notebook."

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -16,6 +16,8 @@ import json
 import nbdime
 from nbdime.prettyprint import pretty_print_notebook
 from nbdime.args import add_generic_args, add_filename_args
+from nbdime.utils import setup_std_streams
+
 
 
 _description = """Show a Jupyter notebook in terminal.
@@ -109,6 +111,7 @@ def main(args=None):
         colorama.init()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
+    setup_std_streams()
     return main_show(arguments)
 
 

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -106,12 +106,9 @@ def _build_arg_parser():
 def main(args=None):
     if args is None:
         args = sys.argv[1:]
-    if sys.platform.startswith('win'):
-        import colorama
-        colorama.init()
+    setup_std_streams()
     arguments = _build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
-    setup_std_streams()
     return main_show(arguments)
 
 

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -3,8 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import unicode_literals
-
 import io
 import json
 import logging

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -9,7 +9,8 @@ import io
 import json
 import logging
 import os
-from subprocess import CalledProcessError, Popen
+from subprocess import CalledProcessError, Popen, check_call
+import sys
 import time
 
 import pytest
@@ -78,6 +79,15 @@ def test_nbdiff_app_null_file(filespath):
 
     args = nbdiffapp._build_arg_parser().parse_args([EXPLICIT_MISSING_FILE, fn])
     assert 0 == main_diff(args)
+
+
+def test_nbdiff_app_unicode_safe(filespath):
+    afn = os.path.join(filespath, "unicode--1.ipynb")
+    bfn = os.path.join(filespath, "unicode--2.ipynb")
+    env = os.environ.copy()
+    env['LC_ALL'] = 'C'
+    env.pop('PYTHONIOENCODING', None)
+    check_call([sys.executable, '-m', 'nbdime.nbdiffapp', afn, bfn], env=env)
 
 
 def test_nbmerge_app(tempfiles, capsys):

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -243,7 +243,7 @@ def find_shared_prefix(a, b):
     return a[:i]
 
 
-def setup_std_streams():
+def _setup_std_stream_encoding():
     """Setup encoding on stdout/err
     
     Ensures sys.stdout/err have error-escaping encoders,
@@ -262,4 +262,20 @@ def setup_std_streams():
             bin_stream = getattr(stream, 'buffer', stream)
             new_stream = codecs.getwriter(enc)(bin_stream, errors='backslashreplace')
             setattr(sys, name, new_stream)
+
+
+def setup_std_streams():
+    """Setup sys.stdout/err
+    
+    - Ensures sys.stdout/err have error-escaping encoders,
+      rather than raising errors.
+    - enables colorama for ANSI escapes on Windows
+    """
+
+    _setup_std_stream_encoding()
+    # must enable colorama after setting up encoding,
+    # or encoding will undo colorama setup
+    if sys.platform.startswith('win'):
+        import colorama
+        colorama.init()
 


### PR DESCRIPTION
rather than raising UnicodeEncodeErrors.

closes #101

Need to do a bit of testing on Python 2 and Windows to ensure this is right everywhere.