### PR TITLE
Allow nbdiff[-web] to take gitrefs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,18 +80,7 @@ you should see a nice diff view, like this:
 
 To use the web-based GUI viewers of notebook diffs, call::
 
-
-    git difftool --tool nbdime [ref [ref]]
-
-
-.. note::
-
-    Using :command:`git-nbdiffdriver config` overrides the ability to call
-    :command:`git difftool` with notebooks.
-
-    You can still call :command:`nbdiff-web` to diff files directly,
-    but getting the files from git refs is still on our TODO list.
-
+    nbdime-web [ref [ref]]
 
 .. figure:: images/nbdiff-web.png
    :alt: example of nbdime's content-aware diff
@@ -111,7 +100,6 @@ and resolving merge conflicts, and it can be launched by calling::
    :alt: nbdime's merge with web-based GUI viewer
 
    Figure: nbdime's merge with web-based GUI viewer
-
 
 For more detailed information on integrating nbdime with version control, see :doc:`vcs`.
 

--- a/docs/source/vcs.rst
+++ b/docs/source/vcs.rst
@@ -70,10 +70,10 @@ will also be used for all merges on notebook files (no specific
 commands needed).
 
 To launch the rich, web-based tools (for diff visualization and
-merge conflict visualization/resolution), the following git
-command will need to be executed::
+merge conflict visualization/resolution), the following
+commands will need to be executed::
 
-    git difftool --tool nbdime [ref [ref]]
+    nbdime-web [ref [ref]]
 
 .. figure:: images/nbdiff-web.png
    :alt: example of nbdime's content-aware diff
@@ -196,69 +196,6 @@ with the following steps:
 
     *.ipynb merge=jupyternotebook
 
-
-Diff web tool
-*************
-
-The rich, web-based diff view can be installed as a git
-*diff tool*. This enables the diff viewer to display diffs
-of repository history instead of just files.
-
-Command line registration
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To register nbdime as a git diff tool, run the command::
-
-    git-nbdifftool config --enable [--global | --system]
-
-Once registered, the diff tool can be started by running
-the git command::
-
-    git difftool --tool=nbdime [<commit> [<commit>]] [--] [<path>…​]
-
-If you want to avoid specifying the tool each time, nbdime
-can be set as the default tool by adding the ``--set-default``
-flag to the registration command::
-
-    git-nbdifftool config --enable [--global | --system] --set-default
-
-This command will set the CLI's diff tool as the default diff tool, and
-the web based diff tool as the default GUI diff tool. To
-launch the web view with this configuration, run the
-git command as follows::
-
-    git difftool -g [<commit> [<commit>]] [--] [<path>…​]
-
-.. note::
-
-    Git does not allow selection of different tools per file type.
-    If you set nbdime as the default tool it will be called
-    for **all** changed files. This includes non-notebook files, which
-    nbdime will fail to process.
-
-Manual registration
-^^^^^^^^^^^^^^^^^^^
-
-Alternatively, the diff tool can be registered manually
-with the following steps:
-
-- To register both the CLI and web diff tools with git under
-  the names "nbdime" and "nbdime", add the following entries
-  to the appropriate ``.gitconfig`` file
-  (`git config [--global | --system] -e` to edit)::
-
-    [difftool "nbdime"]
-    cmd = git-nbdifftool diff "$LOCAL" "$REMOTE"
-
-    [difftool "nbdime"]
-    cmd = git-nbdifftool "$LOCAL" "$REMOTE"
-
-- To set the diff tools as the default tools, add or modify
-  the following entries in the appropriate``.gitconfig`` file::
-
-    [diff]
-    tool = nbdime
-    guitool = nbdime
 
 Merge web tool
 **************

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -2,41 +2,67 @@
 # -*- coding:utf-8 -*-
 
 import os
-
 import io
+from collections import deque
+
+from six import string_types
 
 from git import Repo, InvalidGitRepositoryError, BadName
 
 from .utils import EXPLICIT_MISSING_FILE
 
 
-# Ensure that we can use name attr:
 class BlobWrapper(io.StringIO):
+    """StringIO with a name attribute"""
     name = ''
 
 
 def get_repo(path):
-    popped = []
+    """Gets a Repo for path, also if path is a subidrectory of a repository
+
+    Returns a tuple with the Repo object, and a list of subdirectories
+    between path and the parent repository"""
+    path = os.path.abspath(path)
+    popped = deque()
     while True:
         try:
-            repo = Repo()
-            return (repo, popped)
+            repo = Repo(path)
+            return (repo, tuple(popped))
         except InvalidGitRepositoryError:
             path, pop = os.path.split(path)
             if not pop:
                 raise
-            popped.append(pop)
+            popped.appendleft(pop)
 
 
 def traverse_tree(tree, subdirs):
+    """Get the subtree according to given list of subdirectories"""
     if len(subdirs) == 0:
         return tree
-    tree_map = {subtree.name: subtree for subtree in tree.trees}
     sub = subdirs[0]
-    return traverse_tree(tree_map[sub], subdirs[1:])
+    # Find first subtree whose name matches sub:
+    subtree = next((st for st in tree.trees if st.name == sub), None)
+    if subtree is None:
+        raise KeyError('%s is not a subtree of %s' % (sub, tree.name))
+    return traverse_tree(subtree, subdirs[1:])
+
+
+def is_gitref(candidate):
+    """Is candidate a gitref, or is it a file/filename?
+
+    Returns false for collisions (e.g. when it is both a valid filename and gitref).
+    Tests relative to current directory.
+    """
+    return (
+        (candidate is None or not os.path.exists(candidate)) and
+        candidate != EXPLICIT_MISSING_FILE and
+        is_valid_gitref(candidate)
+        )
 
 
 def is_valid_gitref(ref, path=None):
+    """Checks whether ref is a valid gitref in `path`, per git-rev-parse
+    """
     try:
         repo = get_repo(path)[0]
         repo.commit(ref)
@@ -47,43 +73,59 @@ def is_valid_gitref(ref, path=None):
         return False
 
 
-def changed_notebooks(ref_base, ref_remote, path=None):
-    if path is None:
-        # If path is not supplied, we diff entire repo
-        repo = get_repo(os.curdir)[0]
-        popped = []
-    else:
-        # If path is supplied, we only diff that part
-        repo, popped = get_repo(path)
-    # Get trees from refs:
-    tree_base = traverse_tree(repo.commit(ref_base).tree, popped)
-    tree_remote = traverse_tree(repo.commit(ref_remote).tree, popped)
+def _get_diff_entry_stream(path, blob, ref_name):
+    """Get a stream to the notebook, for a given diff entry's path and blob
+
+    Returns None if path is not a Notebook file, and EXPLICIT_MISSING_FILE
+    if path is missing."""
+    if path:
+        if not path.endswith('.ipynb'):
+            return None
+        if blob is None:
+            # Diffing against working copy, use file on disk!
+            try:
+                return io.open(path)
+            except IOError:
+                return EXPLICIT_MISSING_FILE
+        else:
+            # There were strange issues with passing blob data_streams around,
+            # so we solve this by reading into a StringIO buffer.
+            # The penalty should be low as long as changed_notebooks are used
+            # properly as an iterator.
+            f = BlobWrapper(blob.data_stream.read().decode('utf-8'))
+            f.name = '%s (%s)' % (path, ref_name)
+            return f
+    return EXPLICIT_MISSING_FILE
+
+
+def changed_notebooks(ref_base, ref_remote, paths=None):
+    """Iterator over all notebooks in path that has changed between the two git refs
+
+    References are all valid values according to git-rev-parse. If ref_remote
+    is None, the difference is taken between ref_base and the working directory.
+    Iterator value is a base/remote pair of streams to Notebooks
+    (or possibly EXPLICIT_MISSING_FILE for added/removed files).
+    """
+    repo, popped = get_repo(os.curdir)
+    if isinstance(paths, string_types):
+        paths = (paths,)
+    if paths and popped:
+        # All paths need to be prepended by popped
+        paths = [os.path.join(*(popped + (p,))) for p in paths]
+    # Get tree for base:
+    tree_base = repo.commit(ref_base).tree
     if ref_remote is None:
         # Diff tree against working copy:
-        diff = tree_base.diff(None)
+        diff = tree_base.diff(None, paths)
     else:
-        diff = tree_base.diff(tree_remote)
+        # Get remote tree and diff against base:
+        tree_remote = repo.commit(ref_remote).tree
+        diff = tree_base.diff(tree_remote, paths)
     for entry in diff:
-        if entry.a_path:
-            if not entry.a_path.endswith('.ipynb'):
-                continue
-            if entry.a_blob is None:
-                # Diffing against working copy, use file
-                fa = io.open(entry.a_path)
-            else:
-                fa = BlobWrapper(entry.a_blob.data_stream.read().decode('utf-8'))
-                fa.name = '%s (%s)' % (entry.a_path, ref_base)
-        else:
-            fa = EXPLICIT_MISSING_FILE
-        if entry.b_path:
-            if not entry.b_path.endswith('.ipynb'):
-                continue
-            if entry.b_blob is None:
-                # Diffing against working copy, use file
-                fb = io.open(entry.b_path)
-            else:
-                fb = BlobWrapper(entry.b_blob.data_stream.read().decode('utf-8'))
-                fb.name = '%s (%s)' % (entry.b_path, ref_remote)
-        else:
-            fb = EXPLICIT_MISSING_FILE
+        fa = _get_diff_entry_stream(entry.a_path, entry.a_blob, ref_base)
+        if fa is None:
+            continue
+        fb = _get_diff_entry_stream(entry.b_path, entry.b_blob, ref_remote)
+        if fb is None:
+            continue
         yield (fa, fb)

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+import os
+
+from io import StringIO
+
+from git import Repo, InvalidGitRepositoryError, BadName
+
+from .utils import EXPLICIT_MISSING_FILE
+
+
+# Ensure that we can use name attr:
+class BlobWrapper(StringIO):
+    name = ''
+
+
+def get_repo(path):
+    popped = []
+    while True:
+        try:
+            repo = Repo()
+            return (repo, popped)
+        except InvalidGitRepositoryError:
+            path, pop = os.path.split(path)
+            if not pop:
+                raise
+            popped.append(pop)
+
+
+def traverse_tree(tree, subdirs):
+    if len(subdirs) == 0:
+        return tree
+    tree_map = {subtree.name: subtree for subtree in tree.trees}
+    sub = subdirs[0]
+    return traverse_tree(tree_map[sub], subdirs[1:])
+
+
+def is_valid_gitref(ref, path=None):
+    try:
+        repo = get_repo(path)[0]
+        repo.commit(ref)
+        return True
+    except InvalidGitRepositoryError:
+        return False
+    except BadName:
+        return False
+
+
+def changed_notebooks(ref_base, ref_remote, path=None):
+    if path is None:
+        # If path is not supplied, we diff entire repo
+        repo = get_repo(os.curdir)[0]
+        popped = []
+    else:
+        # If path is supplied, we only diff that part
+        repo, popped = get_repo(path)
+    # Get trees from refs:
+    tree_base = traverse_tree(repo.commit(ref_base).tree, popped)
+    tree_remote = traverse_tree(repo.commit(ref_remote).tree, popped)
+
+    diff = tree_base.diff(tree_remote)
+    for entry in diff:
+        if entry.a_path:
+            if not entry.a_path.endswith('.ipynb'):
+                continue
+            fa = BlobWrapper(entry.a_blob.data_stream.read().decode('utf-8'))
+            fa.name = '%s (%s)' % (entry.a_path, ref_base)
+        else:
+            fa = EXPLICIT_MISSING_FILE
+        if entry.b_path:
+            if not entry.b_path.endswith('.ipynb'):
+                continue
+            fb = BlobWrapper(entry.b_blob.data_stream.read().decode('utf-8'))
+            fb.name = '%s (%s)' % (entry.b_path, ref_remote)
+        else:
+            fb = EXPLICIT_MISSING_FILE
+        yield (fa, fb)

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -64,7 +64,7 @@ def is_valid_gitref(ref, path=None):
     """Checks whether ref is a valid gitref in `path`, per git-rev-parse
     """
     try:
-        repo = get_repo(path)[0]
+        repo = get_repo(path or os.curdir)[0]
         repo.commit(ref)
         return True
     except InvalidGitRepositoryError:

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -20,7 +20,7 @@ from nbdime.prettyprint import pretty_print_notebook_diff
 from nbdime.args import (
     add_generic_args, add_diff_args, process_diff_args)
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
-from .gitfiles import changed_notebooks, is_valid_gitref
+from .gitfiles import changed_notebooks, is_gitref
 
 
 _description = "Compute the difference between two Jupyter notebooks."
@@ -94,10 +94,6 @@ def _build_arg_parser():
              "Otherwise it is printed to the terminal.")
 
     return parser
-
-
-def is_gitref(candidate):
-    return is_valid_gitref(candidate) and (candidate is None or not os.path.exists(candidate))
 
 
 def handle_gitrefs(base, remote, arguments):

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -18,7 +18,7 @@ import nbdime
 from nbdime.diffing.notebooks import diff_notebooks
 from nbdime.prettyprint import pretty_print_notebook_diff
 from nbdime.args import (
-    add_generic_args, add_diff_args, add_filename_args, process_diff_args)
+    add_generic_args, add_diff_args, process_diff_args)
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 from .gitfiles import changed_notebooks, is_valid_gitref
 
@@ -80,9 +80,11 @@ def _build_arg_parser():
     add_diff_args(parser)
     parser.add_argument(
         "base", help="The base notebook filename OR base git-revision.",
+        nargs='?', default='HEAD',
     )
     parser.add_argument(
         "remote", help="The remote modified notebook filename OR remote git-revision.",
+        nargs='?', default=None,
     )
 
     parser.add_argument(
@@ -119,7 +121,7 @@ def main(args=None):
     nbdime.log.init_logging(level=arguments.log_level)
     if is_gitref(base) and is_gitref(remote):
         # We are asked to do a diff of git revisions:
-        return handle_gitrefs(base, remote arguments)
+        return handle_gitrefs(base, remote, arguments)
     return main_diff(arguments)
 
 

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -30,13 +30,13 @@ def main_diff(args):
     """Main handler of diff CLI"""
     output = args.out
     process_diff_flags(args)
-    base, remote, path = resolve_diff_args(args)
+    base, remote, paths = resolve_diff_args(args)
 
     # Check if base/remote are gitrefs:
     if is_gitref(base) and is_gitref(remote):
         # We are asked to do a diff of git revisions:
         status = 0
-        for fbase, fremote in changed_notebooks(base, remote, path):
+        for fbase, fremote in changed_notebooks(base, remote, paths):
             status = _handle_diff(fbase, fremote)
             if status != 0:
                 # Short-circuit on error in diff handling
@@ -103,8 +103,8 @@ def _build_arg_parser():
         nargs='?', default=None,
     )
     parser.add_argument(
-        "path", help="Filter diffs for git-revisions based on path",
-        nargs='?', default=None,
+        "paths", help="Filter diffs for git-revisions based on path",
+        nargs='*', default=None,
     )
 
     parser.add_argument(

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -29,8 +29,8 @@ def main_merge(args):
     rfn = args.remote
     mfn = args.out
 
-    from .args import process_diff_args
-    process_diff_args(args)
+    from .args import process_diff_flags
+    process_diff_flags(args)
 
     for fn in (bfn, lfn, rfn):
         if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -63,9 +63,13 @@ def nocolor(request):
 
 
 @fixture
-def git_repo(tmpdir, request, filespath):
+def needs_git():
     if not have_git:
         skip("requires git")
+
+
+@fixture
+def git_repo(tmpdir, request, filespath, needs_git):
     repo = str(tmpdir.join('repo'))
     os.mkdir(repo)
     save_cwd = os.getcwd()
@@ -102,6 +106,45 @@ def git_repo(tmpdir, request, filespath):
 
     # start on local
     call('git checkout local')
+    assert not os.path.exists('.gitattributes')
+    return repo
+
+
+@fixture
+def git_repo2(tmpdir, request, filespath, needs_git):
+    repo = str(tmpdir.join('repo'))
+    os.mkdir(repo)
+    save_cwd = os.getcwd()
+    os.chdir(repo)
+    request.addfinalizer(lambda: os.chdir(save_cwd))
+    call('git init'.split())
+
+    # setup base branch
+    src = filespath
+    shutil.copy(pjoin(src, 'src-and-output--1.ipynb'), pjoin(repo, 'diff.ipynb'))
+    os.mkdir('sub')
+    shutil.copy(pjoin(src, 'foo--1.ipynb'), pjoin(repo, 'sub', 'subfile.ipynb'))
+    call('git add --all')
+    call('git commit -m "init base branch"')
+    # create base alias for master
+    call('git checkout -b base master')
+
+    # setup local branch
+    call('git checkout -b local master')
+    shutil.copy(pjoin(src, 'src-and-output--2.ipynb'), pjoin(repo, 'diff.ipynb'))
+    shutil.copy(pjoin(src, 'foo--2.ipynb'), pjoin(repo, 'sub', 'subfile.ipynb'))
+    call('git commit -am "create local branch"')
+
+    # setup remote branch
+    call('git checkout -b remote master')
+    shutil.copy(pjoin(src, 'foo--2.ipynb'), pjoin(repo, 'sub', 'subfile.ipynb'))
+    shutil.copy(pjoin(src, 'markdown-only--1.ipynb'), pjoin(repo, 'sub', 'added.ipynb'))
+    call('git add --all')
+    call('git commit -am "create remote branch"')
+
+    # start on remote
+    call('git checkout remote')
+    call('git rm diff.ipynb')
     assert not os.path.exists('.gitattributes')
     return repo
 

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -313,3 +313,13 @@ def matching_nb_triplets(request):
     a, b, c = request.param
     print(a, b, c)
     return _db[a], _db[b], _db[c]
+
+
+_port = 62019
+
+
+@fixture()
+def unique_port():
+    global _port
+    _port += 1
+    return _port

--- a/nbdime/tests/test_autoresolve.py
+++ b/nbdime/tests/test_autoresolve.py
@@ -5,12 +5,9 @@
 
 from __future__ import unicode_literals
 
-import pytest
 from nbdime import merge_notebooks
 
 from nbdime.nbmergeapp import _build_arg_parser
-
-from .utils import have_git
 
 # FIXME: Extend tests to more merge situations!
 
@@ -112,8 +109,7 @@ def test_autoresolve_notebook_ignore_fallback():
     assert not any(d.conflict for d in decisions)
 
 
-@pytest.mark.skipif(not have_git, reason="Missing git.")
-def test_autoresolve_inline_source_conflict(db):
+def test_autoresolve_inline_source_conflict(db, needs_git):
     nbb = db["inline-conflict--1"]
     nbl = db["inline-conflict--2"]
     nbr = db["inline-conflict--3"]
@@ -167,4 +163,3 @@ print(x + q)
     expected = builtin_expected_finegrained
 
     assert source == expected
-

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -79,6 +79,26 @@ def test_nbdiff_app_null_file(filespath):
     assert 0 == main_diff(args)
 
 
+def test_nbdiff_app_gitrefs(git_repo2):
+    args = nbdiffapp._build_arg_parser().parse_args(['local', 'remote'])
+    assert 0 == main_diff(args)
+
+    args = nbdiffapp._build_arg_parser().parse_args(['local', 'remote', 'sub/subfile.ipynb'])
+    assert 0 == main_diff(args)
+
+    args = nbdiffapp._build_arg_parser().parse_args(['local', 'remote', 'sub/subfile.ipynb', 'diff.ipynb'])
+    assert 0 == main_diff(args)
+
+    args = nbdiffapp._build_arg_parser().parse_args(['local', 'sub/subfile.ipynb', 'diff.ipynb'])
+    assert 0 == main_diff(args)
+
+    args = nbdiffapp._build_arg_parser().parse_args(['sub/subfile.ipynb'])
+    assert 0 == main_diff(args)
+
+    args = nbdiffapp._build_arg_parser().parse_args([])
+    assert 0 == main_diff(args)
+
+
 def test_nbdiff_app_unicode_safe(filespath):
     afn = os.path.join(filespath, "unicode--1.ipynb")
     bfn = os.path.join(filespath, "unicode--2.ipynb")

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -34,8 +34,6 @@ from nbdime import (
     gitmergedriver,
     gitmergetool,
 )
-import nbdime.webapp.nbdiffweb
-import nbdime.webapp.nbmergeweb
 from nbdime.utils import EXPLICIT_MISSING_FILE
 
 
@@ -442,12 +440,12 @@ def _wait_up(url, interval=0.1, check=None):
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
-def test_difftool(git_repo, request):
+def test_difftool(git_repo, request, unique_port):
     nbdime.gitdifftool.main(['config', '--enable'])
     cmd = get_output('git config --get --local difftool.nbdime.cmd').strip()
 
     # pick a non-random port so we can connect later, and avoid opening a browser
-    port = 62021
+    port = unique_port
     cmd = cmd + ' --port=%i --browser=disabled' % port
     call(['git', 'config', 'difftool.nbdime.cmd', cmd])
 
@@ -481,12 +479,12 @@ def test_difftool(git_repo, request):
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
-def test_mergetool(git_repo, request):
+def test_mergetool(git_repo, request, unique_port):
     nbdime.gitmergetool.main(['config', '--enable'])
     cmd = get_output('git config --get --local mergetool.nbdime.cmd').strip()
 
     # pick a non-random port so we can connect later, and avoid opening a browser
-    port = 62022
+    port = unique_port
     cmd = cmd + ' --port=%i --browser=disabled' % port
     call(['git', 'config', 'mergetool.nbdime.cmd', cmd])
     call(['git', 'config', 'mergetool.nbdime.trustExitCode', 'true'])

--- a/nbdime/tests/test_diff_gitrefs.py
+++ b/nbdime/tests/test_diff_gitrefs.py
@@ -1,0 +1,198 @@
+
+import os
+from six import string_types
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
+
+import pytest
+
+from git import InvalidGitRepositoryError
+
+from ..gitfiles import changed_notebooks
+from ..utils import EXPLICIT_MISSING_FILE
+
+
+# Test that it can diff
+#  - one ref
+#  - two refs
+#  - all of the above with a directory path
+#  - all of the above with a filename path
+#  - all of the above within a subdirectory of the repo
+#  - all of the above with added and removed files in diff
+#  - does not attempt to diff non-Notebook files
+# Fails if:
+#  - path is non-sensical
+#  - path is not a git repo
+#  - one or both references are invalid
+#  - base ref is None
+
+
+def _nb_name(f):
+    if isinstance(f, string_types):
+        return f
+    return f.name
+
+
+_filename = 'diff.ipynb'
+_subdir_name = 'sub'
+_subdir_filename = 'subfile.ipynb'
+_subpath = os.path.join(_subdir_name, _subdir_filename)
+
+
+# Test one/two args:
+
+def test_head_vs_workdir(git_repo2):
+    expected = [
+        ('diff.ipynb (HEAD)', EXPLICIT_MISSING_FILE),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('HEAD', None), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+def test_ref_vs_ref(git_repo2):
+    expected = [
+        ('diff.ipynb (base)', 'diff.ipynb (local)'),
+        ('sub/subfile.ipynb (base)', 'sub/subfile.ipynb (local)'),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('base', 'local'), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+# Test one/two args executed in subdir. Subdir should have no effect without `path` arg:
+
+def test_head_vs_workdir_subdir(git_repo2):
+    os.chdir(os.path.join(git_repo2, _subdir_name))
+    expected = [
+        ('diff.ipynb (HEAD)', EXPLICIT_MISSING_FILE),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('HEAD', None), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+def test_ref_vs_ref_subdir(git_repo2):
+    os.chdir(os.path.join(git_repo2, _subdir_name))
+    expected = [
+        ('diff.ipynb (base)', 'diff.ipynb (local)'),
+        ('sub/subfile.ipynb (base)', 'sub/subfile.ipynb (local)'),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('base', 'local'), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+# Test one/two args with subdir path:
+
+def test_head_vs_workdir_subdir_path(git_repo2):
+    expected = [
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('HEAD', None, _subdir_name), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+def test_ref_vs_ref_subdir_path(git_repo2):
+    expected = [
+        ('sub/subfile.ipynb (base)', 'sub/subfile.ipynb (local)'),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('base', 'local', _subdir_name), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+# Test one/two args with filename path:
+
+def test_head_vs_workdir_filename(git_repo2):
+    expected = [
+        ('diff.ipynb (HEAD)', EXPLICIT_MISSING_FILE),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('HEAD', None, _filename), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+def test_ref_vs_ref_filename(git_repo2):
+    expected = [
+        ('diff.ipynb (base)', 'diff.ipynb (local)'),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('base', 'local', _filename), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+# Test one/two args executed in subdir with filename path:
+
+def test_head_vs_workdir_subdir_filename(git_repo2):
+    expected = [
+    ]
+    os.chdir(os.path.join(git_repo2, _subdir_name))
+    for expected, actual in zip_longest(expected, changed_notebooks('HEAD', None, _subdir_filename), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+def test_ref_vs_ref_subdir_filename(git_repo2):
+    expected = [
+        ('sub/subfile.ipynb (base)', 'sub/subfile.ipynb (local)'),
+    ]
+    os.chdir(os.path.join(git_repo2, _subdir_name))
+    for expected, actual in zip_longest(expected, changed_notebooks('base', 'local', _subdir_filename), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+# Test one/two args with path to file in subdir:
+
+def test_head_vs_workdir_subdir_filename_path(git_repo2):
+    expected = [
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('HEAD', None, _subpath), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+def test_ref_vs_ref_subdir_filename_path(git_repo2):
+    expected = [
+        ('sub/subfile.ipynb (base)', 'sub/subfile.ipynb (local)'),
+    ]
+    for expected, actual in zip_longest(expected, changed_notebooks('base', 'local', _subpath), fillvalue=None):
+        assert _nb_name(actual[0]) == expected[0]
+        assert _nb_name(actual[1]) == expected[1]
+
+
+# Test failure of one/two args with path to invalid file:
+
+def test_head_vs_workdir_non_existant(git_repo2):
+    assert 0 == len(tuple(changed_notebooks('HEAD', None, 'non-existant-file.ipynb')))
+
+
+def test_ref_vs_ref_non_existant(git_repo2):
+    assert 0 == len(tuple(changed_notebooks('base', 'local', 'non-existant-file.ipynb')))
+
+
+# Test failure of one/two args with (invalid) path to file in parent directory:
+
+def test_head_vs_workdir_invalid_path(git_repo2):
+    os.chdir(os.path.join(git_repo2, _subdir_name))
+    assert 0 == len(tuple(changed_notebooks('HEAD', None, _filename)))
+
+
+def test_ref_vs_ref_invalid_path(git_repo2):
+    os.chdir(os.path.join(git_repo2, _subdir_name))
+    assert 0 == len(tuple(changed_notebooks('base', 'local', _filename)))
+
+
+# Test failure for invalid directory path
+def test_head_vs_workdir_invalid_subdir(git_repo2):
+    assert 0 == len(tuple(changed_notebooks('HEAD', None, 'non-existant-dir')))
+
+
+# Test failure outside git repo
+def test_no_repo(tmpdir):
+    tmpdir.chdir()
+    with pytest.raises(InvalidGitRepositoryError):
+        tuple(changed_notebooks('HEAD', None))

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -4,12 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 from __future__ import unicode_literals
-try:
-    from shutil import which
-except ImportError:
-    from backports.shutil_which import which
 
-import pytest
 import mock
 import os
 from os.path import join as pjoin
@@ -44,8 +39,8 @@ expected_output = """nbdiff {0} {1}
 
 """
 
-@pytest.mark.skipif(not which('git'), reason="Missing git.")
-def test_git_diff_driver(capsys, nocolor):
+
+def test_git_diff_driver(capsys, nocolor, needs_git):
     # Simulate a call from `git diff` to check basic driver functionality
     test_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/nbdime/tests/test_utils.py
+++ b/nbdime/tests/test_utils.py
@@ -3,23 +3,18 @@ import os
 import shutil
 import tempfile
 
-try:
-    from shutil import which
-except ImportError:
-    from backports.shutil_which import which
-
-import pytest
-
 from nbdime.utils import (
     strings_to_lists, revert_strings_to_lists, is_in_repo,
     locate_gitattributes
 )
+
 
 def test_string_to_lists():
     obj = {"c": [{"s": "ting\ntang", "o": [{"ot": "stream"}]}]}
     obj2 = strings_to_lists(obj)
     obj3 = revert_strings_to_lists(obj2)
     assert obj3 == obj
+
 
 def test_is_repo():
     try:
@@ -52,14 +47,12 @@ def test_locate_gitattributes_local(git_repo):
     assert gitattr is not None
 
 
-@pytest.mark.skipif(not which('git'), reason="Missing git.")
-def test_locate_gitattributes_global():
+def test_locate_gitattributes_global(needs_git):
     gitattr = locate_gitattributes(scope='global')
     assert gitattr is not None
 
 
-@pytest.mark.skipif(not which('git'), reason="Missing git.")
-def test_locate_gitattributes_system():
+def test_locate_gitattributes_system(needs_git):
     gitattr = locate_gitattributes(scope='system')
     assert gitattr is not None
 

--- a/nbdime/tests/test_web.py
+++ b/nbdime/tests/test_web.py
@@ -36,6 +36,17 @@ def test_diff_web(filespath, unique_port):
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
+def test_diff_web_gitrefs(git_repo2, unique_port):
+    a = 'local'
+    b = 'remote'
+    c = 'diff.ipynb'
+    d = 'sub/subfile.ipynb'
+    loop = ioloop.IOLoop.current()
+    loop.call_later(0, loop.stop)
+    nbdime.webapp.nbdiffweb.main(['--port=%i' % unique_port, '--browser=disabled', a, b, c, d])
+
+
+@pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
 def test_merge_web(filespath, unique_port):
     a = os.path.join(filespath, merge_a)
     b = os.path.join(filespath, merge_b)

--- a/nbdime/tests/test_web.py
+++ b/nbdime/tests/test_web.py
@@ -27,24 +27,22 @@ merge_c = 'multilevel-test-remote.ipynb'
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
-def test_diff_web(filespath):
-    port = 62023
+def test_diff_web(filespath, unique_port):
     a = os.path.join(filespath, diff_a)
     b = os.path.join(filespath, diff_b)
     loop = ioloop.IOLoop.current()
     loop.call_later(0, loop.stop)
-    nbdime.webapp.nbdiffweb.main(['--port=%i' % port, '--browser=disabled', a, b])
+    nbdime.webapp.nbdiffweb.main(['--port=%i' % unique_port, '--browser=disabled', a, b])
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
-def test_merge_web(filespath):
-    port = 62024
+def test_merge_web(filespath, unique_port):
     a = os.path.join(filespath, merge_a)
     b = os.path.join(filespath, merge_b)
     c = os.path.join(filespath, merge_c)
     loop = ioloop.IOLoop.current()
     loop.call_later(0, loop.stop)
-    nbdime.webapp.nbmergeweb.main(['--port=%i' % port, '--browser=disabled', a, b, c])
+    nbdime.webapp.nbmergeweb.main(['--port=%i' % unique_port, '--browser=disabled', a, b, c])
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -25,7 +25,8 @@ def read_notebook(filename, on_null):
 
     Parameters:
         filename: The filename to read from or null filename
-            ("/dev/null" on *nix, "nul" on Windows)
+            ("/dev/null" on *nix, "nul" on Windows).
+            Alternatively a file-like object can be passed.
         on_null: What to return when filename null
             "empty": return empty dict
             "minimal": return miminal valid notebook

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -20,18 +20,18 @@ else:
     EXPLICIT_MISSING_FILE = '/dev/null'
 
 
-def read_notebook(filename, on_null):
+def read_notebook(f, on_null):
     """Read and return notebook json from filename
 
     Parameters:
-        filename: The filename to read from or null filename
+        f:  The filename to read from or null filename
             ("/dev/null" on *nix, "nul" on Windows).
             Alternatively a file-like object can be passed.
         on_null: What to return when filename null
             "empty": return empty dict
             "minimal": return miminal valid notebook
     """
-    if filename == EXPLICIT_MISSING_FILE:
+    if f == EXPLICIT_MISSING_FILE:
         if on_null == 'empty':
             return {}
         elif on_null == 'minimal':
@@ -41,7 +41,7 @@ def read_notebook(filename, on_null):
                 'Not valid value for `on_null`: "%s". Valid values '
                 'are "empty" or "minimal"', on_null)
     else:
-        return nbformat.read(filename, as_version=4)
+        return nbformat.read(f, as_version=4)
 
 
 def as_text(text):
@@ -246,7 +246,7 @@ def find_shared_prefix(a, b):
 
 def _setup_std_stream_encoding():
     """Setup encoding on stdout/err
-    
+
     Ensures sys.stdout/err have error-escaping encoders,
     rather than raising errors.
     """
@@ -274,7 +274,7 @@ def _setup_std_stream_encoding():
 
 def setup_std_streams():
     """Setup sys.stdout/err
-    
+
     - Ensures sys.stdout/err have error-escaping encoders,
       rather than raising errors.
     - enables colorama for ANSI escapes on Windows

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 from ..args import (
     add_generic_args, add_diff_args, add_web_args, add_filename_args,
-    args_for_server, args_for_browse, process_diff_args)
+    args_for_server, args_for_browse, process_diff_flags)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 import nbdime.log
@@ -42,7 +42,7 @@ def main_parsed(opts):
     Called by both main here and gitdifftool
     """
     nbdime.log.init_logging(level=opts.log_level)
-    process_diff_args(opts)
+    process_diff_flags(opts)
     base = opts.local
     remote = opts.remote
     return run_server(

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -41,8 +41,8 @@ def build_arg_parser():
         nargs='?', default=None,
     )
     parser.add_argument(
-        "path", help="Filter diffs for git-revisions based on path",
-        nargs='?', default=None,
+        "paths", help="Filter diffs for git-revisions based on path",
+        nargs='*', default=None,
     )
     return parser
 

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -14,7 +14,7 @@ from .webutil import browse as browse_util
 from ..args import (
     add_generic_args, add_web_args, add_diff_args,
     args_for_server, args_for_browse, process_diff_args)
-from ..gitfiles import changed_notebooks, is_valid_gitref
+from ..gitfiles import changed_notebooks, is_gitref
 import nbdime.log
 
 
@@ -52,10 +52,6 @@ def browse(port, base, remote, browser):
         'This function is deprecated. '
         'Use nbdime.webapp.webutil.browse() instead.',
         DeprecationWarning)
-
-
-def is_gitref(candidate):
-    return is_valid_gitref(candidate) and (candidate is None or not os.path.exists(candidate))
 
 
 def handle_gitrefs(base, remote, arguments):

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -33,9 +33,11 @@ def build_arg_parser():
     add_diff_args(parser)
     parser.add_argument(
         "base", help="The base notebook filename OR base git-revision.",
+        nargs='?', default='HEAD',
     )
     parser.add_argument(
         "remote", help="The remote modified notebook filename OR remote git-revision.",
+        nargs='?', default=None,
     )
     return parser
 

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 from ..args import (
     add_generic_args, add_filename_args, add_diff_args, add_merge_args,
-    add_web_args, args_for_server, args_for_browse, process_diff_args)
+    add_web_args, args_for_server, args_for_browse, process_diff_flags)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 import nbdime.log
@@ -43,7 +43,7 @@ def main_parsed(opts):
     Called by both main here and gitmergetool
     """
     nbdime.log.init_logging(level=opts.log_level)
-    process_diff_args(opts)
+    process_diff_flags(opts)
     base = opts.base
     local = opts.local
     remote = opts.remote

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 from ..args import (add_generic_args, add_diff_args, add_merge_args,
     add_web_args, add_filename_args, args_for_server, args_for_browse,
-    process_diff_args)
+    process_diff_flags)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 import nbdime.log
@@ -43,7 +43,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
-    process_diff_args(arguments)
+    process_diff_flags(arguments)
     base = arguments.base
     local = arguments.local
     remote = arguments.remote

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,8 @@ install_requires = setuptools_args['install_requires'] = [
     'six',
     'colorama',
     'tornado',
-    'requests'
+    'requests',
+    'GitPython',  # For difftool taking git refs
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
 As git's difftool does not work concurrently with diff driver installed, we allow nbdiff-web to take git refs. For consistency, nbdiff has also been modified to accept them.

Fixes #147.