### PR TITLE
Fix web-merge decision align

### DIFF
--- a/nbdime-web/src/common/util.ts
+++ b/nbdime-web/src/common/util.ts
@@ -176,11 +176,11 @@ function isPrefixArray(parent: any[] | null, child: any[] | null): boolean {
 }
 
 /**
- * Sort array by attribute `key` (i.e. compare by array[0][key] < array[1][key])
+ * Sort array by attribute `key` (i.e. compare by array[0][key] < array[1][key]). Stable.
  */
 export
 function sortByKey<T extends {[key: string]: any}>(array: T[], key: string): T[] {
-    return array.sort(function(a, b) {
+    return stableSort(array, function(a, b) {
         let x = a[key]; let y = b[key];
         return ((x < y) ? -1 : ((x > y) ? 1 : 0));
     });
@@ -228,4 +228,25 @@ function accumulateLengths(arr: string[]) {
 export
 function unique<T>(value: T, index: number, self: T[]): boolean {
   return self.indexOf(value) === index;
+}
+
+
+/**
+ * Similar to Array.sort, but guaranteed to keep order stable
+ * when compare function returns 0
+ */
+export
+function stableSort<T>(arr: T[], compare: (a: T, b: T) => number): T[] {
+  let sorters: {index: number, key: T}[] = [];
+  for (let i=0; i < arr.length; ++i) {
+    sorters.push({index: i, key: arr[i]});
+  }
+  sorters = sorters.sort((a: {index: number, key: T}, b: {index: number, key: T}): number => {
+    return compare(a.key, b.key) || a.index - b.index;
+  });
+  let out: T[] = new Array<T>(arr.length);
+  for (let i=0; i < arr.length; ++i) {
+    out[i] = arr[sorters[i].index];
+  }
+  return out;
 }

--- a/nbdime-web/src/merge/decisions.ts
+++ b/nbdime-web/src/merge/decisions.ts
@@ -594,21 +594,21 @@ function _mergeTree(tree: DiffTree, sortedPaths: string[]): IDiffEntry[] {
   let trunk: IDiffEntry[] = [];
   let root: DecisionPath | null = null;
   for (let i = 0; i < sortedPaths.length; ++i) {
-    let pathStr = sortedPaths[i];
-    let path = tree[pathStr].path;
-    let nextPath: DecisionPath | null = null;
+    let path = tree[sortedPaths[i]].path;
+    let subdiffs = tree[sortedPaths[i]].diff;
+    trunk = trunk.concat(subdiffs);
+
+    let nextPath: DecisionPath | null;
     if (i === sortedPaths.length - 1) {
       nextPath = root;
     } else {
-      let nextPathStr = sortedPaths[i + 1];
-      nextPath = tree[nextPathStr].path;
+      nextPath = tree[sortedPaths[i + 1]].path;
     }
-    let subdiffs = tree[pathStr].diff;
-    trunk = trunk.concat(subdiffs);
+
     // First, check if path is subpath of nextPath:
     if (isPrefixArray(nextPath, path)) {
       // We can simply promote existing diffs to next path
-      if (nextPath) {
+      if (nextPath !== null) {
         trunk = pushPath(trunk, path.slice(nextPath.length));
         root = nextPath;
       }

--- a/nbdime-web/src/merge/model/cell.ts
+++ b/nbdime-web/src/merge/model/cell.ts
@@ -390,7 +390,6 @@ class CellMergeModel extends ObjectMergeModel<nbformat.ICell, CellDiffModel> {
           splitDec.remoteDiff[0] as IDiffPatchObject : null;
 
         let subDecisions = this.splitPatch(splitDec, localDiff, remoteDiff);
-        resolveCommonPaths(subDecisions);
         // Add all split decisions:
         for (let subdec of subDecisions) {
           subdec.level = 2;
@@ -568,8 +567,10 @@ class CellMergeModel extends ObjectMergeModel<nbformat.ICell, CellDiffModel> {
         er ? [er] : null,
         action,
         md.conflict));
-    };
-    return this.splitOnSourceChunks(split);
+    }
+    let ret = this.splitOnSourceChunks(split);
+    resolveCommonPaths(ret);
+    return stableSort(ret, decisionSortKey);
   }
 
   /**

--- a/nbdime-web/src/merge/model/cell.ts
+++ b/nbdime-web/src/merge/model/cell.ts
@@ -38,7 +38,7 @@ import {
 } from '../../patch';
 
 import {
-  arraysEqual, valueIn, hasEntries, splitLines, unique
+  arraysEqual, valueIn, hasEntries, splitLines, unique, stableSort
 } from '../../common/util';
 
 import {
@@ -589,7 +589,7 @@ class CellMergeModel extends ObjectMergeModel<nbformat.ICell, CellDiffModel> {
         dec.level = 3;
         let sub = splitMergeDecisionsOnChunks(base, [dec]);
         resolveCommonPaths(sub);
-        out = out.concat(sub.sort(decisionSortKey));
+        out = out.concat(stableSort(sub, decisionSortKey));
       } else {
         out.push(dec);
       }

--- a/nbdime-web/src/merge/model/notebook.ts
+++ b/nbdime-web/src/merge/model/notebook.ts
@@ -7,7 +7,7 @@ import {
 } from '@jupyterlab/services';
 
 import {
-  arraysEqual, valueIn, hasEntries
+  arraysEqual, valueIn, hasEntries, stableSort
 } from '../../common/util';
 
 import {
@@ -345,7 +345,7 @@ function splitCellListPatch(mergeDecisions: MergeDecision[]): MergeDecision[] {
         ));
     }
   }
-  return output.sort(decisionSortKey);
+  return stableSort(output, decisionSortKey);
 }
 
 


### PR DESCRIPTION
Fixes #238.

Fixes two issues in web-merge:
 - Uses stable sort for sorting decisions. This is not guaranteed for javascripts `Array.sort`.
 - Ensures that `CellDiffModel.splitPatch()` returns sorted decisions. The extra sort step was needed since we split the diff.