### PR TITLE
Diff options

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -9,6 +9,8 @@ import os
 
 from ._version import __version__
 from .log import init_logging, set_nbdime_log_level
+from .diffing.notebooks import set_notebook_diff_targets
+
 
 class LogLevelAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -16,6 +18,62 @@ class LogLevelAction(argparse.Action):
         level = getattr(logging, values)
         init_logging(level=level)
         set_nbdime_log_level(level)
+
+
+class IgnorableAction(argparse.Action):
+    """Adds the supplied positive options and negative/ignore version as well"""
+
+    def __init__(self, option_strings, dest, default=None, required=False, help=None):
+        opts = []
+        for opt in option_strings:
+            if len(opt) == 2 and opt[0] == '-':
+                if not opt[1].islower():
+                    raise ValueError('Single character flags should be lower-case for IgnorableAction')
+                opts.append(opt)
+                opts.append(opt.upper())
+            elif opt[:2] == '--':
+                opts.append(opt)
+                opts.append('--ignore-' + opt[2:])
+            else:
+                ValueError('Could not turn option "%s" into an IgnoreAction option.')
+
+        # Put positives first, negatives last:
+        opts = opts[0::2] + opts[1::2]
+
+        super(IgnorableAction, self).__init__(
+            opts, dest, nargs=0, const=None,
+            default=default, required=required,
+            help=help)
+
+    def __call__(self, parser, ns, values, option_string):
+        if len(option_string) == 2:
+            setattr(ns, self.dest, option_string[1].islower())
+        else:
+            setattr(ns, self.dest, option_string[2:2 + len('ignore')] != 'ignore')
+
+
+def process_exclusive_ignorables(ns, arg_names, default=True):
+    """Parse a set of ignorables.
+
+    It checks that all specified options are either all positive or all negative.
+    It then returns a namespace with the parsed options.
+    """
+    state = getattr(ns, arg_names[0])
+    for name in arg_names[1:]:
+        opt = getattr(ns, name)
+        if state is None:
+            state = opt
+        elif state != opt and opt is not None:
+            message = 'Arguments must either all be negative or all positive: %r' % (arg_names,)
+            raise argparse.ArgumentError(None, message)
+    if state is None:
+        state = not default
+
+    # Set all unset to the opposite of state (if all specified are True, others are False and vice versa)
+    for name in arg_names:
+        if getattr(ns, name) is None:
+            setattr(ns, name, not state)
+
 
 def add_generic_args(parser):
     """Adds a set of arguments common to all nbdime commands.
@@ -105,14 +163,38 @@ def add_diff_args(parser):
         Merge applications also performs diff operations to compute
         the merge, so these arguments should also be included there.
     """
-    # TODO: Add diff strategy options that are reusable for the
-    # merge command here
-
     # TODO: Define sensible strategy variables and implement
     #parser.add_argument('-d', '--diff-strategy',
     #                    default="default", choices=("foo", "bar"),
     #                    help="specify the diff strategy to use.")
-    pass
+
+    # Things we can choose to diff or not
+    ignorables = parser.add_argument_group(
+        title='ignorables',
+        description='Set which parts of the notebook (not) to process.')
+    ignorables.add_argument(
+        '-s', '--sources',
+        action=IgnorableAction,
+        help="process/ignore sources.")
+    ignorables.add_argument(
+        '-o', '--outputs',
+        action=IgnorableAction,
+        help="process/ignore outputs.")
+    ignorables.add_argument(
+        '-a', '--attachments',
+        action=IgnorableAction,
+        help="process/ignore attachments.")
+    ignorables.add_argument(
+        '-m', '--metadata',
+        action=IgnorableAction,
+        help="process/ignore metadata.")
+
+
+def process_diff_args(args):
+    exclusives = ('sources', 'outputs', 'attachments', 'metadata')
+    process_exclusive_ignorables(args, exclusives)
+    set_notebook_diff_targets(args.sources, args.outputs,
+                              args.attachments, args.metadata)
 
 
 def add_merge_args(parser):

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -58,21 +58,27 @@ def process_exclusive_ignorables(ns, arg_names, default=True):
     It checks that all specified options are either all positive or all negative.
     It then returns a namespace with the parsed options.
     """
-    state = getattr(ns, arg_names[0])
+    # `toggle` tracks wheter:
+    #  - True: One or more positive options were defined
+    #  - False: One or more negative options were defined
+    #  - None: No options were defined
+    toggle = getattr(ns, arg_names[0])
     for name in arg_names[1:]:
         opt = getattr(ns, name)
-        if state is None:
-            state = opt
-        elif state != opt and opt is not None:
+        if toggle is None:
+            toggle = opt
+        elif toggle != opt and opt is not None:
             message = 'Arguments must either all be negative or all positive: %r' % (arg_names,)
             raise argparse.ArgumentError(None, message)
-    if state is None:
-        state = not default
 
-    # Set all unset to the opposite of state (if all specified are True, others are False and vice versa)
+    if toggle is not None:
+        # One or more options were defined, set default to the opposite
+        default = not toggle
+
+    # Set all unset options to the default
     for name in arg_names:
         if getattr(ns, name) is None:
-            setattr(ns, name, not state)
+            setattr(ns, name, default)
 
 
 def add_generic_args(parser):

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -120,7 +120,7 @@ def add_merge_args(parser):
     """
     from .merging.notebooks import cli_conflict_strategies, cli_conflict_strategies_input, cli_conflict_strategies_output
     parser.add_argument(
-        '-m', '--merge-strategy',
+        '--merge-strategy',
         default="inline",
         choices=cli_conflict_strategies,
         help="Specify the merge strategy to use.")

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -58,7 +58,7 @@ def process_exclusive_ignorables(ns, arg_names, default=True):
     It checks that all specified options are either all positive or all negative.
     It then returns a namespace with the parsed options.
     """
-    # `toggle` tracks wheter:
+    # `toggle` tracks whether:
     #  - True: One or more positive options were defined
     #  - False: One or more negative options were defined
     #  - None: No options were defined

--- a/nbdime/gitmergedriver.py
+++ b/nbdime/gitmergedriver.py
@@ -90,7 +90,7 @@ def main(args=None):
 
     # TODO: support git-config-specified conflict markers inside sources
     merge_parser.add_argument('marker')
-    merge_parser.add_argument('output', nargs='?')
+    merge_parser.add_argument('out', nargs='?')
     # "The merge driver can learn the pathname in which the merged result will
     # be stored via placeholder %P"
     # - NOTE: This is not where the driver should store its output, see below!
@@ -108,7 +108,7 @@ def main(args=None):
         # "The merge driver is expected to leave the result of the merge in the
         # file named with %A by overwriting it, and exit with zero status if it
         # managed to merge them cleanly, or non-zero if there were conflicts."
-        opts.output = opts.local
+        opts.out = opts.local
         # mergeapp expects an additional decisions arg:
         opts.decisions = False
         return nbmergeapp.main_merge(opts)

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -15,7 +15,8 @@ import json
 import nbdime
 from nbdime.diffing.notebooks import diff_notebooks
 from nbdime.prettyprint import pretty_print_notebook_diff
-from nbdime.args import add_generic_args, add_diff_args, add_filename_args
+from nbdime.args import (
+    add_generic_args, add_diff_args, add_filename_args, process_diff_args)
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 
 
@@ -27,6 +28,8 @@ def main_diff(args):
     afn = args.base
     bfn = args.remote
     dfn = args.out
+
+    process_diff_args(args)
 
     for fn in (afn, bfn):
         if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -46,7 +46,7 @@ def main_diff(args):
 
     # Output diff:
     if dfn:
-        with io.open(dfn, "w", encoding="utf8") as df:
+        with open(dfn, "w") as df:
             # Compact version:
             #json.dump(d, df)
             # Verbose version:

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -10,7 +10,6 @@ import io
 import os
 import sys
 import argparse
-import nbformat
 import json
 
 import nbdime
@@ -24,9 +23,10 @@ _description = "Compute the difference between two Jupyter notebooks."
 
 
 def main_diff(args):
+    # Get input notebooks:
     afn = args.base
     bfn = args.remote
-    dfn = args.output
+    dfn = args.out
 
     for fn in (afn, bfn):
         if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:
@@ -38,8 +38,10 @@ def main_diff(args):
     a = read_notebook(afn, on_null='empty')
     b = read_notebook(bfn, on_null='empty')
 
+    # Perform actual diff:
     d = diff_notebooks(a, b)
 
+    # Output diff:
     if dfn:
         with io.open(dfn, "w", encoding="utf8") as df:
             # Compact version:
@@ -69,7 +71,7 @@ def _build_arg_parser():
     add_filename_args(parser, ["base", "remote"])
 
     parser.add_argument(
-        '-o', '--output',
+        '--out',
         default=None,
         help="if supplied, the diff is written to this file. "
              "Otherwise it is printed to the terminal.")

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -27,7 +27,7 @@ def main_merge(args):
     bfn = args.base
     lfn = args.local
     rfn = args.remote
-    mfn = args.output
+    mfn = args.out
 
     for fn in (bfn, lfn, rfn):
         if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:
@@ -110,7 +110,7 @@ def _build_arg_parser():
     add_filename_args(parser, ["base", "local", "remote"])
 
     parser.add_argument(
-        '-o', '--output',
+        '--out',
         default=None,
         help="if supplied, the merged notebook is written "
              "to this file. Otherwise it is printed to the "

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -29,6 +29,9 @@ def main_merge(args):
     rfn = args.remote
     mfn = args.out
 
+    from .args import process_diff_args
+    process_diff_args(args)
+
     for fn in (bfn, lfn, rfn):
         if not os.path.exists(fn) and fn != EXPLICIT_MISSING_FILE:
             nbdime.log.error("Cannot find file '{}'".format(fn))

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -13,7 +13,7 @@ import nbformat
 
 import nbdime
 from nbdime.prettyprint import pretty_print_notebook
-from nbdime.args import add_generic_args
+from nbdime.args import add_generic_args, IgnorableAction, process_exclusive_ignorables
 from nbdime.utils import setup_std_streams
 
 
@@ -73,28 +73,23 @@ def _build_arg_parser():
     # Things we can choose to show or not
     parser.add_argument(
         '-s', '--sources',
-        action="store_true",
-        default=False,
+        action=IgnorableAction,
         help="show sources.")
     parser.add_argument(
         '-o', '--outputs',
-        action="store_true",
-        default=False,
+        action=IgnorableAction,
         help="show outputs.")
     parser.add_argument(
         '-a', '--attachments',
-        action="store_true",
-        default=False,
+        action=IgnorableAction,
         help="show attachments.")
     parser.add_argument(
         '-m', '--metadata',
-        action="store_true",
-        default=False,
+        action=IgnorableAction,
         help="show metadata.")
     parser.add_argument(
         '-d', '--details',
-        action="store_true",
-        default=False,
+        action=IgnorableAction,
         help="show details not covered by other options.")
 
     return parser
@@ -105,6 +100,9 @@ def main(args=None):
         args = sys.argv[1:]
     setup_std_streams()
     arguments = _build_arg_parser().parse_args(args)
+    process_exclusive_ignorables(
+        arguments,
+        ('sources', 'outputs', 'attachments', 'metadata', 'details'))
     nbdime.log.init_logging(level=arguments.log_level)
     return main_show(arguments)
 

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -6,18 +6,15 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
-import io
 import os
 import sys
 import argparse
 import nbformat
-import json
 
 import nbdime
 from nbdime.prettyprint import pretty_print_notebook
-from nbdime.args import add_generic_args, add_filename_args
+from nbdime.args import add_generic_args
 from nbdime.utils import setup_std_streams
-
 
 
 _description = """Show a Jupyter notebook in terminal.

--- a/nbdime/tests/files/mixed-conflicts--1.ipynb
+++ b/nbdime/tests/files/mixed-conflicts--1.ipynb
@@ -160,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/nbdime/tests/files/mixed-conflicts--2.ipynb
+++ b/nbdime/tests/files/mixed-conflicts--2.ipynb
@@ -75,7 +75,8 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": ["foo"]
    },
    "outputs": [
     {

--- a/nbdime/tests/files/mixed-conflicts--2.ipynb
+++ b/nbdime/tests/files/mixed-conflicts--2.ipynb
@@ -93,7 +93,9 @@
       ]
      },
      "execution_count": 1,
-     "metadata": {},
+     "metadata": {
+      "foo": 3
+    },
      "output_type": "execute_result"
     },
     {

--- a/nbdime/tests/files/mixed-conflicts--3.ipynb
+++ b/nbdime/tests/files/mixed-conflicts--3.ipynb
@@ -75,7 +75,8 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "tags": ["bar"]
    },
    "outputs": [
     {
@@ -92,7 +93,9 @@
       ]
      },
      "execution_count": 1,
-     "metadata": {},
+     "metadata": {
+      "foo": 5
+     },
      "output_type": "execute_result"
     },
     {
@@ -157,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -88,6 +88,38 @@ def test_nbdiff_app_unicode_safe(filespath):
     check_call([sys.executable, '-m', 'nbdime.nbdiffapp', afn, bfn], env=env)
 
 
+def test_nbdiff_app_only_source(filespath, tmpdir):
+    afn = os.path.join(filespath, "multilevel-test-base.ipynb")
+    bfn = os.path.join(filespath, "multilevel-test-local.ipynb")
+    dfn = os.path.join(tmpdir.dirname, "diff_output.json")
+
+    args = nbdiffapp._build_arg_parser().parse_args([afn, bfn, '--out', dfn, '-s'])
+    assert 0 == main_diff(args)
+    with io.open(dfn) as df:
+        diff = json.load(df)
+    for key in ('cells', 1, 'source'):
+        assert len(diff) == 1
+        assert diff[0]['key'] == key
+        assert diff[0]['op'] == 'patch'
+        diff = diff[0]['diff']
+
+
+def test_nbdiff_app_ignore_source(filespath, tmpdir):
+    afn = os.path.join(filespath, "multilevel-test-base.ipynb")
+    bfn = os.path.join(filespath, "multilevel-test-local.ipynb")
+    dfn = os.path.join(tmpdir.dirname, "diff_output.json")
+
+    args = nbdiffapp._build_arg_parser().parse_args([afn, bfn, '--out', dfn, '-S'])
+    assert 0 == main_diff(args)
+    with io.open(dfn) as df:
+        diff = json.load(df)
+    for key in ('cells', 2, 'outputs'):
+        assert len(diff) == 1
+        assert diff[0]['key'] == key
+        assert diff[0]['op'] == 'patch'
+        diff = diff[0]['diff']
+
+
 def test_nbmerge_app(tempfiles, capsys):
     bfn = os.path.join(tempfiles, "multilevel-test-base.ipynb")
     lfn = os.path.join(tempfiles, "multilevel-test-local.ipynb")

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -102,7 +102,7 @@ def test_nbmerge_app(tempfiles, capsys):
 
     nb_stdout, err = capsys.readouterr()
 
-    assert 0 == nbmergeapp.main([bfn, lfn, rfn, '-o', ofn])
+    assert 0 == nbmergeapp.main([bfn, lfn, rfn, '--out', ofn])
     out, err = capsys.readouterr()
     # no stdout when sending output to file
     assert out == ''
@@ -159,7 +159,7 @@ def test_nbmerge_app_conflict(tempfiles, capsys):
     assert 1 == nbmergeapp.main([bfn, lfn, rfn])
     nb_stdout, err = capsys.readouterr()
 
-    assert 1 == nbmergeapp.main([bfn, lfn, rfn, '-o', ofn])
+    assert 1 == nbmergeapp.main([bfn, lfn, rfn, '--out', ofn])
     out, err = capsys.readouterr()
     # no stdout when sending output to file
     assert out == ''
@@ -178,7 +178,7 @@ def test_nbmerge_app_decisions(tempfiles, capsys, reset_log):
     rfn = os.path.join(tempfiles, "inline-conflict--3.ipynb")
     ofn = os.path.join(tempfiles, "inline-conflict-out.ipynb")
 
-    assert 1 == nbmergeapp.main([bfn, lfn, rfn, '--decisions', '-o', ofn])
+    assert 1 == nbmergeapp.main([bfn, lfn, rfn, '--decisions', '--out', ofn])
     out, err = capsys.readouterr()
     # decisions are logged to stderr:
     assert 'conflicted decisions' in err

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 from ..args import (
     add_generic_args, add_diff_args, add_web_args, add_filename_args,
-    args_for_server, args_for_browse)
+    args_for_server, args_for_browse, process_diff_args)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 import nbdime.log
@@ -42,6 +42,7 @@ def main_parsed(opts):
     Called by both main here and gitdifftool
     """
     nbdime.log.init_logging(level=opts.log_level)
+    process_diff_args(opts)
     base = opts.local
     remote = opts.remote
     return run_server(

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -12,7 +12,7 @@ from .nbdimeserver import main_server as run_server
 from .webutil import browse as browse_util
 from ..args import (
     add_generic_args, add_web_args, add_diff_args, add_filename_args,
-    args_for_server, args_for_browse)
+    args_for_server, args_for_browse, process_diff_args)
 import nbdime.log
 
 
@@ -49,6 +49,7 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
+    process_diff_args(arguments)
     nbdime.log.init_logging(level=arguments.log_level)
     base = arguments.base
     remote = arguments.remote

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -33,11 +33,6 @@ def build_arg_parser(parser=None):
     add_diff_args(parser)
     add_merge_args(parser)
     add_web_args(parser, 0)
-    parser.add_argument(
-        '-o', '--output',
-        default=None,
-        help="if supplied, the merged notebook is written "
-             "to this file. Otherwise it cannot be saved.")
     add_filename_args(parser, ["base", "local", "remote", "merged"])
     return parser
 

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 from ..args import (
     add_generic_args, add_filename_args, add_diff_args, add_merge_args,
-    add_web_args, args_for_server, args_for_browse)
+    add_web_args, args_for_server, args_for_browse, process_diff_args)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 import nbdime.log
@@ -43,6 +43,7 @@ def main_parsed(opts):
     Called by both main here and gitmergetool
     """
     nbdime.log.init_logging(level=opts.log_level)
+    process_diff_args(opts)
     base = opts.base
     local = opts.local
     remote = opts.remote

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -30,7 +30,7 @@ def build_arg_parser():
     add_web_args(parser, 0)
     add_filename_args(parser, ["base", "local", "remote"])
     parser.add_argument(
-        '-o', '--output',
+        '--out',
         default=None,
         help="if supplied, the merged notebook is written "
              "to this file. Otherwise it cannot be saved.")
@@ -45,7 +45,7 @@ def main(args=None):
     base = arguments.base
     local = arguments.local
     remote = arguments.remote
-    output = arguments.output
+    output = arguments.out
     return run_server(
         closable=True,
         outputfilename=output,

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -8,7 +8,8 @@ import sys
 from argparse import ArgumentParser
 
 from ..args import (add_generic_args, add_diff_args, add_merge_args,
-    add_web_args, add_filename_args, args_for_server, args_for_browse)
+    add_web_args, add_filename_args, args_for_server, args_for_browse,
+    process_diff_args)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 import nbdime.log
@@ -42,6 +43,7 @@ def main(args=None):
         args = sys.argv[1:]
     arguments = build_arg_parser().parse_args(args)
     nbdime.log.init_logging(level=arguments.log_level)
+    process_diff_args(arguments)
     base = arguments.base
     local = arguments.local
     remote = arguments.remote


### PR DESCRIPTION
Adds flags to diff/merge apps to selectively perform diff/merge on source, outputs, attachments, metadata, or any combination of these. 

Examples:
```
nbdiff a.ipynb b.ipynb -s    # Only considers source for diff

nbdiff a.ipynb b.ipynb -o    # Only considers outputs for diff

nbdiff a.ipynb b.ipynb -O    # Considers everything *except* outputs for diff

nbdiff a.ipynb b.ipynb --ignore-outputs    # Long form of previous

nbdiff a.ipynb b.ipynb -sm    # Only considers source and metadata for diff

nbdiff a.ipynb b.ipynb -sM    # Will give an error, as combination of flags doesn't make sense
```

`nbmerge ` will take the same flags (anything not covered by flags should keep base value).

(Note that due to an detail of how the differ lookup works, cell's `execution_count` does not currently fall into any group, and is therefore always included).

Resolves #273.

### TODO
 - [ ] Document feature