### PR TITLE
Webapps: Add checkbox to hide unchanged cells

### DIFF
--- a/nbdime-web/src/diff/widget/cell.ts
+++ b/nbdime-web/src/diff/widget/cell.ts
@@ -55,6 +55,7 @@ import {
 const PROMPT_CLASS = 'jp-Cell-prompt';
 
 
+export
 const CELLDIFF_CLASS = 'jp-Cell-diff';
 
 const EXECUTIONCOUNT_ROW_CLASS = 'jp-Cellrow-executionCount';

--- a/nbdime-web/src/merge/widget/cell.ts
+++ b/nbdime-web/src/merge/widget/cell.ts
@@ -62,6 +62,7 @@ import {
 } from './common';
 
 
+export
 const CELLMERGE_CLASS = 'jp-Cell-merge';
 const CELL_HEADER_CLASS = 'jp-Merge-cellHeader';
 const CELL_HEADER_TITLE_CLASS = 'jp-Merge-cellHeader-title';

--- a/nbdime-web/src/merge/widget/cell.ts
+++ b/nbdime-web/src/merge/widget/cell.ts
@@ -55,7 +55,7 @@ import {
 } from './output';
 
 import {
-  createCheckbox,
+  createCheckbox, UNCHANGED_MERGE_CLASS,
   ONEWAY_LOCAL_CLASS, ONEWAY_REMOTE_CLASS,
   TWOWAY_ADDITION_CLASS, TWOWAY_DELETION_CLASS,
   MERGE_CLASSES
@@ -162,6 +162,13 @@ class CellMergeWidget extends Panel {
     let CURR_CLASSES = MERGE_CLASSES.slice();  // copy
 
     this.createHeader();
+
+    // Mark cells that have no changes:
+    if (model.merged.unchanged &&
+        model.local && model.local.unchanged &&
+        model.remote && model.remote.unchanged) {
+      this.addClass(UNCHANGED_MERGE_CLASS);
+    }
 
     /*
      Two different display layouts depending on cell merge type:

--- a/nbdime-web/src/merge/widget/common.ts
+++ b/nbdime-web/src/merge/widget/common.ts
@@ -8,6 +8,7 @@ import {
 
 
 // Merge classes:
+export const UNCHANGED_MERGE_CLASS = 'jp-Merge-unchanged';
 export const ONEWAY_LOCAL_CLASS = 'jp-Merge-oneway-local';
 export const ONEWAY_REMOTE_CLASS = 'jp-Merge-oneway-remote';
 export const TWOWAY_ADDITION_CLASS = 'jp-Merge-twoway-addition';

--- a/nbdime-web/src/styles/diff.css
+++ b/nbdime-web/src/styles/diff.css
@@ -19,7 +19,7 @@
 }
 
 /* Do not use border between unchanged cells */
-.jp-Notebook-diff .jp-Diff-unchanged + .jp-Diff-unchanged {
+.jp-Notebook-diff .jp-Diff-unchanged + .jp-Diff-unchanged > div:first-of-type {
     border: none;
 }
 
@@ -36,6 +36,9 @@
 
 .jp-Notebook-diff .jp-Cell-diff {
   margin-bottom: 20px;
+}
+
+.jp-Notebook-diff .jp-Cell-diff > div:first-of-type {
   border-top: solid #ccc 1px;
 }
 

--- a/nbdime-web/src/styles/merge.css
+++ b/nbdime-web/src/styles/merge.css
@@ -11,7 +11,6 @@
 
 .jp-Notebook-merge .jp-Cell-merge {
   margin-bottom: 20px;
-  border-top: solid #ccc 1px;
   background-color: var(--jp-layout-color1);
 }
 
@@ -33,6 +32,7 @@
 .jp-Notebook-merge .jp-Merge-cellHeader {
   display: flex;
   background-color: var(--codemirror-gutter-background);
+  border-top: solid #ccc 1px;
 }
 
 .jp-Notebook-merge .jp-Merge-cellHeader > .p-Widget {

--- a/nbdime/webapp/src/app/common.ts
+++ b/nbdime/webapp/src/app/common.ts
@@ -8,6 +8,23 @@ import {
   NotifyUserError
 } from 'nbdime/lib/common/exceptions';
 
+import {
+  UNCHANGED_DIFF_CLASS
+} from 'nbdime/lib/diff/widget/common';
+
+import {
+  UNCHANGED_MERGE_CLASS
+} from 'nbdime/lib/merge/widget/common';
+
+import {
+  CELLDIFF_CLASS
+} from 'nbdime/lib/diff/widget';
+
+import {
+  CELLMERGE_CLASS
+} from 'nbdime/lib/merge/widget';
+
+
 /**
  * DOM class for whether or not to hide unchanged cells
  */
@@ -134,7 +151,45 @@ function toggleShowUnchanged(show?: boolean) {
   if (show) {
     root.classList.remove(HIDE_UNCHANGED_CLASS);
   } else {
+    markUnchangedRanges();
     root.classList.add(HIDE_UNCHANGED_CLASS);
+  }
+}
+
+
+/**
+ * Marks certain cells with
+ */
+export
+function markUnchangedRanges() {
+  let root = document.getElementById('nbdime-root')!;
+  let children = root.querySelectorAll(`.${CELLDIFF_CLASS}, .${CELLMERGE_CLASS}`);
+  let rangeStart = -1;
+  for (let i=0; i < children.length; ++i) {
+    let child = children[i];
+    if (!child.classList.contains(UNCHANGED_DIFF_CLASS) &&
+        !child.classList.contains(UNCHANGED_MERGE_CLASS)) {
+      // Visible
+      if (rangeStart !== -1) {
+        // Previous was hidden
+        let N = i - rangeStart;
+        child.setAttribute('data-nbdime-NCellsHiddenBefore', N.toString());
+        rangeStart = -1;
+      }
+    } else if (rangeStart === -1) {
+      rangeStart = i;
+    }
+  }
+  if (rangeStart !== -1) {
+    // Last element was part of a hidden range, need to mark
+    // the last cell that will be visible.
+    if (rangeStart === 0) {
+      // All elements were hidden, nothing to mark
+      return;
+    }
+    let N = children.length - rangeStart;
+    let lastVisible = children[rangeStart - 1];
+    lastVisible.setAttribute('data-nbdime-NCellsHiddenAfter', N.toString());
   }
 }
 

--- a/nbdime/webapp/src/app/common.ts
+++ b/nbdime/webapp/src/app/common.ts
@@ -9,6 +9,11 @@ import {
 } from 'nbdime/lib/common/exceptions';
 
 /**
+ * DOM class for whether or not to hide unchanged cells
+ */
+const HIDE_UNCHANGED_CLASS = 'jp-mod-hideUnchanged';
+
+/**
  * Global config data for the Nbdime application.
  */
 let configData: any = null;
@@ -107,6 +112,29 @@ function toggleSpinner(state?: boolean) {
     header.appendChild(spinner);
   } else {
     header.removeChild(spinner);
+  }
+}
+
+
+/**
+ * Toggle whether to show or hide unchanged cells.
+ *
+ * This simply marks with a class, real work is done by CSS.
+ */
+export
+function toggleShowUnchanged(show?: boolean) {
+  let root = document.getElementById('nbdime-root')!;
+  let hiding = root.classList.contains(HIDE_UNCHANGED_CLASS);
+  if (show === undefined) {
+    show = hiding;
+  } else if (hiding !== show) {
+    // Nothing to do
+    return;
+  }
+  if (show) {
+    root.classList.remove(HIDE_UNCHANGED_CLASS);
+  } else {
+    root.classList.add(HIDE_UNCHANGED_CLASS);
   }
 }
 

--- a/nbdime/webapp/src/app/compare.ts
+++ b/nbdime/webapp/src/app/compare.ts
@@ -157,7 +157,7 @@ function initializeCompare() {
   let local = getConfigOption('local');
   let remote = getConfigOption('remote');
   try {
-    compare(base, local, remote, false);
+    compare(base, local, remote, 'replace');
   } catch (e) {
     toggleSpinner(false);
     if (!(e instanceof Error && e.message === ERROR_COMPARE_NUMBER)) {

--- a/nbdime/webapp/src/app/compare.ts
+++ b/nbdime/webapp/src/app/compare.ts
@@ -107,7 +107,7 @@ function compare(b: string, c: string, r: string, pushHistory: boolean | 'replac
   }
 }
 
-function editHistory(pushHistory: boolean | 'replace', statedata: any, title?: string, url?: string): void {
+function editHistory(pushHistory: boolean | 'replace', statedata: any, title: string, url?: string): void {
   if (pushHistory === true) {
     history.pushState(statedata, title, url);
   } else if (pushHistory === 'replace') {

--- a/nbdime/webapp/src/app/compare.ts
+++ b/nbdime/webapp/src/app/compare.ts
@@ -12,7 +12,7 @@ import {
 } from './merge';
 
 import {
-  getConfigOption, closeTool, toggleSpinner
+  getConfigOption, closeTool, toggleSpinner, toggleShowUnchanged
 } from './common';
 
 import {
@@ -178,4 +178,9 @@ function initializeCompare() {
   }
   let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;
   exportBtn.onclick = exportDiff;
+
+  let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
+  hideUnchangedChk.onchange = () => {
+    toggleShowUnchanged(!hideUnchangedChk.checked);
+  };
 }

--- a/nbdime/webapp/src/app/diff.css
+++ b/nbdime/webapp/src/app/diff.css
@@ -48,3 +48,9 @@
 .nbdime-Diff.jp-mod-local-base #nbdime-header-remote {
   display: none;
 }
+
+
+/* Hiding unchanged cells if told to */
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff.jp-Diff-unchanged {
+  display: none;
+}

--- a/nbdime/webapp/src/app/diff.css
+++ b/nbdime/webapp/src/app/diff.css
@@ -54,3 +54,35 @@
 #nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff.jp-Diff-unchanged {
   display: none;
 }
+
+/* Show a marker with the number of cells hidden before */
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore]::before {
+  content: attr(data-nbdime-NCellsHiddenBefore) " unchanged cell(s) hidden";
+  position: absolute;
+  width: 100%;
+  top: 0;
+  background-color: #eee;
+  border-top: solid #ccc 1px;
+  border-bottom: solid #ccc 1px;
+  text-align: center;
+}
+
+/* Show a marker with the number of cells hidden after (for hidden cells at end) */
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter]::after {
+  content: attr(data-nbdime-NCellsHiddenAfter) " unchanged cell(s) hidden";
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+  background-color: #eee;
+  border-top: solid #ccc 1px;
+  border-bottom: solid #ccc 1px;
+  text-align: center;
+}
+
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore] {
+  padding-top: 40px;
+}
+
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter] {
+  padding-bottom: 40px;
+}

--- a/nbdime/webapp/src/app/diff.ts
+++ b/nbdime/webapp/src/app/diff.ts
@@ -45,7 +45,8 @@ import {
 } from 'nbdime/lib/request';
 
 import {
-  getBaseUrl, getConfigOption, toggleSpinner, toggleShowUnchanged
+  getBaseUrl, getConfigOption, toggleSpinner, toggleShowUnchanged,
+  markUnchangedRanges
 } from './common';
 
 import {
@@ -151,6 +152,7 @@ function onDiffRequestCompleted(data: any) {
     let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;
     exportBtn.style.display = 'initial';
     toggleSpinner(false);
+    markUnchangedRanges();
   });
 }
 

--- a/nbdime/webapp/src/app/diff.ts
+++ b/nbdime/webapp/src/app/diff.ts
@@ -45,7 +45,7 @@ import {
 } from 'nbdime/lib/request';
 
 import {
-  getBaseUrl, getConfigOption, toggleSpinner
+  getBaseUrl, getConfigOption, toggleSpinner, toggleShowUnchanged
 } from './common';
 
 import {
@@ -208,4 +208,9 @@ function initializeDiff() {
 
   let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;
   exportBtn.onclick = exportDiff;
+
+  let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
+  hideUnchangedChk.onchange = () => {
+    toggleShowUnchanged(!hideUnchangedChk.checked);
+  };
 }

--- a/nbdime/webapp/src/app/diff.ts
+++ b/nbdime/webapp/src/app/diff.ts
@@ -123,7 +123,7 @@ function compare(base: string, remote: string, pushHistory: boolean | 'replace')
   }
 }
 
-function editHistory(pushHistory: boolean | 'replace', statedata: any, title?: string, url?: string): void {
+function editHistory(pushHistory: boolean | 'replace', statedata: any, title: string, url?: string): void {
   if (pushHistory === true) {
     history.pushState(statedata, title, url);
   } else if (pushHistory === 'replace') {
@@ -195,7 +195,10 @@ function attachToForm() {
   }
 }
 
-/** */
+
+/**
+ *
+ */
 export
 function initializeDiff() {
   attachToForm();

--- a/nbdime/webapp/src/app/merge.css
+++ b/nbdime/webapp/src/app/merge.css
@@ -25,3 +25,9 @@
 .nbdime-Merge #nbdime-header-remote {
   background-color: var(--jp-merge-remote-color1);
 }
+
+
+/* Hiding unchanged cells if told to */
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge.jp-Merge-unchanged {
+  display: none;
+}

--- a/nbdime/webapp/src/app/merge.css
+++ b/nbdime/webapp/src/app/merge.css
@@ -31,3 +31,35 @@
 #nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge.jp-Merge-unchanged {
   display: none;
 }
+
+/* Show a marker with the number of cells hidden before */
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge[data-nbdime-NCellsHiddenBefore]::before {
+  content: attr(data-nbdime-NCellsHiddenBefore) " unchanged cell(s) hidden";
+  position: absolute;
+  width: 100%;
+  top: 0;
+  background-color: #eee;
+  border-top: solid #ccc 1px;
+  border-bottom: solid #ccc 1px;
+  text-align: center;
+}
+
+/* Show a marker with the number of cells hidden after (for hidden cells at end) */
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge[data-nbdime-NCellsHiddenAfter]::after {
+  content: attr(data-nbdime-NCellsHiddenAfter) " unchanged cell(s) hidden";
+  position: absolute;
+  width: 100%;
+  bottom: 0;
+  background-color: #eee;
+  border-top: solid #ccc 1px;
+  border-bottom: solid #ccc 1px;
+  text-align: center;
+}
+
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge[data-nbdime-NCellsHiddenBefore] {
+  padding-top: 40px;
+}
+
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge[data-nbdime-NCellsHiddenAfter] {
+  padding-bottom: 40px;
+}

--- a/nbdime/webapp/src/app/merge.ts
+++ b/nbdime/webapp/src/app/merge.ts
@@ -51,7 +51,8 @@ import {
 } from 'nbdime/lib/request';
 
 import {
-  getBaseUrl, getConfigOption, closeTool, toggleSpinner, toggleShowUnchanged
+  getBaseUrl, getConfigOption, closeTool, toggleSpinner,
+  toggleShowUnchanged, markUnchangedRanges
 } from './common';
 
 import {
@@ -180,6 +181,7 @@ function onMergeRequestCompleted(data: any) {
   let layoutWork = showMerge(data);
   layoutWork.then(() => {
     toggleSpinner(false);
+    markUnchangedRanges();
   });
 }
 

--- a/nbdime/webapp/src/app/merge.ts
+++ b/nbdime/webapp/src/app/merge.ts
@@ -51,7 +51,7 @@ import {
 } from 'nbdime/lib/request';
 
 import {
-  getBaseUrl, getConfigOption, closeTool, toggleSpinner
+  getBaseUrl, getConfigOption, closeTool, toggleSpinner, toggleShowUnchanged
 } from './common';
 
 import {
@@ -398,4 +398,9 @@ function initializeMerge() {
   let downloadBtn = document.getElementById('nbdime-download') as HTMLButtonElement;
   downloadBtn.onclick = downloadMerged;
   downloadBtn.style.display = 'initial';
+
+  let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
+  hideUnchangedChk.onchange = () => {
+    toggleShowUnchanged(!hideUnchangedChk.checked);
+  };
 }

--- a/nbdime/webapp/src/app/merge.ts
+++ b/nbdime/webapp/src/app/merge.ts
@@ -149,7 +149,7 @@ function compare(b: string, c: string, r: string, pushHistory: boolean | 'replac
   }
 }
 
-function editHistory(pushHistory: boolean | 'replace', statedata: any, title?: string, url?: string): void {
+function editHistory(pushHistory: boolean | 'replace', statedata: any, title: string, url?: string): void {
   if (pushHistory === true) {
     history.pushState(statedata, title, url);
   } else if (pushHistory === 'replace') {

--- a/nbdime/webapp/templates/diff.html
+++ b/nbdime/webapp/templates/diff.html
@@ -30,8 +30,9 @@
         </fieldset>
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">
-        <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
-        <button id="nbdime-export" class="nbdime-header-button" style="display: none">Export diff</button>
+        <input id="nbdime-hide-unchanged" type="checkbox"><label for="cbox1">Hide unchanged cells</label></input>
+        <button id="nbdime-close" type="checkbox" style="display: none">Close tool</button>
+        <button id="nbdime-export" type="checkbox" style="display: none">Export diff</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-base">Base</span>

--- a/nbdime/webapp/templates/difftool.html
+++ b/nbdime/webapp/templates/difftool.html
@@ -16,8 +16,9 @@
     <div id="nbdime-header" class="nbdime-Diff">
       <h3>Notebook Diff</h3>
       <div id="nbdime-header-buttonrow">
-        <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
-        <button id="nbdime-export" class="nbdime-header-button" style="display: none">Export diff</button>
+        <input id="nbdime-hide-unchanged" type="checkbox"><label for="cbox1">Hide unchanged cells</label></input>
+        <button id="nbdime-close" style="display: none">Close tool</button>
+        <button id="nbdime-export" style="display: none">Export diff</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-base">Base</span>

--- a/nbdime/webapp/templates/index.html
+++ b/nbdime/webapp/templates/index.html
@@ -29,14 +29,15 @@
           <label>Remote:</label>
           <input id="compare-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-compare" type="submit" name="auto" value="Compare files" />
-          <button id="nbdime-download" class="nbdime-header-button" style="display: none" type="button">Download</button>
+          <button id="nbdime-download" style="display: none" type="button">Download</button>
         </fieldset>
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">
-        <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
-        <button id="nbdime-download" class="nbdime-header-button" style="display: none">Download</button>
-        <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
-        <button id="nbdime-export" class="nbdime-header-button" style="display: none">Export diff</button>
+        <input id="nbdime-hide-unchanged" type="checkbox"><label for="cbox1">Hide unchanged cells</label></input>
+        <button id="nbdime-save" style="display: none">Save</button>
+        <button id="nbdime-download" style="display: none">Download</button>
+        <button id="nbdime-close" style="display: none">Close tool</button>
+        <button id="nbdime-export" style="display: none">Export diff</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-local">Local</span>

--- a/nbdime/webapp/templates/merge.html
+++ b/nbdime/webapp/templates/merge.html
@@ -29,13 +29,14 @@
           <label>Remote:</label>
           <input id="merge-remote" type="text" name="remote" value="{{ escape(config_data['remote']) }}" />
           <input id="nbdime-run-merge" type="submit" name="merge" value="Merge files" />
-          <button id="nbdime-download" class="nbdime-header-button" style="display: none" type="button">Download</button>
+          <button id="nbdime-download" style="display: none" type="button">Download</button>
         </fieldset>
       </form> <!-- nbdime-forms -->
       <div id="nbdime-header-buttonrow">
-        <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
-        <button id="nbdime-download" class="nbdime-header-button" style="display: none">Download</button>
-        <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+        <input id="nbdime-hide-unchanged" type="checkbox"><label for="cbox1">Hide unchanged cells</label></input>
+        <button id="nbdime-save" style="display: none">Save</button>
+        <button id="nbdime-download" style="display: none">Download</button>
+        <button id="nbdime-close" style="display: none">Close tool</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-local">Local</span>

--- a/nbdime/webapp/templates/mergetool.html
+++ b/nbdime/webapp/templates/mergetool.html
@@ -16,9 +16,10 @@
     <div id="nbdime-header" class="nbdime-Merge">
       <h3>Notebook Merge</h3>
       <div id="nbdime-header-buttonrow">
-        <button id="nbdime-save" class="nbdime-header-button" style="display: none">Save</button>
-        <button id="nbdime-download" class="nbdime-header-button" style="display: none">Download</button>
-        <button id="nbdime-close" class="nbdime-header-button" style="display: none">Close tool</button>
+        <input id="nbdime-hide-unchanged" type="checkbox"><label for="cbox1">Hide unchanged cells</label></input>
+        <button id="nbdime-save" style="display: none">Save</button>
+        <button id="nbdime-download" style="display: none">Download</button>
+        <button id="nbdime-close" style="display: none">Close tool</button>
       </div>
       <div id=nbdime-header-banner>
         <span id="nbdime-header-local">Local</span>


### PR DESCRIPTION
Allows hiding unchanged cells in both diff and merge. Replaces the ranges of hidden, unchanged cells with a marker that says "X unchanged cell(s) hidden".

Fixes #272.

![nbdime_hide](https://cloud.githubusercontent.com/assets/510760/24397674/5088cd92-13a7-11e7-94d9-736d979d558a.png)
