### PR TITLE
Add caching for mimedata comparison

### DIFF
--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -3,14 +3,14 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from __future__ import unicode_literals
-
 """Tools for diffing notebooks.
 
 All diff tools here currently assumes the notebooks have already been
 converted to the same format version, currently v4 at time of writing.
 Up- and down-conversion is handled by nbformat.
 """
+
+from __future__ import unicode_literals
 
 import operator
 import re
@@ -362,17 +362,20 @@ def diff_single_outputs(a, b, path="/cells/*/outputs/*",
     if a.output_type in ("execute_result", "display_data"):
         di = MappingDiffBuilder()
 
+        # Separate data from output during diffing:
         tmp_data = a.pop('data')
-        a_conj = copy.deepcopy(a)
-        a.data = tmp_data
+        a_conj = copy.deepcopy(a)  # Output without data
+        a.data = tmp_data          # Restore output
         tmp_data = b.pop('data')
         b_conj = copy.deepcopy(b)
         b.data = tmp_data
+        # Only diff outputs without data:
         dd_conj = diff(a_conj, b_conj)
         if dd_conj:
             for e in dd_conj:
                 di.append(e)
 
+        # Only diff data:
         dd = diff_mime_bundle(a.data, b.data, path=path+"/data")
         if dd:
             di.patch("data", dd)

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -18,6 +18,10 @@ import copy
 from collections import defaultdict
 from six import string_types
 from six.moves import zip
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 
 from ..diff_format import MappingDiffBuilder, DiffOp
 
@@ -90,6 +94,7 @@ def compare_base64_strict(x, y):
     return x == y
 
 
+@lru_cache(maxsize=1024, typed=False)
 def _compare_mimedata(mimetype, x, y, comp_text, comp_base64):
     mimetype = mimetype.lower()
 

--- a/nbdime/profiling.py
+++ b/nbdime/profiling.py
@@ -40,6 +40,7 @@ diff to blow up.
 import time
 import contextlib
 from tabulate import tabulate
+from functools import wraps
 
 
 def _sort_time(value):
@@ -67,6 +68,18 @@ class TimePaths(object):
             self.map[key]['calls'] += 1
         else:
             self.map[key] = dict(time=secs, calls=1)
+
+    def profile(self, key=None):
+        def decorator(function):
+            nonlocal key
+            if key is None:
+                key = function.__name__ or 'unknown'
+            @wraps(function)
+            def inner(*args, **kwargs):
+                with self.time(key):
+                    return function(*args, **kwargs)
+            return inner
+        return decorator
 
     @contextlib.contextmanager
     def enable(self):

--- a/nbdime/profiling.py
+++ b/nbdime/profiling.py
@@ -55,12 +55,13 @@ class TimePaths(object):
 
     @contextlib.contextmanager
     def time(self, key):
+        if not self.enabled:
+            yield
+            return
         start = time.time()
         yield
         end = time.time()
         secs = end - start
-        if not self.enabled:
-            return
         if key in self.map:
             self.map[key]['time'] += secs
             self.map[key]['calls'] += 1
@@ -88,8 +89,8 @@ class TimePaths(object):
         for key, data in items:
             time = data['time']
             calls = data['calls']
-            lines.append((key, calls, time))
-        return tabulate(lines, headers=['Key', 'Calls', 'Time'])
+            lines.append((key, calls, time, time / calls))
+        return tabulate(lines, headers=['Key', 'Calls', 'Time', 'Time/Call'])
 
 
 timer = TimePaths(enabled=False)
@@ -98,7 +99,8 @@ timer = TimePaths(enabled=False)
 def profile_diff_paths(args=None):
     import nbdime.nbdiffapp
     import nbdime.profiling
-    nbdime.nbdiffapp.main(args)
+    with nbdime.profiling.timer.enable():
+        nbdime.nbdiffapp.main(args)
     data = str(nbdime.profiling.timer)
     print(data)
 

--- a/setup.py
+++ b/setup.py
@@ -258,6 +258,7 @@ extras_require = setuptools_args['extras_require'] = {
 
     ':python_version == "2.7"': [
         'backports.shutil_which',
+        'backports.functools_lru_cache',
     ],
 }
 


### PR DESCRIPTION
It seems that with the hierarchical algorithm we end up comparing the same things several times. Due to their low level in the hierarchy, and comparatively large size, MIME data comparisons are especially affected by this. This PR addresses this by simply adding an LRU cache on the MIME data comparison.

Related to #237.