### PR TITLE
Refactor setup.py code to use jupyter-packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,135 +30,22 @@ PY3 = (sys.version_info[0] >= 3)
 import io
 import os
 from glob import glob
-from subprocess import check_call
-
-
-from distutils import log
-from distutils.cmd import Command
-from distutils.command.build_ext import build_ext
-from distutils.command.sdist import sdist
-from distutils.spawn import find_executable
 
 from setuptools import setup
-from setuptools.command.bdist_egg import bdist_egg
+
+from setupbase import create_cmdclass, install_npm, find_packages, combine_commands
 
 pjoin = os.path.join
 here = os.path.abspath(os.path.dirname(__file__))
-is_repo = os.path.exists(os.path.join(here, '.git'))
-pkg_root = pjoin(here, name)
 
 # Representative files that should exist after a successful build
 jstargets = [
-    os.path.join(here, 'nbdime', 'webapp', 'static', 'nbdime.js'),
+    os.path.join(here, name, 'webapp', 'static', 'nbdime.js'),
 ]
 
 
-if "--skip-npm" in sys.argv:
-    print("Skipping install of webtools as requested.")
-    skip_npm = True
-    sys.argv.remove("--skip-npm")
-else:
-    skip_npm = False
-
-
-def run(cmd, cwd=None):
-    """Run a command
-
-    >>> run('npm install', cwd='./subdir')
-    """
-    # On Windows, shell should be True so that the path is searched for the command.
-    shell = (sys.platform == 'win32')
-    check_call(cmd.split(), shell=shell, cwd=cwd, stdout=sys.stdout, stderr=sys.stderr)
-
-
-def js_prerelease(command, strict=False):
-    """Decorator for building minified js/css prior to another command"""
-    class DecoratedCommand(command):
-        def run(self):
-            jsdeps = self.distribution.get_command_obj('jsdeps')
-            if not is_repo and all(os.path.exists(t) for t in jstargets):
-                # sdist, nothing to do
-                command.run(self)
-                return
-
-            try:
-                self.distribution.run_command('jsdeps')
-            except Exception as e:
-                missing = [t for t in jstargets if not os.path.exists(t)]
-                if strict or missing:
-                    log.warn('rebuilding js and css failed')
-                    if missing:
-                        log.error('missing files: %s' % missing)
-                    raise e
-                else:
-                    log.warn('rebuilding js and css failed (not a problem)')
-                    log.warn(str(e))
-            command.run(self)
-    return DecoratedCommand
-
-
-def install_npm(path):
-    """Return a Command for running npm install and npm build at a given path."""
-
-    class NPM(Command):
-        description = 'install package.json dependencies using npm'
-        user_options = []
-
-        node_package = path
-        node_modules = pjoin(node_package, 'node_modules')
-
-        def initialize_options(self):
-            pass
-
-        def finalize_options(self):
-            pass
-
-        def has_npm(self):
-            return find_executable("npm")
-
-        def run(self):
-            if (skip_npm):
-                log.info('Skipping npm-installation')
-                return
-            log.info('Checking npm-installation:')
-            has_npm = self.has_npm()
-            if not has_npm:
-                log.error("`npm` unavailable.  If you're running this command "
-                          "using sudo, make sure `npm` is availble to sudo")
-            log.info('Installing build dependencies with npm.  This may '
-                        'take a while...')
-            run('npm install', cwd=self.node_package)
-            run('npm run build', cwd=self.node_package)
-    return NPM
-
-def combine_commands(*commands):
-    """Return a Command that combines several commands."""
-
-    class CombinedCommand(Command):
-
-        def initialize_options(self):
-            self.commands = []
-            for C in commands:
-                self.commands.append(C(self.distribution))
-            for c in self.commands:
-                c.initialize_options()
-
-        def finalize_options(self):
-            for c in self.commands:
-                c.finalize_options()
-
-        def run(self):
-            for c in self.commands:
-                c.run()
-    return CombinedCommand
-
-packages = []
-for d, _, _ in os.walk(pjoin(here, name)):
-    if os.path.exists(pjoin(d, '__init__.py')):
-        packages.append(d[len(here)+1:].replace(os.path.sep, '.'))
-
 package_data = {
-    'nbdime': [
+    name: [
         'tests/files/*.*',
         '*.schema.json',
         'webapp/static/*.*',
@@ -172,12 +59,20 @@ with io.open(pjoin(here, name, '_version.py'), encoding="utf8") as f:
     exec(f.read(), {}, version_ns)
 
 
+cmdclass = create_cmdclass(('jsdeps',))
+cmdclass['jsdeps'] = combine_commands(
+    install_npm(pjoin(here, 'nbdime-web')),
+    install_npm(pjoin(here, name, 'webapp')),
+)
+
+
 setup_args = dict(
     name            = name,
     description     = "Diff and merge of Jupyter Notebooks",
     version         = version_ns['__version__'],
     scripts         = glob(pjoin('scripts', '*')),
-    packages        = packages,
+    cmdclass        = cmdclass,
+    packages        = find_packages(pjoin(here, name)),
     package_data    = package_data,
     author          = 'Jupyter Development Team',
     author_email    = 'jupyter@googlegroups.com',
@@ -199,34 +94,6 @@ setup_args = dict(
         'Framework :: Jupyter',
     ],
 )
-
-class bdist_egg_disabled(bdist_egg):
-    """Disabled version of bdist_egg
-
-    Prevents setup.py install performing setuptools' default easy_install,
-    which it should never ever do.
-    """
-    def run(self):
-        sys.exit("Aborting implicit building of eggs. Use `pip install .` to install from source.")
-
-
-cmdclass = dict(
-    build_ext = js_prerelease(build_ext),
-    sdist  = js_prerelease(sdist, strict=True),
-    jsdeps = combine_commands(
-        install_npm(pjoin(here, 'nbdime-web')),
-        install_npm(pjoin(here, 'nbdime', 'webapp')),
-    ),
-    bdist_egg = bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled,
-)
-try:
-    from wheel.bdist_wheel import bdist_wheel
-    cmdclass['bdist_wheel'] = js_prerelease(bdist_wheel, strict=True)
-except ImportError:
-    pass
-
-
-setup_args['cmdclass'] = cmdclass
 
 
 setuptools_args = {}

--- a/setupbase.py
+++ b/setupbase.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import os
+from os.path import join as pjoin
+import functools
+import pipes
+
+from setuptools import Command
+from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
+from setuptools.command.develop import develop
+from setuptools.command.bdist_egg import bdist_egg
+from distutils import log
+from subprocess import check_call
+import sys
+
+try:
+    from wheel.bdist_wheel import bdist_wheel
+except ImportError:
+    bdist_wheel = None
+
+if sys.platform == 'win32':
+    from subprocess import list2cmdline
+else:
+    def list2cmdline(cmd_list):
+        return ' '.join(map(pipes.quote, cmd_list))
+
+
+__version__ = '0.1.0'
+
+# ---------------------------------------------------------------------------
+# Top Level Variables
+# ---------------------------------------------------------------------------
+
+
+here = os.path.abspath(os.path.dirname(sys.argv[0]))
+is_repo = os.path.exists(pjoin(here, '.git'))
+node_modules = pjoin(here, 'node_modules')
+npm_path = ':'.join([
+    pjoin(here, 'node_modules', '.bin'),
+    os.environ.get('PATH', os.defpath),
+])
+
+if "--skip-npm" in sys.argv:
+    print("Skipping npm install as requested.")
+    skip_npm = True
+    sys.argv.remove("--skip-npm")
+else:
+    skip_npm = False
+
+# ---------------------------------------------------------------------------
+# Public Functions
+# ---------------------------------------------------------------------------
+
+
+def get_data_files(top):
+    """Get data files"""
+
+    data_files = []
+    ntrim = len(here + os.path.sep)
+
+    for (d, dirs, filenames) in os.walk(top):
+        data_files.append((
+            d[ntrim:],
+            [pjoin(d, f) for f in filenames]
+        ))
+    return data_files
+
+
+def find_packages(top):
+    """
+    Find all of the packages.
+    """
+    packages = []
+    for d, _, _ in os.walk(top):
+        if os.path.exists(pjoin(d, '__init__.py')):
+            packages.append(d.replace(os.path.sep, '.'))
+
+
+def create_cmdclass(wrappers=None, data_dirs=None):
+    """Create a command class with the given optional wrappers.
+
+    Parameters
+    ----------
+    wrappers: list(str), optional
+        The cmdclass names to run before running other commands
+    data_dirs: list(str), optional.
+        The directories containing static data.
+    """
+    egg = bdist_egg if 'bdist_egg' in sys.argv else bdist_egg_disabled
+    wrappers = wrappers or []
+    data_dirs = data_dirs or []
+    wrapper = functools.partial(wrap_command, wrappers, data_dirs)
+    cmdclass = dict(
+        build_py=wrapper(build_py, strict=is_repo),
+        sdist=wrapper(sdist, strict=True),
+        bdist_egg=egg,
+        develop=wrapper(develop, strict=True)
+    )
+    if bdist_wheel:
+        cmdclass['bdist_wheel'] = wrapper(bdist_wheel, strict=True)
+    return cmdclass
+
+
+def run(cmd, *args, **kwargs):
+    """Echo a command before running it.  Defaults to repo as cwd"""
+    log.info('> ' + list2cmdline(cmd))
+    kwargs.setdefault('cwd', here)
+    kwargs.setdefault('shell', sys.platform == 'win32')
+    if not isinstance(cmd, list):
+        cmd = cmd.split()
+    return check_call(cmd, *args, **kwargs)
+
+
+def is_stale(target, source):
+    """Test whether the target file/directory is stale based on the source
+       file/directory.
+    """
+    if not os.path.exists(target):
+        return True
+    target_mtime = recursive_mtime(target)
+    return compare_recursive_mtime(source, cutoff=target_mtime)
+
+
+class BaseCommand(Command):
+    """Empty command because Command needs subclasses to override too much"""
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def get_inputs(self):
+        return []
+
+    def get_outputs(self):
+        return []
+
+
+def combine_commands(*commands):
+    """Return a Command that combines several commands."""
+
+    class CombinedCommand(Command):
+
+        def initialize_options(self):
+            self.commands = []
+            for C in commands:
+                self.commands.append(C(self.distribution))
+            for c in self.commands:
+                c.initialize_options()
+
+        def finalize_options(self):
+            for c in self.commands:
+                c.finalize_options()
+
+        def run(self):
+            for c in self.commands:
+                c.run()
+    return CombinedCommand
+
+
+def compare_recursive_mtime(path, cutoff, newest=True):
+    """Compare the newest/oldest mtime for all files in a directory.
+
+    Cutoff should be another mtime to be compared against. If an mtime that is
+    newer/older than the cutoff is found it will return True.
+    E.g. if newest=True, and a file in path is newer than the cutoff, it will
+    return True.
+    """
+    for dirname, _, filenames in os.walk(path, topdown=False):
+        for filename in filenames:
+            mt = mtime(pjoin(dirname, filename))
+            if newest:  # Put outside of loop?
+                if mt > cutoff:
+                    return True
+            elif mt < cutoff:
+                return True
+    return False
+
+
+def recursive_mtime(path, newest=True):
+    """Gets the newest/oldest mtime for all files in a directory."""
+    current_extreme = None
+    for dirname, _, filenames in os.walk(path, topdown=False):
+        for filename in filenames:
+            mt = mtime(pjoin(dirname, filename))
+            if newest:  # Put outside of loop?
+                if mt >= (current_extreme or mt):
+                    current_extreme = mt
+            elif mt <= (current_extreme or mt):
+                current_extreme = mt
+    return current_extreme
+
+
+def mtime(path):
+    """shorthand for mtime"""
+    return os.stat(path).st_mtime
+
+
+def install_npm(path=None, build_dir=None, source_dir=None, build_cmd='build'):
+    """Return a Command for managing an npm installation.
+
+    Parameters
+    ----------
+    path: str, optional
+        The base path of the node package.  Defaults to the repo root.
+    build_dir: str, optional
+        The target build directory.  If this and source_dir are given,
+        the JavaScript will only be build if necessary.
+    source_dir: str, optional
+        The source code directory.
+    build_cmd: str, optional
+        The npm command to build assets to the build_dir.
+    """
+
+    class NPM(BaseCommand):
+        description = 'install package.json dependencies using npm'
+
+        def run(self):
+            if skip_npm:
+                log.info('Skipping npm-installation')
+                return
+            node_package = path or here
+            node_modules = pjoin(node_package, 'node_modules')
+
+            if not which("npm"):
+                log.error("`npm` unavailable.  If you're running this command "
+                          "using sudo, make sure `npm` is availble to sudo")
+                return
+            if is_stale(node_modules, pjoin(node_package, 'package.json')):
+                log.info('Installing build dependencies with npm.  This may '
+                         'take a while...')
+                run(['npm', 'install'], cwd=node_package)
+            if build_dir and source_dir:
+                should_build = is_stale(build_dir, source_dir)
+            else:
+                should_build = True
+            if should_build:
+                run(['npm', 'run', build_cmd], cwd=node_package)
+
+    return NPM
+
+
+# `shutils.which` function copied verbatim from the Python-3.3 source.
+def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+    """
+
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode) and
+                not os.path.isdir(fn))
+
+    # Short circuit. If we're given a full path which matches the mode
+    # and it exists, we're done here.
+    if _access_check(cmd, mode):
+        return cmd
+
+    path = (path or os.environ.get("PATH", os.defpath)).split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if os.curdir not in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        matches = [cmd for ext in pathext if cmd.lower().endswith(ext.lower())]
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        files = [cmd] if matches else [cmd + ext.lower() for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        dir = os.path.normcase(dir)
+        if dir not in seen:
+            seen.add(dir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Private Functions
+# ---------------------------------------------------------------------------
+
+
+def update_package_data(distribution):
+    """update build_py options to get package_data changes"""
+    build_py = distribution.get_command_obj('build_py')
+    build_py.finalize_options()
+
+
+def wrap_command(cmds, data_dirs, cls, strict=True):
+    """Wrap a setup command
+
+    Parameters
+    ----------
+    cmds: list(str)
+        The names of the other commands to run prior to the command.
+    strict: boolean, optional
+        Wether to raise errors when a pre-command fails.
+    """
+    class WrappedCommand(cls):
+
+        def run(self):
+            if not getattr(self, 'uninstall', None):
+                try:
+                    [self.run_command(cmd) for cmd in cmds]
+                except Exception:
+                    if strict:
+                        raise
+                    else:
+                        pass
+
+            result = cls.run(self)
+            data_files = []
+            for dname in data_dirs:
+                data_files.extend(get_data_files(dname))
+            # update data-files in case this created new files
+            self.distribution.data_files = data_files
+            # also update package data
+            update_package_data(self.distribution)
+            return result
+    return WrappedCommand
+
+
+class bdist_egg_disabled(bdist_egg):
+    """Disabled version of bdist_egg
+    Prevents setup.py install performing setuptools' default easy_install,
+    which it should never ever do.
+    """
+
+    def run(self):
+        sys.exit("Aborting implicit building of eggs. Use `pip install .` " +
+                 " to install from source.")

--- a/setupbase.py
+++ b/setupbase.py
@@ -173,6 +173,13 @@ def compare_recursive_mtime(path, cutoff, newest=True):
     E.g. if newest=True, and a file in path is newer than the cutoff, it will
     return True.
     """
+    if os.path.isfile(path):
+        mt = mtime(path)
+        if newest:
+            if mt > cutoff:
+                return True
+        elif mt < cutoff:
+            return True
     for dirname, _, filenames in os.walk(path, topdown=False):
         for filename in filenames:
             mt = mtime(pjoin(dirname, filename))
@@ -186,6 +193,8 @@ def compare_recursive_mtime(path, cutoff, newest=True):
 
 def recursive_mtime(path, newest=True):
     """Gets the newest/oldest mtime for all files in a directory."""
+    if os.path.isfile(path):
+        return mtime(path)
     current_extreme = None
     for dirname, _, filenames in os.walk(path, topdown=False):
         for filename in filenames:

--- a/setupbase.py
+++ b/setupbase.py
@@ -122,7 +122,7 @@ def is_stale(target, source):
     """
     if not os.path.exists(target):
         return True
-    target_mtime = recursive_mtime(target)
+    target_mtime = recursive_mtime(target) or 0
     return compare_recursive_mtime(source, cutoff=target_mtime)
 
 


### PR DESCRIPTION
Use setupbase.py from jupyter-packaging.

This should also fix the issue that @martinal experienced where a `pip install .` from the repo would not include the built files (via the implicit call to `update_package_data()`).