### PR TITLE
Fix mishandled ignore flags

### DIFF
--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -98,9 +98,14 @@ def main(args=None):
 
     opts = parser.parse_args(args)
     if opts.subcommand == 'diff':
-        return nbdiffapp.main(
-            [opts.a, opts.b] +
-            ['--%s' % name for name in diff_exclusives if getattr(opts, name)])
+        subargs = [opts.a, opts.b]
+        for name in diff_exclusives:
+            included = getattr(opts, name)
+            if included:
+                subargs.append('--%s' % name)
+            elif included is not None:
+                subargs.append('--ignore-%s' % name)
+        return nbdiffapp.main(subargs)
     elif opts.subcommand == 'config':
         opts.config_func(opts.scope)
         return 0

--- a/nbdime/gitdiffdriver.py
+++ b/nbdime/gitdiffdriver.py
@@ -24,7 +24,7 @@ import sys
 from subprocess import check_call, CalledProcessError
 
 from . import nbdiffapp
-from .args import add_git_config_subcommand, add_diff_args, diff_exclusives
+from .args import add_git_config_subcommand, add_diff_args, diff_exclusives, process_exclusive_ignorables
 from .utils import locate_gitattributes, ensure_dir_exists
 
 
@@ -98,14 +98,10 @@ def main(args=None):
 
     opts = parser.parse_args(args)
     if opts.subcommand == 'diff':
-        subargs = [opts.a, opts.b]
-        for name in diff_exclusives:
-            included = getattr(opts, name)
-            if included:
-                subargs.append('--%s' % name)
-            elif included is not None:
-                subargs.append('--ignore-%s' % name)
-        return nbdiffapp.main(subargs)
+        process_exclusive_ignorables(opts, diff_exclusives)
+        return nbdiffapp.main(
+            [opts.a, opts.b] +
+            ['--%s' % name for name in diff_exclusives if getattr(opts, name)])
     elif opts.subcommand == 'config':
         opts.config_func(opts.scope)
         return 0

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -103,3 +103,25 @@ def test_git_diff_driver_flags(capsys, nocolor, needs_git, reset_diff_targets):
         assert r == 0
         cap_out = capsys.readouterr()[0]
         assert cap_out == expected_source_only.format(fn1, fn2, t1, t2)
+
+
+def test_git_diff_driver_ignore_flags(capsys, nocolor, needs_git, reset_diff_targets):
+    # Simulate a call from `git diff` to check basic driver functionality
+    test_dir = os.path.abspath(os.path.dirname(__file__))
+
+    fn1 = pjoin(test_dir, 'files/foo--1.ipynb')
+    fn2 = pjoin(test_dir, 'files/foo--2.ipynb')
+    t1 = file_timestamp(fn1)
+    t2 = file_timestamp(fn2)
+
+    mock_argv = [
+        '/mock/path/git-nbdiffdriver', 'diff', '-O',
+        fn1,
+        fn1, 'invalid_mock_checksum', '100644',
+        fn2, 'invalid_mock_checksum', '100644']
+
+    with mock.patch('sys.argv', mock_argv):
+        r = gdd_main()
+        assert r == 0
+        cap_out = capsys.readouterr()[0]
+        assert cap_out == expected_source_only.format(fn1, fn2, t1, t2)


### PR DESCRIPTION
When gitdiffdriver hands off to nbdiffapp, ignore flags (like`--ignore-metadata`) are dropped because of a bug that does not distinguish between False (an ignore flag is passed) and None (neither an ignore flag nor its opposite are passed). This prevented use of ignore flags from being usable in a gitconfig file.