### PR TITLE
Fix pretty-print diff filtering for added/removed cells etc.

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -190,7 +190,7 @@ def add_diff_args(parser):
         the merge, so these arguments should also be included there.
     """
     # TODO: Define sensible strategy variables and implement
-    #parser.add_argument('-d', '--diff-strategy',
+    #parser.add_argument('-X', '--diff-strategy',
     #                    default="default", choices=("foo", "bar"),
     #                    help="specify the diff strategy to use.")
 
@@ -214,9 +214,13 @@ def add_diff_args(parser):
         '-m', '--metadata',
         action=IgnorableAction,
         help="process/ignore metadata.")
+    ignorables.add_argument(
+        '-d', '--details',
+        action=IgnorableAction,
+        help="process/ignore details not covered by other options.")
 
 
-diff_exclusives = ('sources', 'outputs', 'attachments', 'metadata')
+diff_exclusives = ('sources', 'outputs', 'attachments', 'metadata', 'details')
 
 
 def add_git_diff_driver_args(diff_parser):

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -13,7 +13,12 @@ from .generic import decide_merge_with_diff
 from .decisions import apply_decisions
 from ..diffing.notebooks import diff_notebooks
 from ..utils import Strategies
-from ..prettyprint import pretty_print_notebook_diff, pretty_print_merge_decisions, pretty_print_notebook
+from ..prettyprint import (
+    pretty_print_notebook_diff,
+    pretty_print_merge_decisions,
+    pretty_print_notebook,
+    PrettyPrintConfig
+)
 
 import nbdime.log
 
@@ -130,15 +135,18 @@ def decide_notebook_merge(base, local, remote, args=None):
 
     # Debug outputs
     if args and args.log_level == "DEBUG":
+        # log pretty-print config object:
+        config = PrettyPrintConfig()
+
         nbdime.log.debug("In merge, base-local diff:")
-        buf = StringIO()
-        pretty_print_notebook_diff("<base>", "<local>", base, local_diffs, buf)
-        nbdime.log.debug(buf.getvalue())
+        config.out = StringIO()
+        pretty_print_notebook_diff("<base>", "<local>", base, local_diffs, config)
+        nbdime.log.debug(config.out.getvalue())
 
         nbdime.log.debug("In merge, base-remote diff:")
-        buf = StringIO()
-        pretty_print_notebook_diff("<base>", "<remote>", base, remote_diffs, buf)
-        nbdime.log.debug(buf.getvalue())
+        config.out = StringIO()
+        pretty_print_notebook_diff("<base>", "<remote>", base, remote_diffs, config)
+        nbdime.log.debug(config.out.getvalue())
 
     # Execute a generic merge operation
     decisions = decide_merge_with_diff(
@@ -149,9 +157,9 @@ def decide_notebook_merge(base, local, remote, args=None):
     # Debug outputs
     if args and args.log_level == "DEBUG":
         nbdime.log.debug("In merge, decisions:")
-        buf = StringIO()
-        pretty_print_merge_decisions(base, decisions, buf)
-        nbdime.log.debug(buf.getvalue())
+        config.out = StringIO()
+        pretty_print_merge_decisions(base, decisions, config)
+        nbdime.log.debug(config.out.getvalue())
 
     return decisions
 
@@ -162,11 +170,13 @@ def merge_notebooks(base, local, remote, args=None):
     Return new (partially) merged notebook and unapplied diffs from the local and remote side.
     """
     if args and args.log_level == "DEBUG":
+        # log pretty-print config object:
+        config = PrettyPrintConfig()
         for (name, nb) in [("base", base), ("local", local), ("remote", remote)]:
             nbdime.log.debug("In merge, input %s notebook:", name)
-            buf = StringIO()
-            pretty_print_notebook(nb, None, buf)
-            nbdime.log.debug(buf.getvalue())
+            config.out = StringIO()
+            pretty_print_notebook(nb, config)
+            nbdime.log.debug(config.out.getvalue())
 
     decisions = decide_notebook_merge(base, local, remote, args)
 
@@ -174,9 +184,9 @@ def merge_notebooks(base, local, remote, args=None):
 
     if args and args.log_level == "DEBUG":
         nbdime.log.debug("In merge, merged notebook:")
-        buf = StringIO()
-        pretty_print_notebook(merged, None, buf)
-        nbdime.log.debug(buf.getvalue())
+        config.out = StringIO()
+        pretty_print_notebook(merged, config)
+        nbdime.log.debug(config.out.getvalue())
         nbdime.log.debug("End merge")
 
     return merged, decisions

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -16,7 +16,7 @@ import nbformat
 import nbdime
 import nbdime.log
 from nbdime.merging import merge_notebooks
-from nbdime.prettyprint import pretty_print_merge_decisions
+from nbdime.prettyprint import pretty_print_merge_decisions, PrettyPrintConfig
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 
 _description = ('Merge two Jupyter notebooks "local" and "remote" with a '
@@ -60,9 +60,9 @@ def main_merge(args):
 
     if args.decisions:
         # Print merge decisions (including unconflicted)
-        out = io.StringIO()
-        pretty_print_merge_decisions(b, decisions, out=out)
-        nbdime.log.warning("Decisions:\n%s", out.getvalue())
+        config = PrettyPrintConfig(out=io.StringIO())
+        pretty_print_merge_decisions(b, decisions, config=config)
+        nbdime.log.warning("Decisions:\n%s", config.out.getvalue())
     elif mfn:
         # Write partial or fully completed merge to given foo.ipynb filename
         with io.open(mfn, "w", encoding="utf8"):
@@ -89,8 +89,8 @@ def handle_agreed_deletion(base_fn, output_fn, print_decisions=False):
         bld.agreement([], local_diff=diff, remote_diff=diff)
         decisions = bld.validated(b)
         # Print decition
-        out = io.StringIO()
-        pretty_print_merge_decisions(b, decisions, out=out)
+        config = PrettyPrintConfig(out=io.StringIO())
+        pretty_print_merge_decisions(b, decisions, config=config)
         nbdime.log.warning("Decisions:\n%s", out.getvalue())
 
     elif output_fn:
@@ -119,7 +119,7 @@ def _build_arg_parser():
              "to this file. Otherwise it is printed to the "
              "terminal.")
     parser.add_argument(
-        '-d', '--decisions',
+        '--decisions',
         action="store_true",
         help="print a human-readable summary of conflicted "
              "merge decisions instead of merging the notebook.")

--- a/nbdime/nbshowapp.py
+++ b/nbdime/nbshowapp.py
@@ -11,7 +11,7 @@ import sys
 import argparse
 import nbformat
 
-from nbdime.prettyprint import pretty_print_notebook
+from nbdime.prettyprint import pretty_print_notebook, PrettyPrintConfig
 from nbdime.args import add_generic_args, IgnorableAction, process_exclusive_ignorables
 from nbdime.utils import setup_std_streams
 
@@ -45,17 +45,16 @@ def main_show(args):
         class Printer:
             def write(self, text):
                 print(text, end="")
-        if not any((args.sources, args.outputs, args.attachments, args.metadata, args.details)):
-            ppargs = None
-        else:
-            ppargs = args
+
+        # This configures which parts to include/ignore
+        config = PrettyPrintConfig(out=Printer(), include=args)
 
         if len(args.notebook) > 1:
             # 'more' prints filenames with colons, should be good enough for us as well
             print(":"*14)
             print(fn)
             print(":"*14)
-        pretty_print_notebook(nb, ppargs, Printer())
+        pretty_print_notebook(nb, config)
 
     return 0
 

--- a/nbdime/tests/test_merge_notebooks_inline.py
+++ b/nbdime/tests/test_merge_notebooks_inline.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 from nbdime import merge_notebooks, diff
 from nbdime.diff_format import op_patch
 from nbdime.utils import Strategies
-from nbdime.prettyprint import pretty_print_merge_decisions
 from nbdime.merging.generic import decide_merge, decide_merge_with_diff
 from nbdime.merging.decisions import apply_decisions
 

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -33,6 +33,10 @@ def b64text(nbytes):
     return encodebytes(os.urandom(nbytes)).decode('ascii')
 
 
+def TestConfig():
+    return pp.PrettyPrintConfig(out=StringIO())
+
+
 def test_pretty_print_dict_complex():
     d = {
         'a': 5,
@@ -46,9 +50,9 @@ def test_pretty_print_dict_complex():
     }
     prefix = '-'
 
-    io = StringIO()
-    pp.pretty_print_dict(d, {'d'}, prefix, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_dict(d, {'d'}, prefix, config)
+    text = config.out.getvalue()
 
     print(text)
     for key in d:
@@ -63,9 +67,9 @@ def test_pretty_print_dict_complex():
 def test_pretty_print_multiline_string_b64():
     ins = b64text(1024)
     prefix = '+'
-    io = StringIO()
-    pp.pretty_print_value(ins, prefix, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value(ins, prefix, config)
+    text = config.out.getvalue()
     lines = text.splitlines(True)
     assert len(lines) == 1
     line = lines[0]
@@ -78,9 +82,9 @@ def test_pretty_print_multiline_string_short():
     ins = 'short string'
     prefix = '+'
 
-    io = StringIO()
-    pp.pretty_print_value_at(ins, "no/addr", prefix, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value_at(ins, "no/addr", prefix, config)
+    text = config.out.getvalue()
     lines = text.splitlines(False)
 
     assert lines == [prefix + ins]
@@ -89,9 +93,9 @@ def test_pretty_print_multiline_string_short():
 def test_pretty_print_multiline_string_long():
     ins = '\n'.join('line %i' % i for i in range(64))
     prefix = '+'
-    io = StringIO()
-    pp.pretty_print_value(ins, prefix, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value(ins, prefix, config)
+    text = config.out.getvalue()
     lines = text.splitlines(False)
     assert len(lines) == 64
     assert (prefix + 'line 32') in lines
@@ -100,9 +104,9 @@ def test_pretty_print_multiline_string_long():
 def test_pretty_print_value_int():
     v = 5
     assert pp.format_value(v) == '5'
-    io = StringIO()
-    pp.pretty_print_value(v, "+", io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value(v, "+", config)
+    text = config.out.getvalue()
     print("'%s'" % text)
     assert "+5" in text
     # path is only used for dispatching to special formatters
@@ -118,9 +122,9 @@ def test_format_value_str():
 
 
 def _pretty_print(value, prefix="+", path="/dummypath"):
-    io = StringIO()
-    pp.pretty_print_value_at(value, path, prefix, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value_at(value, path, prefix, config)
+    text = config.out.getvalue()
     return text
 
 
@@ -155,9 +159,9 @@ def test_pretty_print_list_longstrings():
 def test_pretty_print_stream_output():
     output = v4.new_output('stream', name='stdout', text='some\ntext')
 
-    io = StringIO()
-    pp.pretty_print_value_at(output, "/cells/2/outputs/3", "+", io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value_at(output, "/cells/2/outputs/3", "+", config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert lines == [
@@ -176,9 +180,9 @@ def test_pretty_print_display_data():
         'image/png': b64text(1024),
     })
 
-    io = StringIO()
-    pp.pretty_print_value_at(output, "/cells/1/outputs/2", "+", io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value_at(output, "/cells/1/outputs/2", "+", config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert 'output_type: display_data' in text
@@ -192,9 +196,9 @@ def test_pretty_print_display_data():
 def test_pretty_print_markdown_cell():
     cell = v4.new_markdown_cell(source='# Heading\n\n*some markdown*')
 
-    io = StringIO()
-    pp.pretty_print_value_at(cell, "/cells/0", "+", io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value_at(cell, "/cells/0", "+", config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert lines[0] == '+markdown cell:'
@@ -214,9 +218,9 @@ def test_pretty_print_code_cell():
         ]
     )
 
-    io = StringIO()
-    pp.pretty_print_value_at(cell, "/cells/0", "+", io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_value_at(cell, "/cells/0", "+", config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert lines == [
@@ -244,9 +248,9 @@ def test_pretty_print_dict_diff(nocolor):
     b = {'a': 2}
     di = diff(a, b, path='x/y')
 
-    io = StringIO()
-    pp.pretty_print_diff(a, di, 'x/y', io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_diff(a, di, 'x/y', config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert lines == [
@@ -263,9 +267,9 @@ def test_pretty_print_list_diff(nocolor):
     path = '/a/b'
     di = diff(a, b, path=path)
 
-    io = StringIO()
-    pp.pretty_print_diff(a, di, path, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_diff(a, di, path, config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert lines == [
@@ -284,9 +288,9 @@ def test_pretty_print_list_multilinestrings(nocolor):
     path = '/a/b'
     di = diff(a, b, path=path)
 
-    io = StringIO()
-    pp.pretty_print_diff(a, di, path, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_diff(a, di, path, config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     assert lines == [
@@ -322,9 +326,9 @@ def test_pretty_print_string_diff(nocolor):
     di = diff(a, b, path=path)
 
     with mock.patch('nbdime.prettyprint.which', lambda cmd: None):
-        io = StringIO()
-        pp.pretty_print_diff(a, di, path, io)
-        text = io.getvalue()
+        config = TestConfig()
+        pp.pretty_print_diff(a, di, path, config)
+        text = config.out.getvalue()
         lines = text.splitlines()
 
     text = '\n'.join(lines)
@@ -338,9 +342,9 @@ def test_pretty_print_string_diff_b64(nocolor):
     path = '/a/b'
     di = diff(a, b, path=path)
 
-    io = StringIO()
-    pp.pretty_print_diff(a, di, path, io)
-    text = io.getvalue()
+    config = TestConfig()
+    pp.pretty_print_diff(a, di, path, config)
+    text = config.out.getvalue()
     lines = text.splitlines()
 
     ha = pp.hash_string(a)


### PR DESCRIPTION
Overhauls the pretty-print system in order to filter diffs properly according to ignore flags to diff. Also adds the `-d`/`--details` flag to nbdiff for filtering similar to what is available in `nbshow`.

Possible breaking change in CLI arguments: Removed the `-d` short-hand for `--decisions` to nbmerge, as it now conflicts with the `--details` flag's short-hand for diff filtering.

Note that the filtering is still not fully applied for nbdiff-web, which should probably be solved in a different PR.

Fixes #303.