### PR TITLE
Update GitPython version requirement

### DIFF
--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -7,6 +7,7 @@ from collections import deque
 
 from six import string_types
 
+os.environ['GIT_PYTHON_REFRESH'] = 'quiet'
 from git import Repo, InvalidGitRepositoryError, BadName
 
 from .utils import EXPLICIT_MISSING_FILE

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ install_requires = setuptools_args['install_requires'] = [
     'colorama',
     'tornado',
     'requests',
-    'GitPython<=2.1.3',  # For difftool taking git refs
+    'GitPython!=2.1.4, !=2.1.5, !=2.1.6',  # For difftool taking git refs
 ]
 
 extras_require = setuptools_args['extras_require'] = {


### PR DESCRIPTION
GitPython has fixed an error in version 2.1.4 - 2.1.6 in which a missing git command would prevent nbdime from working at all if git was missing. This has now been fixed, so updating the requirement spec.

Ref #295.