### PR TITLE
Fix apparent typo of nbdiff-web

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,7 +84,7 @@ you should see a nice diff view, like this:
 
 To use the web-based GUI viewers of notebook diffs, call::
 
-    nbdime-web [ref [ref]]
+    nbdiff-web [ref [ref]]
 
 .. versionadded:: 0.3
 


### PR DESCRIPTION
This looks like a typo where 'nbdime-web' was entered, which doesn't exist, instead of 'nbdiff-web'.