### PR TITLE
Web diff: Show consequent added/removed cells/outputs side-by-side

### DIFF
--- a/nbdime/webapp/src/index.ts
+++ b/nbdime/webapp/src/index.ts
@@ -29,6 +29,7 @@ import '@jupyterlab/application/style/materialcolors.css';
 import '@jupyterlab/theme-light-extension/style/variables.css';
 import '@jupyterlab/markdownwidget/style/index.css';
 import '@jupyterlab/notebook/style/index.css';
+import '@jupyterlab/cells/style/index.css';
 import '@jupyterlab/rendermime/style/index.css';
 import '@jupyterlab/codemirror/style/index.css';
 

--- a/nbdime/webapp/templates/nbdimepage.html
+++ b/nbdime/webapp/templates/nbdimepage.html
@@ -3,6 +3,7 @@
 
   <head>
     <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>

--- a/packages/nbdime/src/common/mergeview.ts
+++ b/packages/nbdime/src/common/mergeview.ts
@@ -976,7 +976,7 @@ class MergeView extends Panel {
       }
     }
 
-    if (options.collapseIdentical) {
+    if (options.collapseIdentical && panes > 1) {
       this.base.cm.operation(function() {
           collapseIdenticalStretches(self, options.collapseIdentical);
       });

--- a/packages/nbdime/src/diff/model/cell.ts
+++ b/packages/nbdime/src/diff/model/cell.ts
@@ -123,6 +123,40 @@ export class CellDiffModel {
   get deleted(): boolean {
     return this.source.deleted;
   }
+
+  /**
+   * Chunked outputs
+   */
+  getChunkedOutputs(): OutputDiffModel[][] | null {
+    if (this.outputs === null) {
+      return null;
+    }
+    const chunks: OutputDiffModel[][] = [];
+    if (this.added || this.deleted) {
+      // Should not chunk outputs for added/deleted cells
+      // simply make one element chunks:
+      for (let o of this.outputs) {
+        chunks.push([o]);
+      }
+    } else {
+      let currentChunk: OutputDiffModel[] = [];
+      for (let o of this.outputs) {
+        if (o.added || o.deleted) {
+          currentChunk.push(o);
+        } else {
+          if (currentChunk.length) {
+            chunks.push(currentChunk);
+          }
+          chunks.push([o]);
+          currentChunk = [];
+        }
+      }
+      if (currentChunk.length) {
+        chunks.push(currentChunk);
+      }
+    }
+    return chunks;
+  }
 }
 
 export

--- a/packages/nbdime/src/diff/widget/cell.ts
+++ b/packages/nbdime/src/diff/widget/cell.ts
@@ -59,8 +59,6 @@ const SOURCE_ROW_CLASS = 'jp-Cellrow-source';
 const METADATA_ROW_CLASS = 'jp-Cellrow-metadata';
 const OUTPUTS_ROW_CLASS = 'jp-Cellrow-outputs';
 
-const ADD_DEL_LABEL_CLASS = 'jp-Diff-label';
-
 /**
  * A list of MIME types that can be shown as string diff.
  */
@@ -93,17 +91,9 @@ class CellDiffWidget extends Panel {
     // Add 'cell added/deleted' notifiers, as appropriate
     let CURR_DIFF_CLASSES = DIFF_CLASSES.slice();  // copy
     if (model.added) {
-      let widget = new Widget();
-      widget.node.textContent = 'Cell added';
-      widget.addClass(ADD_DEL_LABEL_CLASS);
-      this.addWidget(widget);
       this.addClass(ADDED_DIFF_CLASS);
       CURR_DIFF_CLASSES = DIFF_CLASSES.slice(1, 2);
     } else if (model.deleted) {
-      let widget = new Widget();
-      widget.node.textContent = 'Cell deleted';
-      widget.addClass(ADD_DEL_LABEL_CLASS);
-      this.addWidget(widget);
       this.addClass(DELETED_DIFF_CLASS);
       CURR_DIFF_CLASSES = DIFF_CLASSES.slice(0, 1);
     } else if (model.unchanged) {
@@ -231,22 +221,8 @@ class CellDiffWidget extends Panel {
     let container = new Panel();
     if (model instanceof OutputDiffModel) {
       if (model.added) {
-        if (!parent.added) {
-          // Implies this is added output
-          let addSpacer = new Widget();
-          addSpacer.node.textContent = 'Output added';
-          addSpacer.addClass(ADD_DEL_LABEL_CLASS);
-          container.addWidget(addSpacer);
-        }
         container.addClass(ADDED_DIFF_CLASS);
       } else if (model.deleted) {
-        if (!parent.deleted) {
-          // Implies this is deleted output
-          let delSpacer = new Widget();
-          delSpacer.node.textContent = 'Output deleted';
-          delSpacer.addClass(ADD_DEL_LABEL_CLASS);
-          container.addWidget(delSpacer);
-        }
         container.addClass(DELETED_DIFF_CLASS);
       } else if (model.unchanged) {
         container.addClass(UNCHANGED_DIFF_CLASS);

--- a/packages/nbdime/src/diff/widget/cell.ts
+++ b/packages/nbdime/src/diff/widget/cell.ts
@@ -49,7 +49,7 @@ import {
 /**
  * The class name added to the prompt area of cell.
  */
-const PROMPT_CLASS = 'jp-Cell-prompt';
+const PROMPT_CLASS = 'jp-InputPrompt';
 
 
 export

--- a/packages/nbdime/src/diff/widget/common.ts
+++ b/packages/nbdime/src/diff/widget/common.ts
@@ -9,3 +9,7 @@ export const DELETED_DIFF_CLASS = 'jp-Diff-deleted';
 export const UNCHANGED_DIFF_CLASS = 'jp-Diff-unchanged';
 
 export const DIFF_CLASSES = ['jp-Diff-base', 'jp-Diff-remote'];
+
+export const CHUNK_PANEL_CLASS = 'jp-Diff-addremchunk';
+export const ADDED_CHUNK_PANEL_CLASS = 'jp-Diff-addedchunk';
+export const REMOVED_CHUNK_PANEL_CLASS = 'jp-Diff-removedchunk';

--- a/packages/nbdime/src/diff/widget/notebook.ts
+++ b/packages/nbdime/src/diff/widget/notebook.ts
@@ -25,6 +25,10 @@ import {
 
 const NBDIFF_CLASS = 'jp-Notebook-diff';
 
+const CHUNK_PANEL_CLASS = 'jp-Diff-cellchunk';
+const ADDED_CHUNK_PANEL_CLASS = 'jp-Diff-cellchunk_added';
+const REMOVED_CHUNK_PANEL_CLASS = 'jp-Diff-cellchunk_removed';
+
 
 /**
  * NotebookDiffWidget
@@ -53,11 +57,28 @@ class NotebookDiffWidget extends Panel {
         this.addWidget(new MetadataDiffWidget(model.metadata));
       }
     });
-    for (let c of model.cells) {
+    for (let chunk of model.chunkedCells) {
       work = work.then(() => {
         return new Promise<void>(resolve => {
-          this.addWidget(new CellDiffWidget(c, rendermime, model.mimetype));
-          // This limits us to drawing 60 cells per second, which shoudln't
+          if (chunk.length === 1) {
+            this.addWidget(new CellDiffWidget(
+              chunk[0], rendermime, model.mimetype));
+          } else {
+            let chunkPanel = new Panel();
+            chunkPanel.addClass(CHUNK_PANEL_CLASS);
+            let addedPanel = new Panel();
+            addedPanel.addClass(ADDED_CHUNK_PANEL_CLASS);
+            let removedPanel = new Panel();
+            removedPanel.addClass(REMOVED_CHUNK_PANEL_CLASS);
+            for (let cell of chunk) {
+              let target = cell.deleted ? removedPanel : addedPanel;
+              target.addWidget(new CellDiffWidget(cell, rendermime, model.mimetype));
+            }
+            chunkPanel.addWidget(addedPanel);
+            chunkPanel.addWidget(removedPanel);
+            this.addWidget(chunkPanel);
+          }
+          // This limits us to drawing 60 cells per second, which shouldn't
           // be a problem...
           requestAnimationFrame(() => {
             resolve();

--- a/packages/nbdime/src/diff/widget/notebook.ts
+++ b/packages/nbdime/src/diff/widget/notebook.ts
@@ -15,6 +15,10 @@ import {
 } from './cell';
 
 import {
+  CHUNK_PANEL_CLASS, ADDED_CHUNK_PANEL_CLASS, REMOVED_CHUNK_PANEL_CLASS
+} from './common';
+
+import {
   MetadataDiffWidget
 } from './metadata';
 
@@ -24,10 +28,6 @@ import {
 
 
 const NBDIFF_CLASS = 'jp-Notebook-diff';
-
-const CHUNK_PANEL_CLASS = 'jp-Diff-cellchunk';
-const ADDED_CHUNK_PANEL_CLASS = 'jp-Diff-cellchunk_added';
-const REMOVED_CHUNK_PANEL_CLASS = 'jp-Diff-cellchunk_removed';
 
 
 /**

--- a/packages/nbdime/src/styles/diff.css
+++ b/packages/nbdime/src/styles/diff.css
@@ -168,7 +168,7 @@
   width: 100%;
 }
 
-.jp-Notebook-diff .jp-Cellrow-source .jp-Cell-prompt {
+.jp-Notebook-diff .jp-Cellrow-source .jp-InputPrompt {
   text-align: left;
 }
 

--- a/packages/nbdime/src/styles/diff.css
+++ b/packages/nbdime/src/styles/diff.css
@@ -38,6 +38,7 @@
   margin-bottom: 20px;
 }
 
+/* Border on top of cell */
 .jp-Notebook-diff .jp-Cell-diff > div:first-of-type {
   border-top: solid #ccc 1px;
 }
@@ -58,18 +59,39 @@
 
 .jp-Notebook-diff .jp-Diff-added .jp-Cellrow-source,
 .jp-Notebook-diff .jp-Diff-added .jp-Cellrow-outputs {
-  margin-left: 25%;
-  width: 75%;
   border-left: var(--codemirror-border);
 }
 
 .jp-Notebook-diff .jp-Diff-deleted .jp-Cellrow-source,
 .jp-Notebook-diff .jp-Diff-deleted .jp-Cellrow-outputs {
-  margin-right: 25%;
-  width: 75%;
   border-right: var(--codemirror-border);
 }
 
+/* Add/delete chunks for small width devices (added before delete) */
+.jp-Notebook-diff .jp-Diff-cellchunk {
+  display: flex;
+  flex-direction: column-reverse;
+  justify-content: space-between;
+}
+
+.jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_added,
+.jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_removed {
+  width: 100%;
+}
+
+/* Add/delete chunks should show side-by-side for larger screens */
+@media (min-width: 1000px) {
+  .jp-Notebook-diff .jp-Diff-cellchunk {
+    flex-direction: row-reverse;
+  }
+
+  .jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_added,
+  .jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_removed {
+    width: 49%;
+  }
+}
+
+/* Hide metadata changes by default */
 .jp-Notebook-diff .jp-Diff-added .jp-Cellrow-metadata,
 .jp-Notebook-diff .jp-Diff-deleted .jp-Cellrow-metadata,
 .jp-Notebook-diff .jp-Diff-unchanged .jp-Cellrow-outputs {

--- a/packages/nbdime/src/styles/diff.css
+++ b/packages/nbdime/src/styles/diff.css
@@ -43,19 +43,6 @@
   border-top: solid #ccc 1px;
 }
 
-.jp-Notebook-diff .jp-Diff-added > .jp-Diff-label {
-  left: 0;
-  position: absolute;
-  width: 25%;
-  text-align: center;
-}
-
-.jp-Notebook-diff .jp-Diff-deleted > .jp-Diff-label {
-  right: 0;
-  position: absolute;
-  width: 25%;
-  text-align: center;
-}
 
 .jp-Notebook-diff .jp-Diff-added .jp-Cellrow-source,
 .jp-Notebook-diff .jp-Diff-added .jp-Cellrow-outputs {
@@ -68,25 +55,25 @@
 }
 
 /* Add/delete chunks for small width devices (added before delete) */
-.jp-Notebook-diff .jp-Diff-cellchunk {
+.jp-Notebook-diff .jp-Diff-addremchunk {
   display: flex;
   flex-direction: column-reverse;
   justify-content: space-between;
 }
 
-.jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_added,
-.jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_removed {
+.jp-Notebook-diff .jp-Diff-addremchunk .jp-Diff-addedchunk,
+.jp-Notebook-diff .jp-Diff-addremchunk .jp-Diff-removedchunk {
   width: 100%;
 }
 
 /* Add/delete chunks should show side-by-side for larger screens */
 @media (min-width: 1000px) {
-  .jp-Notebook-diff .jp-Diff-cellchunk {
+  .jp-Notebook-diff .jp-Diff-addremchunk {
     flex-direction: row-reverse;
   }
 
-  .jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_added,
-  .jp-Notebook-diff .jp-Diff-cellchunk .jp-Diff-cellchunk_removed {
+  .jp-Notebook-diff .jp-Diff-addremchunk .jp-Diff-addedchunk,
+  .jp-Notebook-diff .jp-Diff-addremchunk .jp-Diff-removedchunk {
     width: 49%;
   }
 }
@@ -149,14 +136,6 @@
 }
 .jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged {
   text-align: center;
-}
-
-.jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-added > :not(.jp-Diff-label) {
-  margin-left: 25%;
-}
-
-.jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-deleted > :not(.jp-Diff-label) {
-  margin-right: 25%;
 }
 
 .jp-Notebook-diff .CodeMirror-merge-r-chunk { background-color: var(--jp-diff-deleted-color2); }


### PR DESCRIPTION
Chunks blocks of added/removed cells (or outputs) together, allowing them to be shown side-by-side in the web diff. Also adds styling rules so that side-by-side is not used on smaller screens (the removed block is then shown first, followed by the added block).

Also includes a fix for when the first line-number of added/deleted source was hidden.

Fixes #299.