### PR TITLE
Add --color-words to CLI diff entry points

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -223,6 +223,17 @@ def add_diff_args(parser):
 diff_exclusives = ('sources', 'outputs', 'attachments', 'metadata', 'details')
 
 
+def add_diff_cli_args(parser):
+    """Adds a set of arguments for CLI diff commands (i.e. not web).
+    """
+    parser.add_argument(
+        '--color-words',
+        action='store_true', default=False,
+        help=("whether to pass the --color-words flag to any internal calls "
+              "to git diff")
+    )
+
+
 def add_git_diff_driver_args(diff_parser):
     """Adds a set of 7 stanard git diff driver arguments:
         path old-file old-hex old-mode new-file new-hex new-mode [ rename-to ]

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -16,7 +16,9 @@ from six import string_types
 from nbdime.diffing.notebooks import diff_notebooks
 from nbdime.prettyprint import pretty_print_notebook_diff, PrettyPrintConfig
 from nbdime.args import (
-    add_generic_args, add_diff_args, process_diff_flags, resolve_diff_args)
+    add_generic_args, add_diff_args, process_diff_flags, resolve_diff_args,
+    add_diff_cli_args,
+    )
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 from .gitfiles import changed_notebooks, is_gitref
 
@@ -78,7 +80,7 @@ def _handle_diff(base, remote, output, args):
             def write(self, text):
                 print(text, end="")
         # This sets up what to ignore:
-        config = PrettyPrintConfig(out=Printer(), include=args)
+        config = PrettyPrintConfig(out=Printer(), include=args, color_words=args.color_words)
         # Separate out filenames:
         base_name = base if isinstance(base, string_types) else base.name
         remote_name = remote if isinstance(remote, string_types) else remote.name
@@ -94,6 +96,8 @@ def _build_arg_parser():
         )
     add_generic_args(parser)
     add_diff_args(parser)
+    add_diff_cli_args(parser)
+
     parser.add_argument(
         "base", help="The base notebook filename OR base git-revision.",
         nargs='?', default='HEAD',

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -149,6 +149,15 @@ def test_nbdiff_app_ignore_source(filespath, tmpdir, reset_diff_targets):
         diff = diff[0]['diff']
 
 
+def test_nbdiff_app_color_words(filespath):
+    # Simply check that the --color-words argument is accepted, not behavior
+    afn = os.path.join(filespath, "multilevel-test-base.ipynb")
+    bfn = os.path.join(filespath, "multilevel-test-local.ipynb")
+
+    args = nbdiffapp._build_arg_parser().parse_args([afn, bfn, '--color-words'])
+    assert 0 == main_diff(args)
+
+
 def test_nbmerge_app(tempfiles, capsys):
     bfn = os.path.join(tempfiles, "multilevel-test-base.ipynb")
     lfn = os.path.join(tempfiles, "multilevel-test-local.ipynb")

--- a/nbdime/vcs/git/diffdriver.py
+++ b/nbdime/vcs/git/diffdriver.py
@@ -25,7 +25,8 @@ from subprocess import check_call, CalledProcessError
 
 from nbdime.args import (
     add_git_config_subcommand, add_generic_args, add_diff_args, add_web_args,
-    add_git_diff_driver_args)
+    add_git_diff_driver_args, add_diff_cli_args,
+    )
 from nbdime.utils import locate_gitattributes, ensure_dir_exists, setup_std_streams
 
 def enable(scope=None):
@@ -80,6 +81,7 @@ def _build_arg_parser():
     )
     add_git_diff_driver_args(diff_parser)
     add_diff_args(diff_parser)
+    add_diff_cli_args(diff_parser)
 
     webdiff_parser = subparsers.add_parser('webdiff',
         description="The actual entrypoint for the webdiff tool. Git will call this."

--- a/nbdime/vcs/hg/diff.py
+++ b/nbdime/vcs/hg/diff.py
@@ -16,7 +16,10 @@ import sys
 
 from nbdime import nbdiffapp
 from nbdime.diffing.directorydiff import diff_directories
-from nbdime.args import add_diff_args, add_filename_args, diff_exclusives, process_exclusive_ignorables
+from nbdime.args import (
+    add_diff_args, add_filename_args, diff_exclusives, process_exclusive_ignorables,
+    add_diff_cli_args,
+)
 
 
 def main(args=None):
@@ -28,6 +31,7 @@ def main(args=None):
     )
 
     add_diff_args(parser)
+    add_diff_cli_args(parser)
     add_filename_args(parser, ('base', 'remote'))
 
     opts = parser.parse_args(args)


### PR DESCRIPTION
Adds an argument to CLI diff entry points, which controls whether any calls out to `git diff` will use the `--color-words` argument. Off by default, due to its white-space stripping nature, c.f. #293, but can now be turned back on manually (opt-in).

Fixes #293.