### PR TITLE
Web: Render fixes

### DIFF
--- a/packages/nbdime/src/diff/model/output.ts
+++ b/packages/nbdime/src/diff/model/output.ts
@@ -23,6 +23,9 @@ import {
 } from './string';
 
 
+const TEXT_MIMETYPES = ['text/plain', 'application/vnd.jupyter.stdout',
+                        'application/vnd.jupyter.stderr'];
+
 
 /**
  * Diff model for single cell output entries.
@@ -44,7 +47,7 @@ class OutputDiffModel extends RenderableDiffModel<nbformat.IOutput> {
   hasMimeType(mimetype: string): string | null {
     let outputs = this.base || this.remote!;
     if (nbformat.isStream(outputs) &&
-          mimetype === 'application/vnd.jupyter.console-text') {
+        TEXT_MIMETYPES.indexOf(mimetype) !== -1) {
       return 'text';
     } else if (nbformat.isError(outputs)) {
       return 'traceback';

--- a/packages/nbdime/src/styles/diff.css
+++ b/packages/nbdime/src/styles/diff.css
@@ -134,10 +134,12 @@
   width: initial;
   max-width: 100%;
 }
-.jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged {
+/* Ensure unchanged images are centered */
+.jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged .jp-Rendered-Image {
   text-align: center;
 }
 
+/* Color diff highlighting according to style vars */
 .jp-Notebook-diff .CodeMirror-merge-r-chunk { background-color: var(--jp-diff-deleted-color2); }
 .jp-Notebook-diff .CodeMirror-merge-r-chunk-start { border-top: 1px solid var(--jp-diff-deleted-color1); }
 .jp-Notebook-diff .CodeMirror-merge-r-chunk-end { border-bottom: 1px solid var(--jp-diff-deleted-color1); }

--- a/packages/nbdime/src/styles/diff.css
+++ b/packages/nbdime/src/styles/diff.css
@@ -135,7 +135,7 @@
   max-width: 100%;
 }
 /* Ensure unchanged images are centered */
-.jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged .jp-Rendered-Image {
+.jp-Notebook-diff .jp-Diff-twoway .jp-Cellrow-outputs .jp-Diff-unchanged .jp-RenderedImage {
   text-align: center;
 }
 


### PR DESCRIPTION
 - Updates MIME type check to follow update in jupyterlab dependency.
 - Ensures images in unchanged outputs are centered, *without* centering unchanged text outputs.