### PR TITLE
Fix chunking of patched cells + CSS

### DIFF
--- a/nbdime/webapp/src/app/common.ts
+++ b/nbdime/webapp/src/app/common.ts
@@ -9,7 +9,7 @@ import {
 } from 'nbdime/lib/common/exceptions';
 
 import {
-  UNCHANGED_DIFF_CLASS
+  UNCHANGED_DIFF_CLASS, CHUNK_PANEL_CLASS
 } from 'nbdime/lib/diff/widget/common';
 
 import {
@@ -141,6 +141,22 @@ function toggleShowUnchanged(show?: boolean) {
 
 
 /**
+ * Gets the chunk element of an added/removed cell, or the cell element for others
+ * @param cellElement
+ */
+function getChunkElement(cellElement: Element): Element {
+  if (!cellElement.parentElement || !cellElement.parentElement.parentElement) {
+    return cellElement;
+  }
+  let chunkCandidate = cellElement.parentElement.parentElement;
+  if (chunkCandidate.classList.contains(CHUNK_PANEL_CLASS)) {
+    return chunkCandidate;
+  }
+  return cellElement;
+}
+
+
+/**
  * Marks certain cells with
  */
 export
@@ -156,7 +172,8 @@ function markUnchangedRanges() {
       if (rangeStart !== -1) {
         // Previous was hidden
         let N = i - rangeStart;
-        child.setAttribute('data-nbdime-NCellsHiddenBefore', N.toString());
+        // Set attribute on element / chunk element as appropriate
+        getChunkElement(child).setAttribute('data-nbdime-NCellsHiddenBefore', N.toString());
         rangeStart = -1;
       }
     } else if (rangeStart === -1) {
@@ -172,7 +189,8 @@ function markUnchangedRanges() {
     }
     let N = children.length - rangeStart;
     let lastVisible = children[rangeStart - 1];
-    lastVisible.setAttribute('data-nbdime-NCellsHiddenAfter', N.toString());
+    // Set attribute on element / chunk element as appropriate
+    getChunkElement(lastVisible).setAttribute('data-nbdime-NCellsHiddenAfter', N.toString());
   }
 }
 

--- a/nbdime/webapp/src/app/diff.css
+++ b/nbdime/webapp/src/app/diff.css
@@ -56,7 +56,8 @@
 }
 
 /* Show a marker with the number of cells hidden before */
-#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore]::before {
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore]::before,
+#nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenBefore]::before {
   content: attr(data-nbdime-NCellsHiddenBefore) " unchanged cell(s) hidden";
   position: absolute;
   width: 100%;
@@ -68,7 +69,8 @@
 }
 
 /* Show a marker with the number of cells hidden after (for hidden cells at end) */
-#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter]::after {
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter]::after,
+#nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenAfter]::after {
   content: attr(data-nbdime-NCellsHiddenAfter) " unchanged cell(s) hidden";
   position: absolute;
   width: 100%;
@@ -79,10 +81,12 @@
   text-align: center;
 }
 
-#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore] {
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore],
+#nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenBefore] {
   padding-top: 40px;
 }
 
-#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter] {
+#nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter],
+#nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenAfter] {
   padding-bottom: 40px;
 }

--- a/packages/nbdime/src/diff/model/notebook.ts
+++ b/packages/nbdime/src/diff/model/notebook.ts
@@ -100,6 +100,11 @@ export class NotebookDiffModel {
           currentChunk.push(cell);
         }
       } else if (e.op === 'patch') {
+        // Ensure patches gets their own chunk, even if they share index:
+        if (currentChunk.length > 0) {
+          currentChunk = [];
+          this.chunkedCells.push(currentChunk);
+        }
         // A cell has changed:
         let cell = createPatchedCellDiffModel(base.cells[index], e.diff, this.mimetype);
         this.cells.push(cell);

--- a/packages/nbdime/src/diff/widget/notebook.ts
+++ b/packages/nbdime/src/diff/widget/notebook.ts
@@ -60,7 +60,7 @@ class NotebookDiffWidget extends Panel {
     for (let chunk of model.chunkedCells) {
       work = work.then(() => {
         return new Promise<void>(resolve => {
-          if (chunk.length === 1) {
+          if (chunk.length === 1 && !(chunk[0].added || chunk[0].deleted)) {
             this.addWidget(new CellDiffWidget(
               chunk[0], rendermime, model.mimetype));
           } else {


### PR DESCRIPTION
Fixes #325.

Fixes the following issues introduced in #317:
 - Patches no longer chunk with directly preceding additions (i.e. presentation cell chunks in web view).
- "N unchanged cells hidden" pseudo-elements are now added to chunk element if appropriate, in order to ensure a full width banner as expected.

Screenshot of fixed layout, corresponding to broken one in #325.

![nbdime_fix_styling](https://user-images.githubusercontent.com/510760/33036114-cf3abd3a-ce2d-11e7-8a0a-13c960b3434e.png)
