### PR TITLE
Polyfill mathjax config for older notebook versions

### DIFF
--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -119,6 +119,14 @@ class NbdimeHandler(IPythonHandler):
     def curdir(self):
         return self.params.get('cwd', os.curdir)
 
+    # Polyfill in until we can rely on Notebook 5.0 being present
+    @property
+    def mathjax_config(self):
+        try:
+            return super(NbdimeHandler, self).mathjax_config
+        except AttributeError:
+            return 'TeX-AMS_HTML-full,Safe'
+
 
 class MainHandler(NbdimeHandler):
     def get(self):


### PR DESCRIPTION
Would cause `AttributeError` for anyone on notebook less than version 5.