### PR TITLE
Ignoring noisy standard metadata on --ignore-details

### DIFF
--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -548,8 +548,12 @@ def set_notebook_diff_targets(sources=True, outputs=True, attachments=True, meta
     metadata_keys = ("/cells/*/metadata", "/metadata", "/cells/*/outputs/*/metadata")
     if metadata:
         for key in metadata_keys:
-            if key in notebook_differs:
-                del notebook_differs[key]
+            if details:
+                if key in notebook_differs:
+                    del notebook_differs[key]
+            else:
+                notebook_differs[key] = diff_ignore_keys(
+                    inner_differ=diff, ignore_keys=['collapsed', 'autoscroll', 'deletable', 'editable'])
     else:
         for key in metadata_keys:
             notebook_differs[key] = diff_ignore


### PR DESCRIPTION
That would be great to have more control over what can be ignored in comparisons.

Perhaps at least some "standard and obvoiusly noisy" attributes should be dropped from metadata when "--ignore-details" is used?

I propose a static list below, but it'd be great if that could be done through some kind of configuration...

(I am sorry I was unable to pass the pytest suite because my global git configuration was lacking and some seamingly test-purpose repos were not created. Still, I hope I don't break anything important, though literal comparisons may differ if attributes I like removed were present...)