### PR TITLE
Add git filter integration

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -232,13 +232,42 @@ def add_diff_cli_args(parser):
     )
 
 
+def add_filter_args(diff_parser):
+    """Adds configuration for git commands where filter use is flagged"""
+    # Ideally, we would want to apply the filter only if we knew
+    # the file was not from a blob. However, this is not possible:
+    # If remote file path is equal to repo file path, it implies
+    # that the hex of remote equals the hex of the file on disk.
+    # Two possible cases can cause this:
+    # 1) Diffing against working dir (or stage when entire file is staged)
+    # 2) Diffing against a blob (clean) that happens to have the same hex as
+    #    the (smudged) file in working tree.
+    # Condition 1 should have filter applied, 2 should not.
+    # We can learn something by comparing the remote hash to the hash of the
+    # file in HEAD.
+    # - If they are equal, we know that is cannot come from a diff
+    #   agains working tree (git would not see it as changed),
+    #   so it must be from a blob (clean). No filter.
+    # - If they differ, consider the setup:
+    #   git co A; git co B -- file.path; git reset A
+    #   + remote could be from a working-tree diff: git diff (smudged, apply filter).
+    #   + remote could be from a blob: git diff A B (clean, no filter).
+    #
+    # These are undistinguishable to us. Therefore, we will always
+    # apply the filter to the remote file if flag use_filter is set.
+    diff_parser.add_argument(
+        '--use-filter',
+        action='store_true', default=False,
+        help='apply any configured git filters on remote')
+
+
 def add_git_diff_driver_args(diff_parser):
     """Adds a set of 7 stanard git diff driver arguments:
         path old-file old-hex old-mode new-file new-hex new-mode [ rename-to ]
 
     Note: Only path, base and remote are added to parsed namespace
     """
-
+    add_filter_args(diff_parser)
     diff_parser.add_argument('path')
     diff_parser.add_argument('base', nargs='?', default=None)
     diff_parser.add_argument('base_sha1', nargs='?', default=None, action=SkipAction)

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -10,6 +10,7 @@ from six import string_types
 os.environ['GIT_PYTHON_REFRESH'] = 'quiet'
 from git import Repo, InvalidGitRepositoryError, BadName, NoSuchPathError
 
+from nbdime.vcs.git.filter_integration import apply_possible_filter
 from .utils import EXPLICIT_MISSING_FILE, pushd
 
 
@@ -100,6 +101,13 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
         if blob is None:
             # Diffing against working copy, use file on disk!
             with pushd(repo_dir):
+                # Ensure we filter if appropriate:
+                if ref_name is None:
+                    # We are diffing against working dir, so remote is candidate
+                    ret = apply_possible_filter(path)
+                    # ret == path means no filter was applied
+                    if ret != path:
+                        return ret
                 try:
                     return io.open(path)
                 except IOError:

--- a/nbdime/tests/filters/add_helper.py
+++ b/nbdime/tests/filters/add_helper.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+Test git filter for notebooks that adds a cell on clean, and removes it on smudge.
+
+Useful, as it is both a deterministic, circular filter, but also one that
+adds content on clean (normally it is the reverse).
+"""
+
+import argparse
+import sys
+
+import nbformat
+
+from nbdime.utils import setup_std_streams
+
+
+# Generate a marker
+MARKER = 'nbdime test filter marker'
+
+
+def _build_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'mode', default=None,
+        help='The mode to run the filter in. Either "clean" or "smudge".')
+    return parser
+
+
+def clean(notebook):
+    if get_marker_cell(notebook) is None:
+        notebook['cells'].append(nbformat.v4.new_raw_cell(
+            source=MARKER
+        ))
+
+def smudge(notebook):
+    if get_marker_cell(notebook) is not None:
+        notebook['cells'].pop()
+
+
+def get_marker_cell(notebook):
+    if not notebook['cells']:
+        return None
+    candidate = notebook['cells'][-1]
+    if candidate['cell_type'] != 'raw':
+        return None
+    source = candidate['source']
+    if source == MARKER:
+        return candidate
+
+def do_filter(notebook, args):
+    if args.mode == 'clean':
+        return clean(notebook)
+    elif args.mode == 'smudge':
+        return smudge(notebook)
+
+    raise argparse.ArgumentError(
+        args.mode,
+        'mode can only be "clean" or "smudge", got %r.' % args.mode
+    )
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    setup_std_streams()
+    nb = nbformat.read(sys.stdin, as_version=4)
+    opts = _build_arg_parser().parse_args(args)
+    do_filter(nb, opts)
+    nbformat.write(nb, sys.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nbdime/tests/filters/noop.py
+++ b/nbdime/tests/filters/noop.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""A no-op filter.
+"""
+
+import argparse
+import sys
+
+import nbformat
+
+from nbdime.utils import setup_std_streams
+
+
+def _build_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'mode', default=None,
+        help='The mode to run the filter in. Either "clean" or "smudge".')
+    return parser
+
+
+def clean(notebook):
+    pass
+
+
+def smudge(notebook):
+    pass
+
+
+def do_filter(notebook, args):
+    if args.mode == 'clean':
+        return clean(notebook)
+    elif args.mode == 'smudge':
+        return smudge(notebook)
+
+    raise argparse.ArgumentError(
+        args.mode,
+        'mode can only be "clean" or "smudge", got %r.' % args.mode
+    )
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    setup_std_streams()
+    nb = nbformat.read(sys.stdin, as_version=4)
+    opts = _build_arg_parser().parse_args(args)
+    do_filter(nb, opts)
+    nbformat.write(nb, sys.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nbdime/tests/filters/strip_outputs.py
+++ b/nbdime/tests/filters/strip_outputs.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""A test filter that removes outputs on clean, no-op on smudge.
+"""
+
+import argparse
+import sys
+
+import nbformat
+
+from nbdime.utils import setup_std_streams
+
+
+def _build_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'mode', default=None,
+        help='The mode to run the filter in. Either "clean" or "smudge".')
+    return parser
+
+
+def clean(notebook):
+    for cell in notebook['cells']:
+        if 'outputs' in cell:
+            cell['outputs'] = []
+
+
+def smudge(notebook):
+    pass
+
+
+def do_filter(notebook, args):
+    if args.mode == 'clean':
+        return clean(notebook)
+    elif args.mode == 'smudge':
+        return smudge(notebook)
+
+    raise argparse.ArgumentError(
+        args.mode,
+        'mode can only be "clean" or "smudge", got %r.' % args.mode
+    )
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    setup_std_streams()
+    nb = nbformat.read(sys.stdin, as_version=4)
+    opts = _build_arg_parser().parse_args(args)
+    do_filter(nb, opts)
+    nbformat.write(nb, sys.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import io
 import os
 from os.path import join as pjoin
+import sys
 
 import mock
 import pytest
@@ -67,6 +68,122 @@ expected_source_only = """nbdiff {0} {1}
 
 """
 
+expected_no_filter = """nbdiff {0} {1}
+--- {0}  {2}
++++ {1}  {3}
+## inserted before /cells/2:
++  code cell:
++    execution_count: 2
++    metadata (known keys):
++      collapsed: False
++    source:
++      x
+
+## deleted /cells/3:
+-  code cell:
+-    execution_count: 2
+-    metadata (known keys):
+-      collapsed: False
+-    source:
+-      x
+
+## inserted before /cells/5:
++  code cell:
++    metadata (known keys):
++      collapsed: False
++    source:
++      x
+
+## deleted /cells/6:
+-  code cell:
+-    metadata (known keys):
+-      collapsed: False
+-    source:
+-      x
+
+"""
+
+expected_strip_output_filter = """nbdiff {0} {1}
+--- {0}  {2}
++++ {1}  {3}
+## inserted before /cells/2:
++  code cell:
++    execution_count: 2
++    metadata (known keys):
++      collapsed: False
++    source:
++      x
+
+## deleted /cells/3:
+-  code cell:
+-    execution_count: 2
+-    metadata (known keys):
+-      collapsed: False
+-    source:
+-      x
+-    outputs:
+-      output 0:
+-        output_type: execute_result
+-        execution_count: 2
+-        data:
+-          text/plain: 3
+
+## replaced (type changed from int to NoneType) /cells/5/execution_count:
+-  4
++  None
+
+## deleted /cells/5/outputs/0:
+-  output:
+-    output_type: execute_result
+-    execution_count: 4
+-    data:
+-      text/plain: 5
+
+## replaced (type changed from NoneType to int) /cells/6/execution_count:
+-  None
++  4
+
+"""
+
+expected_helper_filter = """nbdiff {0} {1}
+--- {0}  {2}
++++ {1}  {3}
+## inserted before /cells/2:
++  code cell:
++    execution_count: 2
++    metadata (known keys):
++      collapsed: False
++    source:
++      x
+
+## deleted /cells/3:
+-  code cell:
+-    execution_count: 2
+-    metadata (known keys):
+-      collapsed: False
+-    source:
+-      x
+
+## inserted before /cells/5:
++  code cell:
++    metadata (known keys):
++      collapsed: False
++    source:
++      x
+
+## inserted before /cells/6:
++  raw cell:
++    source:
++      nbdime test filter marker
+
+## deleted /cells/6:
+-  code cell:
+-    metadata (known keys):
+-      collapsed: False
+-    source:
+-      x
+
+"""
 
 def test_git_diff_driver(filespath, capsys, nocolor, needs_git):
     # Simulate a call from `git diff` to check basic driver functionality
@@ -131,19 +248,29 @@ def test_git_diff_driver_ignore_flags(filespath, capsys, nocolor, needs_git, res
         assert cap_out == expected_source_only.format(fn1, fn2, t1, t2)
 
 
-def test_git_diff_driver_filter(git_repo, capsys, nocolor):
-    # Setup no-op filter
+
+def _config_filter_driver(name, capsys):
+    path = os.path.abspath(pjoin(os.path.dirname(__file__), 'filters', '%s.py' % name))
+    base_cmd = '%s %s' % (sys.executable, path)
     gitattr = locate_gitattributes()
     with io.open(gitattr, 'a', encoding="utf8") as f:
-        f.write(u'\n*.ipynb\tfilter=myfilter\n')
+        f.write(u'\n*.ipynb\tfilter=%s\n' % (name,))
     with capsys.disabled():
-        call('git config --local --add filter.myfilter.clean "cat"')
+        call('git config --local --add filter.%s.clean "%s clean"' % (name, base_cmd))
+        call('git config --local --add filter.%s.smudge "%s smudge"' % (name, base_cmd))
 
-    fn1 = pjoin(git_repo, 'merge-conflict.ipynb')
-    fn2 = pjoin(git_repo, 'diff.ipynb')
+
+def test_git_diff_driver_noop_filter(git_repo, filespath, capsys, nocolor):
+    _config_filter_driver('noop', capsys)
+    fn1 = pjoin(git_repo, 'diff.ipynb')
+    fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
+    t1 = file_timestamp(fn1)
+    t2 = file_timestamp(fn2)
 
     mock_argv = [
-        '/mock/path/git-nbdiffdriver', 'diff', '-O',
+        '/mock/path/git-nbdiffdriver', 'diff',
+        '--use-filter',
+        '-O',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
         fn2, 'invalid_mock_checksum', '100644']
@@ -152,7 +279,71 @@ def test_git_diff_driver_filter(git_repo, capsys, nocolor):
         r = gdd_main()
         assert r == 0
         cap_out = capsys.readouterr()[0]
-        assert cap_out
+        assert cap_out == expected_no_filter.format(fn1, fn2, t1, t2)
+
+
+def test_git_diff_driver_strip_outputs_filter(git_repo, filespath, capsys, nocolor):
+    _config_filter_driver('strip_outputs', capsys)
+    fn1 = pjoin(git_repo, 'diff.ipynb')
+    fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
+    t1 = file_timestamp(fn1)
+    t2 = file_timestamp(fn2)
+
+    mock_argv = [
+        '/mock/path/git-nbdiffdriver', 'diff',
+        '--use-filter',
+        fn1,
+        fn1, 'invalid_mock_checksum', '100644',
+        fn2, 'invalid_mock_checksum', '100644']
+
+    with mock.patch('sys.argv', mock_argv):
+        r = gdd_main()
+        assert r == 0
+        cap_out = capsys.readouterr()[0]
+        assert cap_out == expected_strip_output_filter.format(fn1, fn2, t1, t2)
+
+
+def test_git_diff_driver_add_helper_filter(git_repo, filespath, capsys, nocolor):
+    _config_filter_driver('add_helper', capsys)
+    fn1 = pjoin(git_repo, 'diff.ipynb')
+    fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
+    t1 = file_timestamp(fn1)
+    t2 = file_timestamp(fn2)
+
+    mock_argv = [
+        '/mock/path/git-nbdiffdriver', 'diff',
+        '--use-filter',
+        '-O',
+        fn1,
+        fn1, 'invalid_mock_checksum', '100644',
+        fn2, 'invalid_mock_checksum', '100644']
+
+    with mock.patch('sys.argv', mock_argv):
+        r = gdd_main()
+        assert r == 0
+        cap_out = capsys.readouterr()[0]
+        assert cap_out == expected_helper_filter.format(fn1, fn2, t1, t2)
+
+
+def test_git_diff_driver_no_filter_without_flag(git_repo, filespath, capsys, nocolor):
+    _config_filter_driver('add_helper', capsys)
+    fn1 = pjoin(git_repo, 'diff.ipynb')
+    fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
+    t1 = file_timestamp(fn1)
+    t2 = file_timestamp(fn2)
+
+    mock_argv = [
+        '/mock/path/git-nbdiffdriver', 'diff',
+        '-O',
+        fn1,
+        fn1, 'invalid_mock_checksum', '100644',
+        fn2, 'invalid_mock_checksum', '100644']
+
+    with mock.patch('sys.argv', mock_argv):
+        r = gdd_main()
+        assert r == 0
+        cap_out = capsys.readouterr()[0]
+        assert cap_out == expected_no_filter.format(fn1, fn2, t1, t2)
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)

--- a/nbdime/tests/test_git_filter_integration.py
+++ b/nbdime/tests/test_git_filter_integration.py
@@ -1,0 +1,108 @@
+
+import io
+import os
+from six import StringIO
+
+import nbformat
+
+from nbdime.vcs.git.filter_integration import (
+    interrogate_filter, apply_possible_filter, get_clean_filter_cmd)
+from nbdime.utils import locate_gitattributes
+
+from .utils import call
+
+pjoin = os.path.join
+
+
+def test_interrogate_filter_no_repo(filespath):
+    assert interrogate_filter(pjoin(filespath, 'foo--1.ipynb')) is None
+
+
+def test_interrogate_filter_blank(git_repo):
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\tfilter=\n')
+
+    attr = interrogate_filter(pjoin(git_repo, 'foo--1.ipynb'))
+
+    assert attr is None
+
+
+def test_interrogate_filter_unspecified(git_repo):
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\t!filter\n')
+
+    attr = interrogate_filter(pjoin(git_repo, 'foo--1.ipynb'))
+
+    assert attr is None
+
+
+def test_interrogate_filter_value(git_repo):
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\tfilter=myfilter\n')
+
+    attr = interrogate_filter(pjoin(git_repo, 'diff.ipynb'))
+
+    assert attr == 'myfilter'
+
+
+def test_interrogate_filter_set(git_repo):
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\tfilter\n')
+
+    attr = interrogate_filter(pjoin(git_repo, 'diff.ipynb'))
+
+    assert attr is None
+
+
+def test_interrogate_filter_unset(git_repo):
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\t-filter\n')
+
+    attr = interrogate_filter(pjoin(git_repo, 'diff.ipynb'))
+
+    assert attr is None
+
+
+def test_filter_cmd_invalid_filter():
+    assert get_clean_filter_cmd('mynonexistantfilter') is None
+
+
+def test_filter_cmd_valid_filter(git_repo):
+    call('git config --local --add filter.myfilter.clean "testcmd --arg"')
+    assert get_clean_filter_cmd('myfilter') == 'testcmd --arg'
+
+
+
+def test_apply_filter_no_repo(filespath):
+    path = pjoin(filespath, 'foo--1.ipynb')
+    assert apply_possible_filter(path) == path
+
+
+def test_apply_filter_no_filter(git_repo):
+    path = pjoin(git_repo, 'diff.ipynb')
+    assert apply_possible_filter(path) == path
+
+
+def test_apply_filter_invalid_filter(git_repo):
+    path = pjoin(git_repo, 'diff.ipynb')
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\tfilter=myfilter\n')
+    assert apply_possible_filter(path) == path
+
+
+def test_apply_filter_valid_filter(git_repo):
+    path = pjoin(git_repo, 'diff.ipynb')
+    gitattr = locate_gitattributes()
+    with io.open(gitattr, 'a', encoding="utf8") as f:
+        f.write(u'\n*.ipynb\tfilter=myfilter\n')
+    call('git config --local --add filter.myfilter.clean "cat"')
+    f = apply_possible_filter(path)
+    assert isinstance(f, StringIO)
+    # Read validates notebook:
+    nbformat.validate(nbformat.read(f, as_version=4))

--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -180,7 +180,7 @@ def ensure_dir_exists(path):
 def locate_gitattributes(scope=None):
     """Locate the .gitattributes file
 
-    returns None if not in a git repo and global=False
+    returns None if not in a git repo and scope=None
     """
     if scope == 'global':
         try:

--- a/nbdime/vcs/git/difftool.py
+++ b/nbdime/vcs/git/difftool.py
@@ -27,7 +27,7 @@ def enable(scope=None, set_default=False):
     """Enable nbdime git difftool"""
     cmd = ['git', 'config']
     if scope:
-        assert scope in ('global', 'system'), 'invalid scope value'
+        assert scope in ('global', 'system'), 'invalid scope value: %r' % scope
         cmd.append('--' + scope)
 
     check_call(cmd + ['difftool.nbdime.cmd', 'git-nbdifftool diff "$LOCAL" "$REMOTE" "$BASE"'])
@@ -42,7 +42,7 @@ def disable(scope=None, *args):
     """Disable nbdime git difftool"""
     cmd = ['git', 'config']
     if scope:
-        assert scope in ('global', 'system'), 'invalid scope value'
+        assert scope in ('global', 'system'), 'invalid scope value: %r' % scope
         cmd.append('--' + scope)
     try:
         tool = check_output(cmd + ['diff.guitool']).decode('utf8', 'replace').strip()

--- a/nbdime/vcs/git/filter_integration.py
+++ b/nbdime/vcs/git/filter_integration.py
@@ -1,0 +1,86 @@
+
+import io
+import os
+from subprocess import check_output, STDOUT, CalledProcessError
+import sys
+
+from six import StringIO
+
+from nbdime.utils import EXPLICIT_MISSING_FILE
+
+
+USE_SHELL = os.name == 'nt'
+
+class NamedStringIO(StringIO):
+    name = ''
+
+
+def interrogate_filter(path):
+    """Check whether a filter git attribute is set for path.
+
+    Returns None if no valid filter attribute could be found.
+    """
+    # Ask for the fit attributes of file on path (-z = null-terminated fields)
+    try:
+        spec = check_output(['git', 'check-attr', '-z', 'filter', path])
+    except CalledProcessError:
+        return None
+    path_list, attr, info = [s.decode('utf8', 'replace') for s in spec.split(b'\x00')[:3]]
+    if attr != 'filter' or path != path_list:
+        raise ValueError(
+            'Unexpected output from git check-attr. ' +
+            ('Expected to start with "%s\x00filter", ' % path) +
+            ('started with "%s\x00%s"' % (path_list, attr))
+        )
+    if not info or info in ('unspecified', 'set', 'unset'):
+        return None
+    # We have a valid attribute
+    return info
+
+
+def get_clean_filter_cmd(filter_attr):
+    """Given a filter attribute, look up its driver in git config.
+
+    Returns None if noe valid config could be found.
+    """
+    try:
+        spec = check_output([
+            'git', 'config', '--get', '-z', 'filter.%s.clean' % filter_attr
+        ])
+        return spec.split(b'\x00')[0].decode('utf8', 'replace') or None
+    except CalledProcessError:
+        return None
+
+
+def apply_possible_filter(git_path, path=None):
+    """Apply any configured git filters to path.
+
+    Returns the original remote path if no filter is configured,
+    or a StringIO instance with the filtered content if a filter
+    should be applied.
+    """
+    if path is None:
+        path = git_path
+
+    if path == EXPLICIT_MISSING_FILE:
+        return path
+
+    filter_attr = interrogate_filter(git_path)
+    if not filter_attr:
+        return path
+    filter_cmd = get_clean_filter_cmd(filter_attr)
+    if not filter_cmd:
+        return path
+
+    # Apply filter and pipe to a string buffer
+    with io.open(path, 'r', encoding="utf8") as f:
+        output = check_output(
+            filter_cmd.split(),
+            stdin=f,
+            stderr=STDOUT, shell=USE_SHELL
+        ).decode('utf8', 'replace')
+    buffer = NamedStringIO()
+    buffer.name = path
+    buffer.write(output)
+    buffer.seek(0)
+    return buffer

--- a/nbdime/vcs/git/mergedriver.py
+++ b/nbdime/vcs/git/mergedriver.py
@@ -95,7 +95,8 @@ def main(args=None):
     # - NOTE: This is not where the driver should store its output, see below!
 
 
-    config = add_git_config_subcommand(subparsers,
+    add_git_config_subcommand(
+        subparsers,
         enable, disable,
         subparser_help="Configure git to use nbdime for notebooks in `git merge`",
         enable_help="enable nbdime merge driver via git config",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ jstargets = [
 package_data = {
     name: [
         'tests/files/*.*',
+        'tests/filters/*.py',
         '*.schema.json',
         'webapp/static/*.*',
         'webapp/templates/*.*',


### PR DESCRIPTION
- Adds capability for applying git filters according to git config.
- Applies filter on remote as it should for calls to `nbdiff` with git refs.
- As diff drivers/tools cannot correctly apply filters, it will always apply any filter on remote if the flag `--use-filter` is given, otherwise it will not consider filters.