### PR TITLE
Improve error feedback for extensions

### DIFF
--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -8,7 +8,10 @@ from collections import deque
 from six import string_types
 
 os.environ['GIT_PYTHON_REFRESH'] = 'quiet'
-from git import Repo, InvalidGitRepositoryError, BadName, NoSuchPathError
+from git import (
+    Repo, InvalidGitRepositoryError, BadName, NoSuchPathError,
+    GitCommandNotFound,
+)
 
 from .utils import EXPLICIT_MISSING_FILE, pushd
 

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -26,7 +26,8 @@ from .nbdimeserver import (
 
 from ..gitfiles import (
     changed_notebooks, is_path_in_repo, find_repo_root,
-    InvalidGitRepositoryError, BadName)
+    InvalidGitRepositoryError, BadName, GitCommandNotFound,
+    )
 from ..utils import split_os_path, EXPLICIT_MISSING_FILE, read_notebook
 
 
@@ -102,6 +103,12 @@ class ExtensionApiDiffHandler(ApiDiffHandler):
         except (InvalidGitRepositoryError, BadName) as e:
             self.log.exception(e)
             raise HTTPError(422, 'Invalid notebook: %s' % base_arg)
+        except GitCommandNotFound as e:
+            self.log.exception(e)
+            raise HTTPError(
+                500, 'Could not find git executable. '
+                     'Please ensure git is available to the server process.')
+
         return base_nb, remote_nb
 
     @gen.coroutine


### PR DESCRIPTION
Improves the error reporting for the extensions:
 - Server handler message is informative when git diffing fails due to missing git executable.
 - Notebook extension handler error is informative if it suspects the server extension is not installed (404). Also disables the button.