### PR TITLE
Add --persist flag to web tools

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -162,6 +162,13 @@ def add_web_args(parser, default_port=8888):
         type=str,
         help="specify the browser to use, to override the system default.")
     parser.add_argument(
+        '--persist',
+        action="store_true",
+        default=False,
+        help="prevent server shutting down on remote close request (when these"
+             " would normally supported)."
+    )
+    parser.add_argument(
         '--ip',
         default='127.0.0.1',
         help="specify the interface to listen to for the web server. "
@@ -348,7 +355,10 @@ def args_for_server(arguments):
                 workdirectory='cwd',
                 base_url='base_url',
                 )
-    return {kmap[k]: v for k, v in vars(arguments).items() if k in kmap}
+    ret = {kmap[k]: v for k, v in vars(arguments).items() if k in kmap}
+    if 'persist' in arguments:
+        ret['closable'] = not arguments.persist
+    return ret
 
 
 def args_for_browse(arguments):

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -166,7 +166,7 @@ def add_web_args(parser, default_port=8888):
         action="store_true",
         default=False,
         help="prevent server shutting down on remote close request (when these"
-             " would normally supported)."
+             " would normally be supported)."
     )
     parser.add_argument(
         '--ip',

--- a/nbdime/webapp/nbdifftool.py
+++ b/nbdime/webapp/nbdifftool.py
@@ -44,7 +44,6 @@ def main_parsed(opts):
     base = opts.local
     remote = opts.remote
     return run_server(
-        closable=True,
         difftool_args=dict(base=base, remote=remote),
         on_port=lambda port: browse(
             port=port,

--- a/nbdime/webapp/nbdiffweb.py
+++ b/nbdime/webapp/nbdiffweb.py
@@ -61,7 +61,6 @@ def handle_gitrefs(base, remote, path, arguments):
     status = 0
     for fbase, fremote in changed_notebooks(base, remote, path):
         status = run_server(
-            closable=True,
             difftool_args=dict(base=fbase, remote=fremote),
             on_port=lambda port: browse_util(
                 port=port,
@@ -81,7 +80,6 @@ def main_diff(opts):
         # We are asked to do a gui for git diff
         return handle_gitrefs(base, remote, path, opts)
     return run_server(
-        closable=True,
         on_port=lambda port: browse_util(
             port=port,
             rel_url='diff',

--- a/nbdime/webapp/nbmergetool.py
+++ b/nbdime/webapp/nbmergetool.py
@@ -47,7 +47,6 @@ def main_parsed(opts):
     remote = opts.remote
     merged = opts.merged
     return run_server(
-        closable=True,
         mergetool_args=dict(base=base, local=local, remote=remote),
         outputfilename=merged,
         on_port=lambda port: browse(

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -47,7 +47,6 @@ def main(args=None):
     remote = arguments.remote
     output = arguments.out
     return run_server(
-        closable=True,
         outputfilename=output,
         on_port=lambda port: browse(
             port=port,


### PR DESCRIPTION
Disables remote shutdown of web tools. Useful for e.g. debugging, but might have other uses.