### PR TITLE
Handle concurrent inserts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build
 MANIFEST
 .coverage
 .cache
+.pytest_cache
 
 
 .spyderproject

--- a/docs/source/merging.rst
+++ b/docs/source/merging.rst
@@ -38,6 +38,7 @@ represented as a dict with the following entries::
         "action": <action taken/suggested>,
         "common_path": <JSON path>,
         "custom_diff": <diff object>
+        "similar_insert: <diff object>
     }
 
 Merge conflicts

--- a/nbdime/merge_format.schema.json
+++ b/nbdime/merge_format.schema.json
@@ -44,6 +44,12 @@
           "description": "A common path of local_diff and remote_diff. Optional, as both can alternatively just contain single patch entries down to this path, but should help with opimization",
           "type": "array",
           "items": { "type": ["integer", "string"] }
+        },
+
+        "similar_insert": {
+          "description": "If not-null, indicates that the decision is an insertion of similar items. This field then holds the relative diff from local to remote.",
+          "type": ["array", "null"],
+          "items": { "$ref": "diff_format.schema.json#/definitions/diff" }
         }
       }
     }

--- a/nbdime/merging/chunks.py
+++ b/nbdime/merging/chunks.py
@@ -143,3 +143,34 @@ def make_merge_chunks(base, *diffs, **kwargs):
         assert chunks[-1][1] == len(base), 'invalid range end of final merge chunk'
 
     return chunks
+
+
+def chunk_typename(diffs):
+    """For the diffs of a chunk, return string representations of its type.
+
+    Returns a two-tuple of strings.
+     - The first string contains zero or more characters 'a' and/or 'A', where
+       'a' signifies a dict 'add' operation, and 'A' signifies a sequence
+       'addrange' operation.
+    - The second string contains zero or more characters 'P', 'R', 'r',
+      and/or 'c': 'P': patch, 'R': removerange, 'r': remove, 'c': replace
+
+    For a proper chunk, each string should have either 0 or 1 character each,
+    but this function will not perform any checks.
+    """
+    aname = ""
+    pname = ""
+    for e in diffs:
+        if e.op == DiffOp.ADDRANGE:
+            aname += "A"
+        elif e.op == DiffOp.ADD:
+            aname += "a"
+        elif e.op == DiffOp.PATCH:
+            pname += "P"
+        elif e.op == DiffOp.REMOVERANGE:
+            pname += "R"
+        elif e.op == DiffOp.REMOVE:
+            pname += "r"
+        elif e.op == DiffOp.REPLACE:
+            pname += "c"
+    return aname, pname

--- a/nbdime/merging/decisions.py
+++ b/nbdime/merging/decisions.py
@@ -297,6 +297,27 @@ class MergeDecisionBuilder(object):
             strategy=strategy
             )
 
+    def similar_insert(self, path, local_diff, remote_diff, insert_diff, strategy=None):
+        """Same as `conflict`, but with marker `similar_insert``"""
+        assert local_diff and remote_diff, 'onesided merges should not be conflicted'
+        assert local_diff != remote_diff, 'agreed merges should not be conflicted'
+
+        # Try to defuse situation with given strategy
+        action = self.tryresolve(path, local_diff, remote_diff, strategy)
+
+        # If none of them applied, use base and mark as conflict
+        if action is None:
+            # If a strategy was provided but failed to apply, mark as conflict.
+            # NB! Not passing strategy argument on to decision because it hasn't been applied.
+            self.add_decision(
+                path=path,
+                conflict=True,
+                action="base",
+                local_diff=local_diff,
+                remote_diff=remote_diff,
+                similar_insert=insert_diff
+                )
+
 
 def ensure_common_path(path, diffs):
     """Resolves common paths in a list of diffs.

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -355,10 +355,11 @@ def _split_addrange(key, local, remote, path, item_strategy):
 
         elif d.op == DiffOp.PATCH:
             # Predicates indicate that local and remote items are similar!
-            decisions.conflict(
+            decisions.similar_insert(
                 path,
                 [op_addrange(key, [local[d.key]])],
                 [op_addrange(key, [remote[d.key + offset]])],
+                [d],
                 item_strategy)
             taken += 1
 

--- a/nbdime/merging/generic.py
+++ b/nbdime/merging/generic.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 import nbdime.log
 from .decisions import MergeDecisionBuilder
-from .chunks import make_merge_chunks
+from .chunks import make_merge_chunks, chunk_typename
 from .strategies import (
     resolve_strategy_generic,
      resolve_conflicted_decisions_dict,
@@ -146,37 +146,6 @@ def __unused__tryresolve_conflicts(conflicts, decisions):
         if not action_taken:
             unresolved_conflicts.append(conf)
     return unresolved_conflicts
-
-
-def chunk_typename(diffs):
-    """For the diffs of a chunk, return string representations of its type.
-
-    Returns a two-tuple of strings.
-     - The first string contains zero or more characters 'a' and/or 'A', where
-       'a' signifies a dict 'add' operation, and 'A' signifies a sequence
-       'addrange' operation.
-    - The second string contains zero or more characters 'P', 'R', 'r',
-      and/or 'c': 'P': patch, 'R': removerange, 'r': remove, 'c': replace
-
-    For a proper chunk, each string should have either 0 or 1 character each,
-    but this function will not perform any checks.
-    """
-    aname = ""
-    pname = ""
-    for e in diffs:
-        if e.op == DiffOp.ADDRANGE:
-            aname += "A"
-        elif e.op == DiffOp.ADD:
-            aname += "a"
-        elif e.op == DiffOp.PATCH:
-            pname += "P"
-        elif e.op == DiffOp.REMOVERANGE:
-            pname += "R"
-        elif e.op == DiffOp.REMOVE:
-            pname += "r"
-        elif e.op == DiffOp.REPLACE:
-            pname += "c"
-    return aname, pname
 
 
 

--- a/nbdime/merging/notebooks.py
+++ b/nbdime/merging/notebooks.py
@@ -29,6 +29,7 @@ generic_conflict_strategies = (
     "remove",           # Discard value in case of conflict
     "clear-all",        # Discard all values on conflict
     "fail",             # Unexpected: crash and burn in case of conflict (only implemented for leaf nodes)
+    "inline-cells",     # Valid for cell only: use markdown cells as diff markers for conflicting inserts/replace
     "inline-source",    # Valid for source only: produce new source with inline diff markers
     "inline-outputs",   # Valid for outputs only: produce new outputs with inline diff markers
     "mergetool",        # Do not modify decision (but prevent processing at deeper path)
@@ -42,7 +43,7 @@ generic_conflict_strategies = (
 
 # Strategies that can be applied to an entire notebook
 cli_conflict_strategies = (
-    "inline",           # Inline source and outputs, and record metadata conflicts
+    "inline",           # Inline cells or source and outputs, and record metadata conflicts
     "use-base",         # Keep base value in case of conflict
     "use-local",        # Use local value in case of conflict
     "use-remote",       # Use remote value in case of conflict
@@ -93,7 +94,9 @@ def notebook_merge_strategies(args):
     metadata_strategy = merge_strategy
 
     # Set root strategy
-    if merge_strategy != 'inline':
+    if merge_strategy == 'inline':
+        strategies['/cells'] = "inline-cells"
+    else:
         strategies["/"] = merge_strategy
 
     # Translate 'inline' to specific strategies for different fields

--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -811,7 +811,7 @@ def pretty_print_merge_decision(base, decision, config=DefaultConfig):
     confnote = "conflicted " if decision.conflict else ""
     config.out.write("%s%sdecision at %s:%s\n" % (INFO.replace("##", "===="), confnote, path, RESET))
 
-    diff_keys = ("diff", "local_diff", "remote_diff", "custom_diff")
+    diff_keys = ("diff", "local_diff", "remote_diff", "custom_diff", "similar_insert")
     exclude_keys = set(diff_keys) | {"common_path", "action", "conflict"}
     pretty_print_dict(decision, exclude_keys, prefix, config)
 

--- a/nbdime/tests/test_merge_notebooks.py
+++ b/nbdime/tests/test_merge_notebooks.py
@@ -107,7 +107,10 @@ def test_merge_cell_sources_neighbouring_inserts():
             ])
         expected_conflicts = []
 
-    _check_sources(base, local, remote, expected_partial, expected_conflicts)
+    merge_args = copy.deepcopy(args)
+    merge_args.merge_strategy = "mergetool"
+
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 def test_merge_cell_sources_separate_inserts():
@@ -299,7 +302,11 @@ def test_merge_simple_cell_source_conflicting_insert():
     else:  # Treat as non-conflict (insert both)
         expected_partial = [["base"], ["local"], ["remote"]]
         expected_conflicts = []
-    _check_sources(base, local, remote, expected_partial, expected_conflicts)
+
+    merge_args = copy.deepcopy(args)
+    merge_args.merge_strategy = "mergetool"
+
+    _check_sources(base, local, remote, expected_partial, expected_conflicts, merge_args)
 
 
 @pytest.mark.xfail

--- a/nbdime/tests/utils.py
+++ b/nbdime/tests/utils.py
@@ -60,14 +60,16 @@ def check_symmetric_diff_and_patch(a, b):
     check_diff_and_patch(b, a)
 
 
-def sources_to_notebook(sources):
+def sources_to_notebook(sources, cell_type='code'):
     assert isinstance(sources, list)
-    assert len(sources) == 0 or isinstance(sources[0], list)
     nb = nbformat.v4.new_notebook()
     for source in sources:
         if isinstance(source, list):
             source = "".join(source)
-        nb.cells.append(nbformat.v4.new_code_cell(source))
+        if cell_type == 'code':
+            nb.cells.append(nbformat.v4.new_code_cell(source))
+        elif cell_type == 'markdown':
+            nb.cells.append(nbformat.v4.new_markdown_cell(source))
     return nb
 
 

--- a/packages/nbdime/src/merge/decisions.ts
+++ b/packages/nbdime/src/merge/decisions.ts
@@ -40,6 +40,8 @@ interface IMergeDecision {
   common_path?: DecisionPath;
 
   custom_diff?: IDiffEntry[] | null;
+
+  similar_insert?: IDiffEntry[] | null;
 }
 
 export
@@ -79,7 +81,8 @@ class MergeDecision {
               remoteDiff?: IDiffEntry[] | null,
               action?: Action,
               conflict?: boolean,
-              customDiff?: IDiffEntry[] | null);
+              customDiff?: IDiffEntry[] | null,
+              similarInsert?: IDiffEntry[] | null);
   /**
    * Create a MergeDecision from values.
    *
@@ -90,7 +93,8 @@ class MergeDecision {
               remoteDiff?: IDiffEntry[] | null,
               action?: Action,
               conflict?: boolean,
-              customDiff?: IDiffEntry[] | null);
+              customDiff?: IDiffEntry[] | null,
+              similarInsert?: IDiffEntry[] | null);
   /**
    * MergeDecision copy constructor.
    */
@@ -100,7 +104,8 @@ class MergeDecision {
               remoteDiff: IDiffEntry[] | null = null,
               action: Action = 'base',
               conflict = false,
-              customDiff: IDiffEntry[] | null = null) {
+              customDiff: IDiffEntry[] | null = null,
+              similarInsert: IDiffEntry[] | null = null) {
     this.level = 0;
     if (obj instanceof Array) {
       this._path = obj;
@@ -111,6 +116,7 @@ class MergeDecision {
       action = obj.action;
       conflict = obj.conflict;
       customDiff = obj.customDiff;
+      similarInsert = obj.similarInsert;
       this.level = obj.level;
     } else {
       this._path = valueOrDefault(obj.common_path, []);
@@ -120,12 +126,14 @@ class MergeDecision {
         valueOrDefault(obj.action, action));
       conflict = valueOrDefault(obj.conflict, conflict);
       customDiff = valueOrDefault(obj.custom_diff, customDiff);
+      similarInsert = valueOrDefault(obj.similar_insert, similarInsert);
     }
     this.localDiff = localDiff;
     this.remoteDiff = remoteDiff;
     this.action = action;
     this.conflict = conflict;
     this.customDiff = customDiff;
+    this.similarInsert = similarInsert;
   }
 
   setValuesFrom(other: MergeDecision): void {
@@ -135,6 +143,7 @@ class MergeDecision {
     this.action = other.action;
     this.conflict = other.conflict;
     this.customDiff = other.customDiff;
+    this.similarInsert = other.similarInsert;
     this.level = other.level;
   }
 
@@ -157,6 +166,8 @@ class MergeDecision {
   remoteDiff: IDiffEntry[] | null;
 
   customDiff: IDiffEntry[] | null;
+
+  similarInsert: IDiffEntry[] | null;
 
   conflict: boolean;
 


### PR DESCRIPTION
- Add an optional field `similar_insert` on merge decision. This is used when there are two conflicting inserts that are deemed to be similar. In that case, this field stores their relative difference (local vs remote).
- Add an internal merge strategy `inline-cell`, used with the CLI `inline` strategy. For conflicting concurrent inserts, this does one of two things:
  - For non-similar insertions, it adds merge markers around the cells (`<<<<<<< local` etc), and then includes the local insertion and remote insertion).
  - For similar insertions, it inserts a cell while recursing to use merge markers for source / output / metadata similar to other existing inline strategies.

Screenshot of non-similar insertion of markdown cells with `inline-cell` strategy:

![nbdime-cell-markers](https://user-images.githubusercontent.com/510760/37344130-c8366cba-26c9-11e8-8268-7ca9b1bf21b0.png)

Ref #345.