### PR TITLE
Custom ignore config

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -13,7 +13,7 @@ from six import PY2
 from ._version import __version__
 from .log import init_logging, set_nbdime_log_level
 from .gitfiles import is_gitref
-from .diffing.notebooks import set_notebook_diff_targets
+from .diffing.notebooks import set_notebook_diff_targets, set_notebook_diff_ignores
 from .config import get_defaults_for_argparse, entrypoint_configurables
 from .prettyprint import pretty_print_dict, PrettyPrintConfig
 
@@ -24,7 +24,11 @@ class ConfigBackedParser(argparse.ArgumentParser):
         if entrypoint is None:
             entrypoint = self.prog
         try:
-            self.set_defaults(**get_defaults_for_argparse(entrypoint))
+            defs = get_defaults_for_argparse(entrypoint)
+            ignore = defs.pop('Ignore', None)
+            self.set_defaults(**defs)
+            if ignore:
+                set_notebook_diff_ignores(ignore)
         except ValueError:
             pass
         return super(ConfigBackedParser, self).parse_args(args=args, namespace=namespace)

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -171,27 +171,32 @@ class IgnoreConfig(Dict):
 class _Ignorables(NbdimeConfigurable):
 
     source = Bool(
-        True,
+        None,
+        allow_none=True,
         help="process/ignore sources.",
     ).tag(config=True)
 
     outputs = Bool(
-        True,
+        None,
+        allow_none=True,
         help="process/ignore outputs.",
     ).tag(config=True)
 
     metadata = Bool(
-        True,
+        None,
+        allow_none=True,
         help="process/ignore metadata.",
     ).tag(config=True)
 
     attachments = Bool(
-        True,
+        None,
+        allow_none=True,
         help="process/ignore attachments.",
     ).tag(config=True)
 
     details = Bool(
-        True,
+        None,
+        allow_none=True,
         help="process/ignore details not covered by other options.",
     ).tag(config=True)
 

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -6,7 +6,6 @@ from ipython_genutils import py3compat
 from jupyter_core.paths import jupyter_config_path
 
 from traitlets import Unicode, Enum, Integer, Bool, HasTraits, Dict, TraitError
-from traitlets.config.manager import BaseJSONConfigManager
 from traitlets.config.loader import JSONFileConfigLoader, ConfigFileNotFound
 
 from .merging.notebooks import (

--- a/nbdime/tests/test_args.py
+++ b/nbdime/tests/test_args.py
@@ -1,13 +1,18 @@
 
 import argparse
 import pytest
+import json
 
 from traitlets import Enum
 
 from nbdime.args import (
     SkipAction, ConfigBackedParser, LogLevelAction,
 )
-from nbdime.config import entrypoint_configurables, Global
+from nbdime.config import (
+    entrypoint_configurables, Global, _Ignorables
+)
+import nbdime.diffing.notebooks
+from nbdime.diffing.notebooks import notebook_differs, diff
 
 
 class FixtureConfig(Global):
@@ -19,6 +24,18 @@ class FixtureConfig(Global):
 @pytest.fixture
 def entrypoint_config():
     entrypoint_configurables['test-prog'] = FixtureConfig
+    yield
+    del entrypoint_configurables['test-prog']
+
+class IgnorableConfig1(_Ignorables):
+    pass
+
+class IgnorableConfig2(IgnorableConfig1):
+    pass
+
+@pytest.fixture
+def entrypoint_ignore_config():
+    entrypoint_configurables['test-prog'] = IgnorableConfig2
     yield
     del entrypoint_configurables['test-prog']
 
@@ -50,3 +67,76 @@ def test_config_parser(entrypoint_config):
 
     arguments = parser.parse_args(['--log-level', 'ERROR'])
     assert arguments.log_level == 'ERROR'
+
+
+def test_ignore_config_simple(entrypoint_ignore_config, tmpdir):
+    tmpdir.join('nbdime_config.json').write_text(
+        json.dumps({
+            "IgnorableConfig1": {
+                "Ignore": {
+                    '/cells/*/metadata': ['collapsed', 'autoscroll']
+                }
+            },
+        }),
+        encoding='utf-8'
+    )
+
+    def mock_ignore_keys(inner, keys):
+        return (inner, keys)
+    parser = ConfigBackedParser('test-prog')
+    old_keys = nbdime.diffing.notebooks.diff_ignore_keys
+    nbdime.diffing.notebooks.diff_ignore_keys = mock_ignore_keys
+    try:
+        with tmpdir.as_cwd():
+            arguments = parser.parse_args([])
+    except:
+        nbdime.diffing.notebooks.reset_notebook_differ()
+        raise
+    finally:
+        nbdime.diffing.notebooks.diff_ignore_keys = old_keys
+
+    try:
+        assert notebook_differs['/cells/*/metadata'] == (diff, ['collapsed', 'autoscroll'])
+    finally:
+        nbdime.diffing.notebooks.reset_notebook_differ()
+
+
+
+def test_ignore_config_merge(entrypoint_ignore_config, tmpdir):
+    tmpdir.join('nbdime_config.json').write_text(
+        json.dumps({
+            "IgnorableConfig1": {
+                "Ignore": {
+                    '/cells/*/metadata': ['collapsed', 'autoscroll']
+                }
+            },
+            "IgnorableConfig2": {
+                "Ignore": {
+                    '/metadata': ['foo'],
+                    '/cells/*/metadata': ['tags']
+                }
+            },
+        }),
+        encoding='utf-8'
+    )
+
+    def mock_ignore_keys(inner, keys):
+        return (inner, keys)
+    parser = ConfigBackedParser('test-prog')
+    old_keys = nbdime.diffing.notebooks.diff_ignore_keys
+    nbdime.diffing.notebooks.diff_ignore_keys = mock_ignore_keys
+    try:
+        with tmpdir.as_cwd():
+            arguments = parser.parse_args([])
+    except:
+        nbdime.diffing.notebooks.reset_notebook_differ()
+        raise
+    finally:
+        nbdime.diffing.notebooks.diff_ignore_keys = old_keys
+
+    try:
+        assert notebook_differs['/metadata'] == (diff, ['foo'])
+        # Lists are not merged:
+        assert notebook_differs['/cells/*/metadata'] == (diff, ['tags'])
+    finally:
+        nbdime.diffing.notebooks.reset_notebook_differ()

--- a/nbdime/tests/test_args.py
+++ b/nbdime/tests/test_args.py
@@ -3,6 +3,8 @@ import argparse
 import pytest
 import json
 
+from six import text_type
+
 from traitlets import Enum
 
 from nbdime.args import (
@@ -71,13 +73,13 @@ def test_config_parser(entrypoint_config):
 
 def test_ignore_config_simple(entrypoint_ignore_config, tmpdir):
     tmpdir.join('nbdime_config.json').write_text(
-        json.dumps({
-            "IgnorableConfig1": {
-                "Ignore": {
+        text_type(json.dumps({
+            'IgnorableConfig1': {
+                'Ignore': {
                     '/cells/*/metadata': ['collapsed', 'autoscroll']
                 }
             },
-        }),
+        })),
         encoding='utf-8'
     )
 
@@ -104,19 +106,19 @@ def test_ignore_config_simple(entrypoint_ignore_config, tmpdir):
 
 def test_ignore_config_merge(entrypoint_ignore_config, tmpdir):
     tmpdir.join('nbdime_config.json').write_text(
-        json.dumps({
-            "IgnorableConfig1": {
-                "Ignore": {
+        text_type(json.dumps({
+            'IgnorableConfig1': {
+                'Ignore': {
                     '/cells/*/metadata': ['collapsed', 'autoscroll']
                 }
             },
-            "IgnorableConfig2": {
-                "Ignore": {
+            'IgnorableConfig2': {
+                'Ignore': {
                     '/metadata': ['foo'],
                     '/cells/*/metadata': ['tags']
                 }
             },
-        }),
+        })),
         encoding='utf-8'
     )
 

--- a/nbdime/tests/test_args.py
+++ b/nbdime/tests/test_args.py
@@ -90,7 +90,7 @@ def test_ignore_config_simple(entrypoint_ignore_config, tmpdir):
     nbdime.diffing.notebooks.diff_ignore_keys = mock_ignore_keys
     try:
         with tmpdir.as_cwd():
-            arguments = parser.parse_args([])
+            parser.parse_args([])
     except:
         nbdime.diffing.notebooks.reset_notebook_differ()
         raise
@@ -129,7 +129,7 @@ def test_ignore_config_merge(entrypoint_ignore_config, tmpdir):
     nbdime.diffing.notebooks.diff_ignore_keys = mock_ignore_keys
     try:
         with tmpdir.as_cwd():
-            arguments = parser.parse_args([])
+            parser.parse_args([])
     except:
         nbdime.diffing.notebooks.reset_notebook_differ()
         raise


### PR DESCRIPTION
Allows for using the config system for full configuration of keys to ignore. This should be a better long term solution than adding more logic to ignore flags on the CLI.