### PR TITLE
Fix dot diff

### DIFF
--- a/packages/nbdime/src/common/util.ts
+++ b/packages/nbdime/src/common/util.ts
@@ -73,7 +73,7 @@ export function deepCopy<T extends DeepCopyableValue>(obj: T | null): T | null {
       r.prototype = a.prototype;
     }
     for (let k in obj) {
-      r[k] = deepCopy(a[k] as any);
+      r[k] = deepCopy(a[k]);
     }
     return r as T;
   }
@@ -90,7 +90,7 @@ function shallowCopy< T extends { [key: string]: any } >(original: T): T {
 
   for (let k in original) {
     // Don't copy function
-    let ok = original[k] as any;
+    let ok = original[k];
     if (ok !== null && ok !== undefined &&
         ok.hasOwnProperty('constructor') &&
         ok.constructor === Function) {

--- a/packages/nbdime/src/diff/model/output.ts
+++ b/packages/nbdime/src/diff/model/output.ts
@@ -44,7 +44,7 @@ class OutputDiffModel extends RenderableDiffModel<nbformat.IOutput> {
    *
    * See also: innerMimeType
    */
-  hasMimeType(mimetype: string): string | null {
+  hasMimeType(mimetype: string): string | string[] | null {
     let outputs = this.base || this.remote!;
     if (nbformat.isStream(outputs) &&
         TEXT_MIMETYPES.indexOf(mimetype) !== -1) {
@@ -54,7 +54,7 @@ class OutputDiffModel extends RenderableDiffModel<nbformat.IOutput> {
     } else if (nbformat.isExecuteResult(outputs) || nbformat.isDisplayData(outputs)) {
       let data = outputs.data;
       if (mimetype in data) {
-        return 'data.' + mimetype;
+        return ['data', mimetype];
       }
     }
     return null;
@@ -68,24 +68,24 @@ class OutputDiffModel extends RenderableDiffModel<nbformat.IOutput> {
    *
    * See also: hasMimeType
    */
-  protected innerMimeType(key: string) : string {
+  innerMimeType(key: string | string[]) : string {
     let t = (this.base || this.remote!).output_type;
     if (t === 'stream' && key === 'text' || t === 'error' && key === 'traceback') {
       // TODO: 'application/vnd.jupyter.console-text'?
       return 'text/plain';
     } else if ((t === 'execute_result' || t === 'display_data') &&
-          key.indexOf('data.') === 0) {
-      return key.slice('data.'.length);
+          Array.isArray(key)) {
+      return key[1];
     }
     throw new NotifyUserError('Unknown MIME type for key: ' + key);
   }
 
   /**
-   * Can converted to a StringDiffModel via the method `stringify()`, which also
+   * Can be converted to a StringDiffModel via the method `stringify()`, which also
    * takes an optional argument `key` which specifies a subpath of the IOutput to
    * make the model from.
    */
-  stringify(key?: string) : IStringDiffModel {
+  stringify(key?: string | string[]) : IStringDiffModel {
     let model = super.stringify(key);
     if (key) {
        model.mimetype = this.innerMimeType(key);

--- a/packages/nbdime/src/diff/widget/output.ts
+++ b/packages/nbdime/src/diff/widget/output.ts
@@ -215,7 +215,7 @@ class OutputPanel extends Panel {
     let view: Widget | undefined;
     let model = this.model as OutputDiffModel;
     // Find highest order MIME-type supported by rendermime
-    let key: string | null = null;
+    let key: string | string[] | null = null;
     if (this.selectedMimetype === null) {
       find(this.rendermime.mimeTypes, (mt) => {
         key = model.hasMimeType(mt);

--- a/packages/nbdime/src/merge/model/notebook.ts
+++ b/packages/nbdime/src/merge/model/notebook.ts
@@ -551,23 +551,23 @@ function splitCellInsertions(mergeDecisions: MergeDecision[]): MergeDecision[] {
         console.assert(start === dr.key);
         if (md.action === 'remote_then_local') {
           // Only case where we need to switch order!
-          for (let c of dr.valuelist as any[]) {
+          for (let c of dr.valuelist) {
             const part = makeSplitPart(md, c, false, true);
             part.action = 'remote';
             output.push(part);
           }
-          for (let c of dl.valuelist as any[]) {
+          for (let c of dl.valuelist) {
             const part = makeSplitPart(md, c, true, false);
             part.action = 'local';
             output.push(part);
           }
         } else {
-          for (let c of dl.valuelist as any[]) {
+          for (let c of dl.valuelist) {
             const part = makeSplitPart(md, c, true, false);
             part.action = 'local';
             output.push(part);
           }
-          for (let c of dr.valuelist as any[]) {
+          for (let c of dr.valuelist) {
             const part = makeSplitPart(md, c, false, true);
             part.action = 'remote';
             output.push(part);

--- a/packages/nbdime/test/src/common/flexpanel.spec.ts
+++ b/packages/nbdime/test/src/common/flexpanel.spec.ts
@@ -135,7 +135,6 @@ describe('upstreaming', () => {
     it('should set and get direction', () => {
       let p = new FlexPanel();
       // Check that it has a valid initial value
-      let initial = p.direction;
       p.direction = 'bottom-to-top';
       expect(p.direction).to.be('bottom-to-top');
     });
@@ -171,7 +170,6 @@ describe('upstreaming', () => {
     it('should set and get minimumSpacing', () => {
       let p = new FlexPanel();
       // Check that it has a valid initial value
-      let initial = p.minimumSpacing;
       p.minimumSpacing = 10;
       expect(p.minimumSpacing).to.be(10);
     });
@@ -206,7 +204,6 @@ describe('upstreaming', () => {
     it('should set and get wrap', () => {
       let p = new FlexPanel();
       // Check that it has a valid initial value
-      let initial = p.wrap;
       p.wrap = true;
       expect(p.wrap).to.be(true);
     });

--- a/packages/nbdime/test/src/merge/decisions.spec.ts
+++ b/packages/nbdime/test/src/merge/decisions.spec.ts
@@ -342,7 +342,7 @@ describe('merge', () => {
         expect(decs.length).to.be(2);
         expect(decs[0].absolutePath).to.eql(['a', 0]);
         expect(decs[1].absolutePath).to.eql([33, 0, 'foo']);
-      })
+      });
 
     });
 
@@ -584,7 +584,6 @@ describe('merge', () => {
           secret: 'foo!'
         }
       };
-      let baseArray = [1, 2, 3];
 
       let simpleObjectDecision : decisions.IMergeDecision = {
           local_diff: [opAddRange(3, ['line 4\n'])],


### PR DESCRIPTION
Fixes an issue with outputs where the MIME type contains a '.' (e.g. 'vnd.application.etc'). Also cleans up some typings that were needed for older versions of TS.