### PR TITLE
Fixes for inline source merge strategy

### DIFF
--- a/nbdime/merging/strategies.py
+++ b/nbdime/merging/strategies.py
@@ -531,7 +531,8 @@ def resolve_strategy_inline_recurse(path, base, decisions):
         laname, lpname = chunk_typename(d.local_diff)
         raname, rpname = chunk_typename(d.remote_diff)
         chunktype = laname + lpname + "/" + raname + rpname
-        if chunktype not in ('AR/A', 'A/AR', 'A/A', 'AR/AR'):
+        if (chunktype not in ('AR/A', 'A/AR', 'A/A', 'AR/AR') or 
+                d.common_path != ('cells',)):
             decisions.decisions.append(d)
             continue
         if d.get('similar_insert', None) is None:


### PR DESCRIPTION
Certain edge cases were incorrectly double identified as different types of conflicts. This ensures that the `inline-cell` strategy is now only used for conflicts on `cells`.

Fixes #379.