### PR TITLE
Include LICENSE file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,9 @@ ignore=E123,E265,E261,E226,E241,E221,E251s
 [pep8]
 max-line-length=140
 
+[metadata]
+license_file = LICENSE.md
+
 [manifix]
 known-excludes =
     .git*


### PR DESCRIPTION
The license requires that all copies of the software include the license.  This makes sure the license is included in the wheels.  See the wheel documentation [here](https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file) for more information.