### PR TITLE
Config cleanup

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,7 +5,7 @@
 ###  1.0.1 - 2018-06
 
 - Web: Fix output rendering of outputs with a period in MIME type name.
-- Config: Add configuration option for front end extensions.
+- Config: Add configuration option for front-end extensions.
 - Merging: Fix handling of corner case for inline merge strategy.
 - Various other fixes and adjustments.
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -266,10 +266,10 @@ included in the merge.
 
 
 
-Front end extensions
--------------------
+Front-end extensions
+--------------------
 
-The configuration of the diffing for the front end extensions (notebook and lab)
+The configuration of the diffing for the front-end extensions (notebook and lab)
 is controlled by the section key "Extension". For extensions, nbdime is not
 launched as a separate process, but is called as a server extension. For this
 reason, any of config options that conflict with those of the lab/notebook

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -3,8 +3,8 @@ Configuration
 
 Nbdime uses a config system loosely based on that of Jupyter. This means that
 it looks for config files ``nbdime_config.json`` in all the directories listed
-by the ``jupyter --paths`` command. The syntax of the config files are similar
-to that of other Jupyter commands::
+by the ``jupyter --paths`` command, as well as the current working directory.
+The syntax of the config files are similar to that of other Jupyter commands::
 
     {
       "NbDiff": {
@@ -23,6 +23,150 @@ Alternatively, you can use the ``--config`` flag for any CLI entry point::
     nbmerge --config
 
 Any flags passed on the CLI will override the config value.
+
+The current output of `nbdime --config` is:
+
+.. code-block:: none
+
+    All available config options, and their current values:
+
+    NbDiff:
+      Ignore: {}
+      attachments: None
+      color_words: False
+      details: None
+      metadata: False
+      outputs: None
+      source: None
+
+    NbDiffWeb:
+      Ignore: {}
+      attachments: None
+      base_url: '/'
+      browser: None
+      color_words: False
+      details: None
+      ip: '127.0.0.1'
+      metadata: False
+      outputs: None
+      persist: False
+      port: 0
+      source: None
+      workdirectory: ''
+
+    NbMerge:
+      Ignore: {}
+      attachments: None
+      color_words: False
+      details: None
+      ignore_transients: True
+      input_strategy: None
+      merge_strategy: 'inline'
+      metadata: None
+      output_strategy: None
+      outputs: None
+      source: None
+
+    NbMergeWeb:
+      Ignore: {}
+      attachments: None
+      base_url: '/'
+      browser: None
+      color_words: False
+      details: None
+      ignore_transients: True
+      input_strategy: None
+      ip: '127.0.0.1'
+      merge_strategy: 'inline'
+      metadata: None
+      output_strategy: None
+      outputs: None
+      persist: False
+      port: 0
+      source: None
+      workdirectory: ''
+
+    NbShow:
+      Ignore: {}
+      attachments: None
+      details: None
+      metadata: None
+      outputs: None
+      source: None
+
+    Server:
+      base_url: '/'
+      browser: None
+      ip: '127.0.0.1'
+      persist: False
+      port: 8888
+      workdirectory: ''
+
+    Extension:
+      Ignore: {}
+      attachments: None
+      color_words: False
+      details: None
+      metadata: False
+      outputs: None
+      source: None
+
+    NbDiffDriver:
+      Ignore: {}
+      attachments: None
+      color_words: False
+      details: None
+      metadata: False
+      outputs: None
+      source: None
+
+    NbDiffTool:
+      Ignore: {}
+      attachments: None
+      base_url: '/'
+      browser: None
+      color_words: False
+      details: None
+      ip: '127.0.0.1'
+      metadata: False
+      outputs: None
+      persist: False
+      port: 0
+      source: None
+      workdirectory: ''
+
+    NbMergeDriver:
+      Ignore: {}
+      attachments: None
+      color_words: False
+      details: None
+      ignore_transients: True
+      input_strategy: None
+      merge_strategy: 'inline'
+      metadata: None
+      output_strategy: None
+      outputs: None
+      source: None
+
+    NbMergeTool:
+      Ignore: {}
+      attachments: None
+      base_url: '/'
+      browser: None
+      color_words: False
+      details: None
+      ignore_transients: True
+      input_strategy: None
+      ip: '127.0.0.1'
+      merge_strategy: 'inline'
+      metadata: None
+      output_strategy: None
+      outputs: None
+      persist: False
+      port: 0
+      source: None
+      workdirectory: ''
+
 
 
 
@@ -57,6 +201,14 @@ GitDiff
 
 GitMerge
     Options to git diff commands (NbMergeDriver, NbMergeTool)
+
+
+.. note::
+
+    These sections are ways to configure several commands / entrypoints
+    at once. The individual command names are the once listed in
+    parantheses at the end of the sections, or can be seen by running
+    ``nbdime --config``.
 
 
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -32,140 +32,140 @@ The current output of `nbdime --config` is:
 
     NbDiff:
       Ignore: {}
-      attachments: None
-      color_words: False
-      details: None
-      metadata: False
-      outputs: None
-      source: None
+      attachments: null
+      color_words: false
+      details: null
+      metadata: null
+      outputs: null
+      source: null
 
     NbDiffWeb:
       Ignore: {}
-      attachments: None
-      base_url: '/'
-      browser: None
-      color_words: False
-      details: None
-      ip: '127.0.0.1'
-      metadata: False
-      outputs: None
-      persist: False
+      attachments: null
+      base_url: "/"
+      browser: null
+      color_words: false
+      details: null
+      ip: "127.0.0.1"
+      metadata: null
+      outputs: null
+      persist: false
       port: 0
-      source: None
-      workdirectory: ''
+      source: null
+      workdirectory: ""
 
     NbMerge:
       Ignore: {}
-      attachments: None
-      color_words: False
-      details: None
-      ignore_transients: True
-      input_strategy: None
-      merge_strategy: 'inline'
-      metadata: None
-      output_strategy: None
-      outputs: None
-      source: None
+      attachments: null
+      color_words: false
+      details: null
+      ignore_transients: true
+      input_strategy: null
+      merge_strategy: "inline"
+      metadata: null
+      output_strategy: null
+      outputs: null
+      source: null
 
     NbMergeWeb:
       Ignore: {}
-      attachments: None
-      base_url: '/'
-      browser: None
-      color_words: False
-      details: None
-      ignore_transients: True
-      input_strategy: None
-      ip: '127.0.0.1'
-      merge_strategy: 'inline'
-      metadata: None
-      output_strategy: None
-      outputs: None
-      persist: False
+      attachments: null
+      base_url: "/"
+      browser: null
+      color_words: false
+      details: null
+      ignore_transients: true
+      input_strategy: null
+      ip: "127.0.0.1"
+      merge_strategy: "inline"
+      metadata: null
+      output_strategy: null
+      outputs: null
+      persist: false
       port: 0
-      source: None
-      workdirectory: ''
+      source: null
+      workdirectory: ""
 
     NbShow:
       Ignore: {}
-      attachments: None
-      details: None
-      metadata: None
-      outputs: None
-      source: None
+      attachments: null
+      details: null
+      metadata: null
+      outputs: null
+      source: null
 
     Server:
-      base_url: '/'
-      browser: None
-      ip: '127.0.0.1'
-      persist: False
+      base_url: "/"
+      browser: null
+      ip: "127.0.0.1"
+      persist: false
       port: 8888
-      workdirectory: ''
+      workdirectory: ""
 
     Extension:
       Ignore: {}
-      attachments: None
-      color_words: False
-      details: None
-      metadata: False
-      outputs: None
-      source: None
+      attachments: null
+      color_words: false
+      details: null
+      metadata: null
+      outputs: null
+      source: null
 
     NbDiffDriver:
       Ignore: {}
-      attachments: None
-      color_words: False
-      details: None
-      metadata: False
-      outputs: None
-      source: None
+      attachments: null
+      color_words: false
+      details: null
+      metadata: null
+      outputs: null
+      source: null
 
     NbDiffTool:
       Ignore: {}
-      attachments: None
-      base_url: '/'
-      browser: None
-      color_words: False
-      details: None
-      ip: '127.0.0.1'
-      metadata: False
-      outputs: None
-      persist: False
+      attachments: null
+      base_url: "/"
+      browser: null
+      color_words: false
+      details: null
+      ip: "127.0.0.1"
+      metadata: null
+      outputs: null
+      persist: false
       port: 0
-      source: None
-      workdirectory: ''
+      source: null
+      workdirectory: ""
 
     NbMergeDriver:
       Ignore: {}
-      attachments: None
-      color_words: False
-      details: None
-      ignore_transients: True
-      input_strategy: None
-      merge_strategy: 'inline'
-      metadata: None
-      output_strategy: None
-      outputs: None
-      source: None
+      attachments: null
+      color_words: false
+      details: null
+      ignore_transients: true
+      input_strategy: null
+      merge_strategy: "inline"
+      metadata: null
+      output_strategy: null
+      outputs: null
+      source: null
 
     NbMergeTool:
       Ignore: {}
-      attachments: None
-      base_url: '/'
-      browser: None
-      color_words: False
-      details: None
-      ignore_transients: True
-      input_strategy: None
-      ip: '127.0.0.1'
-      merge_strategy: 'inline'
-      metadata: None
-      output_strategy: None
-      outputs: None
-      persist: False
+      attachments: null
+      base_url: "/"
+      browser: null
+      color_words: false
+      details: null
+      ignore_transients: true
+      input_strategy: null
+      ip: "127.0.0.1"
+      merge_strategy: "inline"
+      metadata: null
+      output_strategy: null
+      outputs: null
+      persist: false
       port: 0
-      source: None
-      workdirectory: ''
+      source: null
+      workdirectory: ""
 
 
 

--- a/nbdime/__main__.py
+++ b/nbdime/__main__.py
@@ -121,13 +121,15 @@ def main_dispatch(args=None):
             sys.exit(HELP_MESSAGE_VERBOSE)
         if cmd == '--config':
             # List all possible config options:
-            from .config import get_defaults_for_argparse, entrypoint_configurables
+            from .args import modify_config_for_print
+            from .config import build_config, entrypoint_configurables
             from .prettyprint import pretty_print_dict, PrettyPrintConfig
             print('All available config options, and their current values:\n',
                   file=sys.stderr)
             for entrypoint, cls in entrypoint_configurables.items():
+                config = build_config(entrypoint, True)
                 pretty_print_dict({
-                        cls.__name__: get_defaults_for_argparse(entrypoint),
+                        cls.__name__: modify_config_for_print(config),
                     },
                     config=PrettyPrintConfig(out=sys.stderr)
                 )

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -66,7 +67,7 @@ def modify_config_for_print(config):
                 output[k] = '{}'
 
         else:
-            output[k] = repr(v)
+            output[k] = json.dumps(v)
     return output
 
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -14,7 +14,7 @@ from ._version import __version__
 from .log import init_logging, set_nbdime_log_level
 from .gitfiles import is_gitref
 from .diffing.notebooks import set_notebook_diff_targets, set_notebook_diff_ignores
-from .config import get_defaults_for_argparse, entrypoint_configurables
+from .config import get_defaults_for_argparse, build_config, entrypoint_configurables
 from .prettyprint import pretty_print_dict, PrettyPrintConfig
 
 
@@ -57,6 +57,19 @@ class SkipAction(argparse.Action):
         pass
 
 
+def modify_config_for_print(config):
+    output = {}
+    for k, v in config.items():
+        if isinstance(v, dict):
+            output[k] = modify_config_for_print(v)
+            if not output[k]:
+                output[k] = '{}'
+
+        else:
+            output[k] = repr(v)
+    return output
+
+
 class ConfigHelpAction(argparse.Action):
     def __init__(self, option_strings, dest, help=None):
         super(ConfigHelpAction, self).__init__(
@@ -64,9 +77,10 @@ class ConfigHelpAction(argparse.Action):
 
     def __call__(self, parser, namespace, values, option_string=None):
         header = entrypoint_configurables[parser.prog].__name__
+        config = build_config(parser.prog, True)
         pretty_print_dict(
             {
-                header: get_defaults_for_argparse(parser.prog),
+                header: modify_config_for_print(config),
             },
             config=PrettyPrintConfig(out=sys.stderr)
         )

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -16,9 +16,8 @@ from .merging.notebooks import (
 
 class NbdimeConfigurable(HasTraits):
 
-    @property
-    def configured_traits(self):
-        traits = self.traits(config=True)
+    def configured_traits(self, cls):
+        traits = cls.class_own_traits(config=True)
         c = {}
         for name, _ in traits.items():
             c[name] = getattr(self, name)
@@ -91,7 +90,7 @@ def build_config(entrypoint):
     configurable = entrypoint_configurables[entrypoint]
     for c in reversed(configurable.mro()):
         if issubclass(c, NbdimeConfigurable):
-            recursive_update(config, config_instance(c).configured_traits)
+            recursive_update(config, config_instance(c).configured_traits(c))
             if (c.__name__ in disk_config):
                 recursive_update(config, disk_config[c.__name__])
 

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -52,7 +52,7 @@ def _load_config_files(basefilename, path=None):
                 yield config
 
 
-def recursive_update(target, new):
+def recursive_update(target, new, include_none):
     """Recursively update one dictionary using another.
 
     None values will delete their keys.
@@ -61,19 +61,19 @@ def recursive_update(target, new):
         if isinstance(v, dict):
             if k not in target:
                 target[k] = {}
-            recursive_update(target[k], v)
-            if not target[k]:
+            recursive_update(target[k], v, include_none)
+            if not include_none and not target[k]:
                 # Prune empty subdicts
                 del target[k]
 
-        elif v is None:
+        elif not include_none and v is None:
             target.pop(k, None)
 
         else:
             target[k] = v
 
 
-def build_config(entrypoint):
+def build_config(entrypoint, include_none=False):
     if entrypoint not in entrypoint_configurables:
         raise ValueError('Config for entrypoint name %r is not defined! Accepted values are %r.' % (
             entrypoint, list(entrypoint_configurables.keys())
@@ -84,15 +84,15 @@ def build_config(entrypoint):
     path = jupyter_config_path()
     path.insert(0, py3compat.getcwd())
     for c in _load_config_files('nbdime_config', path=path):
-        recursive_update(disk_config, c)
+        recursive_update(disk_config, c, include_none)
 
     config = {}
     configurable = entrypoint_configurables[entrypoint]
     for c in reversed(configurable.mro()):
         if issubclass(c, NbdimeConfigurable):
-            recursive_update(config, config_instance(c).configured_traits(c))
+            recursive_update(config, config_instance(c).configured_traits(c), include_none)
             if (c.__name__ in disk_config):
-                recursive_update(config, disk_config[c.__name__])
+                recursive_update(config, disk_config[c.__name__], include_none)
 
     return config
 

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -554,6 +554,8 @@ def set_notebook_diff_ignores(ignore_paths):
                 del notebook_differs[path]
         elif isinstance(subkeys, (list, tuple, set)):
             notebook_differs[path] = diff_ignore_keys(notebook_differs[path], subkeys)
+        else:
+            raise ValueError('Invalid ignore config entry: %r: %r' % (path, subkeys))
 
 
 def set_notebook_diff_targets(sources=True, outputs=True, attachments=True,
@@ -567,8 +569,8 @@ def set_notebook_diff_targets(sources=True, outputs=True, attachments=True,
         '/metadata': not metadata,
         '/cells/*/metadata': not metadata,
         '/cells/*/outputs/*/metadata': not metadata,
-        '/cells/*': ('execution_count') if details else False,
-        '/cells/*/outputs/*': ('execution_count') if details else False,
+        '/cells/*': False if details else ('execution_count',),
+        '/cells/*/outputs/*': False if details else ('execution_count',),
     }
     set_notebook_diff_ignores(config)
 

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -21,7 +21,6 @@ from nbdime.args import (
     )
 from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 from .gitfiles import changed_notebooks, is_gitref
-from .config import get_defaults_for_argparse
 
 
 _description = "Compute the difference between two Jupyter notebooks."

--- a/nbdime/tests/test_args.py
+++ b/nbdime/tests/test_args.py
@@ -14,7 +14,7 @@ from nbdime.config import (
     entrypoint_configurables, Global, _Ignorables
 )
 import nbdime.diffing.notebooks
-from nbdime.diffing.notebooks import notebook_differs, diff
+from nbdime.diffing.notebooks import notebook_differs, diff, diff_ignore
 
 
 class FixtureConfig(Global):
@@ -140,5 +140,25 @@ def test_ignore_config_merge(entrypoint_ignore_config, tmpdir):
         assert notebook_differs['/metadata'] == (diff, ['foo'])
         # Lists are not merged:
         assert notebook_differs['/cells/*/metadata'] == (diff, ['tags'])
+    finally:
+        nbdime.diffing.notebooks.reset_notebook_differ()
+
+
+def test_config_inherit(entrypoint_ignore_config, tmpdir):
+    tmpdir.join('nbdime_config.json').write_text(
+        text_type(json.dumps({
+            'IgnorableConfig1': {
+                'metadata': False
+            },
+        })),
+        encoding='utf-8'
+    )
+
+    parser = ConfigBackedParser('test-prog')
+    with tmpdir.as_cwd():
+        parsed = parser.parse_args([])
+
+    try:
+        assert parsed.metadata == False
     finally:
         nbdime.diffing.notebooks.reset_notebook_differ()


### PR DESCRIPTION
Fix several issues with the config system / documentation:
- Fix an issue of configuration inheritance from sections.
- Improve config docs.
- Make `<command> --config` output include all available options, even unconfigured ones (but mark those as unconfigured).
- Fix a mistake in applying the `--details` ignore option.