### PR TITLE
Optimize text comparison for text MIME data

### DIFF
--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -33,7 +33,7 @@ def default_differs():
     return defaultdict(lambda: diff)
 
 
-def compare_strings_approximate(x, y, threshold=0.7):
+def compare_strings_approximate(x, y, threshold=0.7, maxlen=None):
     "Compare to strings with approximate heuristics."
     # TODO: Add configuration framework
     # TODO: Tune threshold with realistic sources
@@ -70,6 +70,11 @@ def compare_strings_approximate(x, y, threshold=0.7):
         return False
     if s.quick_ratio() < threshold:
         return False
+
+    if maxlen is not None and len(x) > maxlen and len(y) > maxlen:
+        # We know from above that there is not an exact similarity
+        return False
+
     return s.ratio() > threshold
 
 

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -502,7 +502,7 @@ def diff_ignore_keys(inner_differ, ignore_keys):
     """Call inner_differ, but filter the resulting diff.
 
     Will ignore all direct diff values that has a key in
-    ignore_keys. I.e. this will not recurse into patch ops.abs
+    ignore_keys. I.e. this will not recurse into patch ops.
     """
     def ignored_diff(*args, **kwargs):
         d = inner_differ(*args, **kwargs)

--- a/nbdime/profiling.py
+++ b/nbdime/profiling.py
@@ -112,10 +112,12 @@ timer = TimePaths(enabled=False)
 def profile_diff_paths(args=None):
     import nbdime.nbdiffapp
     import nbdime.profiling
-    with nbdime.profiling.timer.enable():
-        nbdime.nbdiffapp.main(args)
-    data = str(nbdime.profiling.timer)
-    print(data)
+    try:
+        with nbdime.profiling.timer.enable():
+            nbdime.nbdiffapp.main(args)
+    finally:
+        data = str(nbdime.profiling.timer)
+        print(data)
 
 
 if __name__ == "__main__":

--- a/nbdime/tests/test_diff_performance.py
+++ b/nbdime/tests/test_diff_performance.py
@@ -1,0 +1,37 @@
+
+import pytest
+
+import random
+import string
+
+from .utils import outputs_to_notebook
+
+from nbdime.diffing import diff_notebooks
+
+
+def random_string(N):
+    return ''.join(random.choice(
+        string.ascii_uppercase + string.digits) for _ in range(N))
+
+
+@pytest.mark.timeout(timeout=20)
+def test_text_mimedata_performance():
+    # Create some random text (seeded) for a few
+    # outputs on each side
+    random.seed(0)
+    base = outputs_to_notebook([
+        [random_string(50000)],
+        [random_string(80000)],
+        [random_string(30000)],
+    ])
+    remote = outputs_to_notebook([
+        [random_string(50000)],
+        [random_string(30000)],
+        [random_string(30000)],
+        [random_string(80000)],
+    ])
+
+    # Since the contents is random, ignore the actual diff
+    # Only interested in performance not blowing up
+    diff_notebooks(base, remote)
+


### PR DESCRIPTION
Supersedes #237.

Difflib's ratio() method blows up for very large contents. This PR limits this problem for output comparison by giving a maximum length for text data when doing mimedata comparison. If both sides of the comparison are larger than this length, it will revert to strict equality instead of the slow `ratio()` method.