### PR TITLE
Fix config parsing for subcommands

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -37,7 +37,7 @@ The current output of `nbdime --config` is:
       details: null
       metadata: null
       outputs: null
-      source: null
+      sources: null
 
     NbDiffWeb:
       Ignore: {}
@@ -51,7 +51,7 @@ The current output of `nbdime --config` is:
       outputs: null
       persist: false
       port: 0
-      source: null
+      sources: null
       workdirectory: ""
 
     NbMerge:
@@ -65,7 +65,7 @@ The current output of `nbdime --config` is:
       metadata: null
       output_strategy: null
       outputs: null
-      source: null
+      sources: null
 
     NbMergeWeb:
       Ignore: {}
@@ -83,7 +83,7 @@ The current output of `nbdime --config` is:
       outputs: null
       persist: false
       port: 0
-      source: null
+      sources: null
       workdirectory: ""
 
     NbShow:
@@ -92,7 +92,7 @@ The current output of `nbdime --config` is:
       details: null
       metadata: null
       outputs: null
-      source: null
+      sources: null
 
     Server:
       base_url: "/"
@@ -109,7 +109,7 @@ The current output of `nbdime --config` is:
       details: null
       metadata: null
       outputs: null
-      source: null
+      sources: null
 
     NbDiffDriver:
       Ignore: {}
@@ -118,7 +118,7 @@ The current output of `nbdime --config` is:
       details: null
       metadata: null
       outputs: null
-      source: null
+      sources: null
 
     NbDiffTool:
       Ignore: {}
@@ -132,7 +132,7 @@ The current output of `nbdime --config` is:
       outputs: null
       persist: false
       port: 0
-      source: null
+      sources: null
       workdirectory: ""
 
     NbMergeDriver:
@@ -146,7 +146,7 @@ The current output of `nbdime --config` is:
       metadata: null
       output_strategy: null
       outputs: null
-      source: null
+      sources: null
 
     NbMergeTool:
       Ignore: {}
@@ -164,7 +164,7 @@ The current output of `nbdime --config` is:
       outputs: null
       persist: false
       port: 0
-      source: null
+      sources: null
       workdirectory: ""
 
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -24,9 +24,8 @@ from .prettyprint import pretty_print_dict, PrettyPrintConfig
 
 class ConfigBackedParser(argparse.ArgumentParser):
 
-    def parse_args(self, args=None, namespace=None, entrypoint=None):
-        if entrypoint is None:
-            entrypoint = self.prog
+    def parse_known_args(self, args=None, namespace=None):
+        entrypoint = self.prog.split(' ')[0]
         try:
             defs = get_defaults_for_argparse(entrypoint)
             ignore = defs.pop('Ignore', None)
@@ -35,7 +34,7 @@ class ConfigBackedParser(argparse.ArgumentParser):
                 set_notebook_diff_ignores(ignore)
         except ValueError:
             pass
-        return super(ConfigBackedParser, self).parse_args(args=args, namespace=namespace)
+        return super(ConfigBackedParser, self).parse_known_args(args=args, namespace=namespace)
 
 
 class LogLevelAction(argparse.Action):

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -169,7 +169,7 @@ class IgnoreConfig(Dict):
 
 class _Ignorables(NbdimeConfigurable):
 
-    source = Bool(
+    sources = Bool(
         None,
         allow_none=True,
         help="process/ignore sources.",

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -33,23 +33,23 @@ def config_instance(cls):
 
 
 def _load_config_files(basefilename, path=None):
-        """Load config files (json) by filename and path.
+    """Load config files (json) by filename and path.
 
-        yield each config object in turn.
-        """
+    yield each config object in turn.
+    """
 
-        if not isinstance(path, list):
-            path = [path]
-        for path in path[::-1]:
-            # path list is in descending priority order, so load files backwards:
-            loader = JSONFileConfigLoader(basefilename+'.json', path=path)
-            config = None
-            try:
-                config = loader.load_config()
-            except ConfigFileNotFound:
-                pass
-            if config:
-                yield config
+    if not isinstance(path, list):
+        path = [path]
+    for path in path[::-1]:
+        # path list is in descending priority order, so load files backwards:
+        loader = JSONFileConfigLoader(basefilename+'.json', path=path)
+        config = None
+        try:
+            config = loader.load_config()
+        except ConfigFileNotFound:
+            pass
+        if config:
+            yield config
 
 
 def recursive_update(target, new, include_none):


### PR DESCRIPTION
Previously the config system didn't work fully for subcommands (e.g. `git-nbdiffdriver diff`).

Also renames the config option `source` to `sources` to be in line with the CLI argument.