### PR TITLE
Ensure localhost is recognized as loopback

### DIFF
--- a/nbdime/tests/test_web.py
+++ b/nbdime/tests/test_web.py
@@ -36,6 +36,21 @@ def test_diff_web(filespath, unique_port, reset_log):
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
+def test_diff_web_localhost(filespath, unique_port, reset_log):
+    a = os.path.join(filespath, diff_a)
+    b = os.path.join(filespath, diff_b)
+    loop = ioloop.IOLoop.current()
+    loop.call_later(0, loop.stop)
+    nbdime.webapp.nbdiffweb.main([
+        '--port=%i' % unique_port,
+        '--browser=disabled',
+        '--ip=localhost',
+        a,
+        b
+    ])
+
+
+@pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
 def test_diff_web_gitrefs(git_repo2, unique_port, reset_log):
     a = 'local'
     b = 'remote'

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -341,7 +341,7 @@ def make_app(**params):
         'base_url': base_url,
         'jinja2_env': env,
         'mathjax_url': prefix + '/nb-static/mathjax/MathJax.js',
-        'local_hostnames': ['localhost']
+        'local_hostnames': ['localhost', '127.0.0.1']
         }
 
     if nbdime.utils.is_in_repo(nbdime.__file__):

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -341,6 +341,7 @@ def make_app(**params):
         'base_url': base_url,
         'jinja2_env': env,
         'mathjax_url': prefix + '/nb-static/mathjax/MathJax.js',
+        'local_hostnames': ['localhost']
         }
 
     if nbdime.utils.is_in_repo(nbdime.__file__):


### PR DESCRIPTION
Ensure we can pass `localhost` as the IP to web entrypoints.

Related to #408.