### PR TITLE
Fix filter integration, always use shell=True

### DIFF
--- a/nbdime/vcs/git/filter_integration.py
+++ b/nbdime/vcs/git/filter_integration.py
@@ -1,6 +1,5 @@
 
 import io
-import os
 from subprocess import check_output, STDOUT, CalledProcessError
 import sys
 
@@ -8,8 +7,6 @@ from six import StringIO
 
 from nbdime.utils import EXPLICIT_MISSING_FILE
 
-
-USE_SHELL = os.name == 'nt'
 
 class NamedStringIO(StringIO):
     name = ''
@@ -20,7 +17,7 @@ def interrogate_filter(path):
 
     Returns None if no valid filter attribute could be found.
     """
-    # Ask for the fit attributes of file on path (-z = null-terminated fields)
+    # Ask for the filter attributes of file on path (-z = null-terminated fields)
     try:
         spec = check_output(['git', 'check-attr', '-z', 'filter', path])
     except CalledProcessError:
@@ -75,9 +72,9 @@ def apply_possible_filter(git_path, path=None):
     # Apply filter and pipe to a string buffer
     with io.open(path, 'r', encoding="utf8") as f:
         output = check_output(
-            filter_cmd.split(),
+            filter_cmd,
             stdin=f,
-            stderr=STDOUT, shell=USE_SHELL
+            stderr=STDOUT, shell=True
         ).decode('utf8', 'replace')
     buffer = NamedStringIO()
     buffer.name = path

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -12,7 +12,6 @@ from notebook.utils import url_path_join, to_os_path
 from notebook.services.contents.checkpoints import GenericCheckpointsMixin
 from notebook.services.contents.filecheckpoints import FileCheckpoints
 from tornado.web import HTTPError, escape, authenticated, gen
-import nbformat
 
 import nbdime
 from .nbdimeserver import (
@@ -27,9 +26,8 @@ from .nbdimeserver import (
 from ..gitfiles import (
     changed_notebooks, is_path_in_repo, find_repo_root,
     InvalidGitRepositoryError, BadName, GitCommandNotFound,
-    apply_possible_filter
     )
-from ..utils import split_os_path, EXPLICIT_MISSING_FILE, read_notebook
+from ..utils import read_notebook
 from ..config import build_config, Namespace
 from ..diffing.notebooks import set_notebook_diff_ignores
 from ..args import process_diff_flags, diff_exclusives


### PR DESCRIPTION
Always use shell=True for git filter call. This is what it seems that git does, so we should be ok. Also, the value comes from git config, which should require write access to modify.

Fixes #415.