### PR TITLE
Fix mathjax use in webapp

### DIFF
--- a/nbdime/tests/test_server_extension.py
+++ b/nbdime/tests/test_server_extension.py
@@ -76,6 +76,8 @@ def test_git_difftool(git_repo2, server_extension_app):
         "remote": "",
         "savable": False,
         "hideUnchanged": True,
+        "mathjaxConfig": "TeX-AMS-MML_HTMLorMML-full,Safe",
+        "mathjaxUrl": "/static/components/MathJax/MathJax.js",
     }
 
 

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -51,8 +51,6 @@ class GitDifftoolHandler(NbdimeHandler):
         self.write(self.render_template(
             'difftool.html',
             config_data=args,
-            mathjax_url=self.mathjax_url,
-            mathjax_config=self.mathjax_config,
             ))
 
 
@@ -68,8 +66,6 @@ class CheckpointDifftoolHandler(NbdimeHandler):
         self.write(self.render_template(
             'difftool.html',
             config_data=args,
-            mathjax_url=self.mathjax_url,
-            mathjax_config=self.mathjax_config,
             ))
 
 

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -54,7 +54,9 @@ class NbdimeHandler(IPythonHandler):
             'closable': self.params.get('closable', False),
             'savable': fn is not None,
             'baseUrl': self.nbdime_base_url,
-            'hideUnchanged': self.params.get('hide_unchanged', True)
+            'hideUnchanged': self.params.get('hide_unchanged', True),
+            'mathjaxUrl': self.mathjax_url,
+            'mathjaxConfig': self.mathjax_config,
         }
         if fn:
             # For reference, e.g. if user wants to download file
@@ -138,8 +140,6 @@ class MainHandler(NbdimeHandler):
         args['remote'] = self.get_argument('remote', '')
         self.write(self.render_template('compare.html',
                     config_data=args,
-                    mathjax_url=self.mathjax_url,
-                    mathjax_config=self.mathjax_config,
                    ))
 
 
@@ -151,8 +151,6 @@ class MainDiffHandler(NbdimeHandler):
 
         self.write(self.render_template('diff.html',
                     config_data=args,
-                    mathjax_url=self.mathjax_url,
-                    mathjax_config=self.mathjax_config,
                    ))
 
 
@@ -175,8 +173,6 @@ class MainDifftoolHandler(NbdimeHandler):
             args['remote'] = self.get_argument('remote', '')
         self.write(self.render_template('difftool.html',
                     config_data=args,
-                    mathjax_url=self.mathjax_url,
-                    mathjax_config=self.mathjax_config,
                    ))
 
 
@@ -188,8 +184,6 @@ class MainMergeHandler(NbdimeHandler):
         args['remote'] = self.get_argument('remote', '')
         self.write(self.render_template('merge.html',
                     config_data=args,
-                    mathjax_url=self.mathjax_url,
-                    mathjax_config=self.mathjax_config,
                    ))
 
 
@@ -206,8 +200,6 @@ class MainMergetoolHandler(NbdimeHandler):
             args['remote'] = self.get_argument('remote', '')
         self.write(self.render_template('mergetool.html',
                     config_data=args,
-                    mathjax_url=self.mathjax_url,
-                    mathjax_config=self.mathjax_config,
                    ))
 
 

--- a/nbdime/webapp/templates/nbdimepage.html
+++ b/nbdime/webapp/templates/nbdimepage.html
@@ -7,9 +7,7 @@
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
-    {% if mathjax_url %}
-    <script type="text/javascript" src="{{mathjax_url}}?config={{mathjax_config}}&delayStartupUntil=configured" charset="utf-8"></script>
-    {% endif %}
+
     <title>nbdime - diff and merge your Jupyter notebooks</title>
 
   </head>

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.18.4",
+    "@jupyterlab/mathjax2": "^0.7.1",
     "@jupyterlab/apputils": "^0.18.4",
     "@jupyterlab/cells": "^0.18.4",
     "@jupyterlab/codemirror": "^0.18.4",

--- a/packages/webapp/src/app/diff.ts
+++ b/packages/webapp/src/app/diff.ts
@@ -20,6 +20,14 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
+  PageConfig
+} from '@jupyterlab/coreutils';
+
+import {
+  MathJaxTypesetter
+} from '@jupyterlab/mathjax2';
+
+import {
   IDiffEntry
 } from 'nbdime/lib/diff/diffentries';
 
@@ -80,6 +88,10 @@ function showDiff(data: {base: nbformat.INotebookContent, diff: IDiffEntry[]}): 
   let rendermime = new RenderMimeRegistry({
     initialFactories: rendererFactories,
     sanitizer: defaultSanitizer,
+    latexTypesetter: new MathJaxTypesetter({
+      url: getConfigOption('mathjaxUrl'),
+      config: getConfigOption('mathjaxConfig'),
+    }),
   });
 
   let nbdModel = new NotebookDiffModel(data.base, data.diff);


### PR DESCRIPTION
Behavior in jupyterlab rendermime changed previously. This uses the most recent way of specifying the latex typesetter. No change needed for the lab extension, as that should be configured from the application level.

Awaiting resolution of https://github.com/jupyterlab/jupyterlab/issues/5257 before merging to possibly clean up dependencies.