### PR TITLE
Add CLI/lab option for hide unchanged cells. On by default.

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -250,6 +250,13 @@ def add_web_args(parser, default_port=8888):
         '--base-url',
         default='/',
         help="The base URL prefix under which to run the web app")
+    parser.add_argument(
+        '--show-unchanged',
+        dest='hide_unchanged',
+        action="store_false",
+        default=True,
+        help="show unchanged cells by default"
+    )
 
 
 def add_diff_args(parser):
@@ -448,6 +455,7 @@ def args_for_server(arguments):
                 port='port',
                 workdirectory='cwd',
                 base_url='base_url',
+                hide_unchanged='hide_unchanged',
                 )
     ret = {kmap[k]: v for k, v in vars(arguments).items() if k in kmap}
     if 'persist' in arguments:

--- a/nbdime/tests/test_server_extension.py
+++ b/nbdime/tests/test_server_extension.py
@@ -74,7 +74,8 @@ def test_git_difftool(git_repo2, server_extension_app):
         "baseUrl": "/nbdime",
         "closable": False,
         "remote": "",
-        "savable": False
+        "savable": False,
+        "hideUnchanged": True,
     }
 
 

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -52,6 +52,7 @@ class NbdimeHandler(IPythonHandler):
             'closable': self.params.get('closable', False),
             'savable': fn is not None,
             'baseUrl': self.nbdime_base_url,
+            'hideUnchanged': self.params.get('hideUnchanged', True)
         }
         if fn:
             # For reference, e.g. if user wants to download file

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -52,7 +52,7 @@ class NbdimeHandler(IPythonHandler):
             'closable': self.params.get('closable', False),
             'savable': fn is not None,
             'baseUrl': self.nbdime_base_url,
-            'hideUnchanged': self.params.get('hideUnchanged', True)
+            'hideUnchanged': self.params.get('hide_unchanged', True)
         }
         if fn:
             # For reference, e.g. if user wants to download file

--- a/packages/labextension/package.json
+++ b/packages/labextension/package.json
@@ -32,6 +32,7 @@
   ],
   "jupyterlab": {
     "extension": true,
+    "schemaDir": "schema",
     "discovery": {
       "server": {
         "base": {
@@ -59,7 +60,10 @@
   },
   "files": [
     "lib/*.js",
-    "style/*.css"
+    "lib/*.js.map",
+    "lib/*.d.ts",
+    "style/*.css",
+    "schema/*.json"
   ],
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",

--- a/packages/labextension/schema/plugin.json
+++ b/packages/labextension/schema/plugin.json
@@ -1,0 +1,17 @@
+{
+  "jupyter.lab.setting-icon-class": "jp-Icon-16 nbdime-icon fa fa-clock-o",
+  "jupyter.lab.setting-icon-label": "Nbdime",
+  "title": "Nbdime",
+  "description": "Settings for the nbdime extension.",
+  "properties": {
+    "hideUnchanged": {
+      "title": "Hide Unchanged Cells",
+      "description":
+        "Whether unchanged cells should be hidden by default.",
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/labextension/src/actions.ts
+++ b/packages/labextension/src/actions.ts
@@ -33,7 +33,12 @@ interface IApiResponse {
 
 
 export
-function diffNotebook(args: {readonly base: string, readonly remote: string, readonly rendermime: IRenderMimeRegistry}): Widget {
+function diffNotebook(args: {
+  readonly base: string,
+  readonly remote: string,
+  readonly rendermime: IRenderMimeRegistry,
+  hideUnchanged?: boolean
+}): Widget {
   let {base, remote} = args;
   let widget = new NbdimeWidget(args);
   widget.title.label = `Diff: ${base} ↔ ${remote}`;
@@ -43,12 +48,21 @@ function diffNotebook(args: {readonly base: string, readonly remote: string, rea
 
 
 export
-function diffNotebookCheckpoint(args: {readonly path: string, readonly rendermime: IRenderMimeRegistry}): Widget {
-  const {path, rendermime} = args;
+function diffNotebookCheckpoint(args: {
+  readonly path: string,
+  readonly rendermime: IRenderMimeRegistry,
+  hideUnchanged?: boolean
+}): Widget {
+  const {path, rendermime, hideUnchanged} = args;
   let nb_dir = PathExt.dirname(path);
   let name = PathExt.basename(path, '.ipynb');
   let base = PathExt.join(nb_dir, name + '.ipynb');
-  let widget = new NbdimeWidget({base, rendermime, baseLabel: 'Checkpoint'});
+  let widget = new NbdimeWidget({
+    base,
+    rendermime,
+    baseLabel: 'Checkpoint',
+    hideUnchanged,
+  });
   widget.title.label = `Diff checkpoint: ${name}`;
   widget.title.caption = `Local: latest checkpoint\nRemote: '${path}'`;
   widget.title.iconClass = 'fa fa-clock-o jp-fa-tabIcon';
@@ -57,10 +71,14 @@ function diffNotebookCheckpoint(args: {readonly path: string, readonly rendermim
 
 
 export
-function diffNotebookGit(args: {readonly path: string, readonly rendermime: IRenderMimeRegistry}): Widget {
-  const {path, rendermime} = args;
+function diffNotebookGit(args: {
+  readonly path: string,
+  readonly rendermime: IRenderMimeRegistry,
+  hideUnchanged?: boolean
+}): Widget {
+  const {path, rendermime, hideUnchanged} = args;
   let name = PathExt.basename(path, '.ipynb');
-  let widget = new NbdimeWidget({base: path, rendermime});
+  let widget = new NbdimeWidget({base: path, rendermime, hideUnchanged});
   widget.title.label = `Diff git: ${name}`;
   widget.title.caption = `Local: git HEAD\nRemote: '${path}'`;
   widget.title.iconClass = 'fa fa-git jp-fa-tabIcon';

--- a/packages/labextension/src/widget.ts
+++ b/packages/labextension/src/widget.ts
@@ -312,11 +312,14 @@ namespace Private {
     if (rangeStart !== -1) {
       // Last element was part of a hidden range, need to mark
       // the last cell that will be visible.
+      let N = children.length - rangeStart;
       if (rangeStart === 0) {
         // All elements were hidden, nothing to mark
+        // Add info on root instead
+        let tag = root.querySelector('.jp-Notebook-diff') || root;
+        tag.setAttribute('data-nbdime-AllCellsHidden', N.toString());
         return;
       }
-      let N = children.length - rangeStart;
       let lastVisible = children[rangeStart - 1];
       getChunkElement(lastVisible).setAttribute('data-nbdime-NCellsHiddenAfter', N.toString());
     }

--- a/packages/labextension/src/widget.ts
+++ b/packages/labextension/src/widget.ts
@@ -1,7 +1,7 @@
 
 
 import {
-  nbformat, URLExt
+  nbformat
 } from '@jupyterlab/coreutils';
 
 import {
@@ -43,10 +43,6 @@ import {
 import {
   requestApiJson
 } from 'nbdime/lib/request';
-
-import {
-  urlRStrip
-} from './utils';
 
 
 

--- a/packages/labextension/src/widget.ts
+++ b/packages/labextension/src/widget.ts
@@ -89,9 +89,14 @@ class NbdimeWidget extends Panel {
     this.addWidget(this.scroller);
 
     let hideUnchangedChk = header.node.getElementsByClassName('nbdime-hide-unchanged')[0] as HTMLInputElement;
+    hideUnchangedChk.checked = options.hideUnchanged === undefined
+      ? true : options.hideUnchanged;
     hideUnchangedChk.onchange = () => {
       Private.toggleShowUnchanged(this.scroller.node, !hideUnchangedChk.checked);
     };
+    if (options.hideUnchanged) {
+      Private.toggleShowUnchanged(this.scroller, false);
+    }
 
     let args: JSONObject;
     if (this.remote) {
@@ -201,6 +206,11 @@ namespace NbdimeWidget {
      * Note: The labels will be ignored for git diffs.
      */
     remoteLabel?: string,
+
+    /**
+     * Whether to hide unchanged cells by default.
+     */
+    hideUnchanged?: boolean,
   }
 }
 

--- a/packages/labextension/style/index.css
+++ b/packages/labextension/style/index.css
@@ -77,7 +77,8 @@
 }
 
 /* Show a marker with the number of cells hidden before */
-.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore]::before {
+.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore]::before,
+.nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenBefore]::before {
   content: attr(data-nbdime-NCellsHiddenBefore) " unchanged cell(s) hidden";
   position: absolute;
   width: 100%;
@@ -89,7 +90,8 @@
 }
 
 /* Show a marker with the number of cells hidden after (for hidden cells at end) */
-.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter]::after {
+.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter]::after,
+.nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenAfter]::after {
   content: attr(data-nbdime-NCellsHiddenAfter) " unchanged cell(s) hidden";
   position: absolute;
   width: 100%;
@@ -100,10 +102,12 @@
   text-align: center;
 }
 
-.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore] {
+.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenBefore],
+.nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenBefore] {
   padding-top: 40px;
 }
 
-.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter] {
+.nbdime-root.jp-mod-hideUnchanged .jp-Cell-diff[data-nbdime-NCellsHiddenAfter],
+.nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenAfter] {
   padding-bottom: 40px;
 }

--- a/packages/labextension/style/index.css
+++ b/packages/labextension/style/index.css
@@ -19,6 +19,11 @@
   color: var(--jp-ui-font-color0);
 }
 
+.jp-PluginList-icon.nbdime-icon {
+  font-size: 16px;
+  vertical-align: text-bottom;
+}
+
 
 /* Header syling */
 

--- a/packages/labextension/style/index.css
+++ b/packages/labextension/style/index.css
@@ -111,3 +111,14 @@
 .nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenAfter] {
   padding-bottom: 40px;
 }
+
+/* Marker for when all cells are unchanged and hidden */
+.nbdime-root.jp-mod-hideUnchanged .jp-Notebook-diff[data-nbdime-AllCellsHidden]::after {
+  content: "No changes, " attr(data-nbdime-AllCellsHidden) " unchanged cell(s) hidden";
+  display: block;
+  width: 100%;
+  background-color: var(--jp-layout-color2);
+  border-top: solid var(--jp-layout-color3) 1px;
+  border-bottom: solid var(--jp-layout-color3) 1px;
+  text-align: center;
+}

--- a/packages/nbdime/src/request/index.ts
+++ b/packages/nbdime/src/request/index.ts
@@ -44,7 +44,7 @@ function requestApiPromise(
     baseUrl: string,
     apiPath: string,
     argument: any): Promise<Response> {
-  const url = URLExt.join(window.location.origin, urlRStrip(baseUrl), apiPath);
+  const url = URLExt.join(urlRStrip(baseUrl), apiPath);
   let request = {
     method: 'POST',
     body: JSON.stringify(argument),

--- a/packages/webapp/src/app/common.ts
+++ b/packages/webapp/src/app/common.ts
@@ -5,6 +5,10 @@
 import * as alertify from 'alertify.js';
 
 import {
+  URLExt
+} from '@jupyterlab/coreutils/lib/url';
+
+import {
   NotifyUserError
 } from 'nbdime/lib/common/exceptions';
 
@@ -90,7 +94,7 @@ function getConfigOption(name: string, defaultValue?: any): any {
  */
 export
 function getBaseUrl(): string {
-  return getConfigOption('baseUrl');
+  return URLExt.join(window.location.origin, getConfigOption('baseUrl'));
 }
 
 const spinner = document.createElement('div');

--- a/packages/webapp/src/app/common.ts
+++ b/packages/webapp/src/app/common.ts
@@ -187,11 +187,14 @@ function markUnchangedRanges() {
   if (rangeStart !== -1) {
     // Last element was part of a hidden range, need to mark
     // the last cell that will be visible.
+    let N = children.length - rangeStart;
     if (rangeStart === 0) {
       // All elements were hidden, nothing to mark
+      // Add info on root instead
+      let tag = root.querySelector('.jp-Notebook-diff, .jp-Notebook-merge') || root;
+      tag.setAttribute('data-nbdime-AllCellsHidden', N.toString());
       return;
     }
-    let N = children.length - rangeStart;
     let lastVisible = children[rangeStart - 1];
     // Set attribute on element / chunk element as appropriate
     getChunkElement(lastVisible).setAttribute('data-nbdime-NCellsHiddenAfter', N.toString());

--- a/packages/webapp/src/app/compare.ts
+++ b/packages/webapp/src/app/compare.ts
@@ -180,6 +180,7 @@ function initializeCompare() {
   exportBtn.onclick = exportDiff;
 
   let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
+  hideUnchangedChk.checked = getConfigOption('hideUnchanged', true);
   hideUnchangedChk.onchange = () => {
     toggleShowUnchanged(!hideUnchangedChk.checked);
   };

--- a/packages/webapp/src/app/diff.css
+++ b/packages/webapp/src/app/diff.css
@@ -90,3 +90,14 @@
 #nbdime-root.jp-mod-hideUnchanged .jp-Diff-addremchunk[data-nbdime-NCellsHiddenAfter] {
   padding-bottom: 40px;
 }
+
+/* Marker for when all cells are unchanged and hidden */
+#nbdime-root.jp-mod-hideUnchanged .jp-Notebook-diff[data-nbdime-AllCellsHidden]::after {
+  content: "No changes, " attr(data-nbdime-AllCellsHidden) " unchanged cell(s) hidden";
+  display: block;
+  width: 100%;
+  background-color: #eee;
+  border-top: solid #ccc 1px;
+  border-bottom: solid #ccc 1px;
+  text-align: center;
+}

--- a/packages/webapp/src/app/diff.ts
+++ b/packages/webapp/src/app/diff.ts
@@ -90,6 +90,9 @@ function showDiff(data: {base: nbformat.INotebookContent, diff: IDiffEntry[]}): 
     throw new Error('Missing root element "nbidme-root"');
   }
   root.innerHTML = '';
+  // Hide unchanged cells by default:
+  toggleShowUnchanged(!getConfigOption('hideUnchanged', true));
+
   let panel = new Panel();
   panel.id = 'main';
   Widget.attach(panel, root);
@@ -241,6 +244,7 @@ function initializeDiff() {
   exportBtn.onclick = exportDiff;
 
   let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
+  hideUnchangedChk.checked = getConfigOption('hideUnchanged', true);
   hideUnchangedChk.onchange = () => {
     toggleShowUnchanged(!hideUnchangedChk.checked);
   };

--- a/packages/webapp/src/app/merge.css
+++ b/packages/webapp/src/app/merge.css
@@ -63,3 +63,14 @@
 #nbdime-root.jp-mod-hideUnchanged .jp-Cell-merge[data-nbdime-NCellsHiddenAfter] {
   padding-bottom: 40px;
 }
+
+/* Marker for when all cells are unchanged and hidden */
+#nbdime-root.jp-mod-hideUnchanged .jp-Notebook-merge[data-nbdime-AllCellsHidden]::after {
+  content: "No changes, " attr(data-nbdime-AllCellsHidden) " unchanged cell(s) hidden";
+  display: block;
+  width: 100%;
+  background-color: #eee;
+  border-top: solid #ccc 1px;
+  border-bottom: solid #ccc 1px;
+  text-align: center;
+}

--- a/packages/webapp/src/app/merge.ts
+++ b/packages/webapp/src/app/merge.ts
@@ -80,6 +80,9 @@ function showMerge(data: {
     throw new Error('Missing root element "nbidme-root"');
   }
   root.innerHTML = '';
+  // Hide unchanged cells by default:
+  toggleShowUnchanged(!getConfigOption('hideUnchanged', true));
+
   let panel = new Panel();
   panel.id = 'main';
   Widget.attach(panel, root);
@@ -405,6 +408,7 @@ function initializeMerge() {
   downloadBtn.style.display = 'initial';
 
   let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
+  hideUnchangedChk.checked = getConfigOption('hideUnchanged', true);
   hideUnchangedChk.onchange = () => {
     toggleShowUnchanged(!hideUnchangedChk.checked);
   };


### PR DESCRIPTION
- Adds settings for lab extension. So far only one setting: `hideUnchanged` that is true by default.
- Changes default for web views to hide unchanged cells by default (but checkbox is still there).
- Adds a CLI option for web diff/merge entry points `--show-unchanged` to allow old behavior.
- Fixes a problem with base urls for some requests.
- Now shows a notice if all cells are unchanged and hidden ("No changes, [N] unchanged cell(s) hidden").

Resolves #401.