### PR TITLE
Expose config for pretty print

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -479,7 +479,7 @@ def prettyprint_config_from_args(arguments, **kwargs):
         use_color=getattr(arguments, 'use_color', True),
         use_git=getattr(arguments, 'use_git', True),
         use_diff=getattr(arguments, 'use_diff', True),
-        **kwargs,
+        **kwargs
     )
 
 

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -9,17 +9,15 @@ import logging
 import os
 import sys
 
-from six import PY2
-
 from ._version import __version__
-from .log import init_logging, set_nbdime_log_level
-from .gitfiles import is_gitref
-from .diffing.notebooks import set_notebook_diff_targets, set_notebook_diff_ignores
 from .config import (
     get_defaults_for_argparse, build_config, entrypoint_configurables,
     Namespace
 )
-from .prettyprint import pretty_print_dict, PrettyPrintConfig
+from .diffing.notebooks import set_notebook_diff_targets, set_notebook_diff_ignores
+from .gitfiles import is_gitref
+from .ignorables import diff_ignorables
+from .log import init_logging, set_nbdime_log_level
 
 
 class ConfigBackedParser(argparse.ArgumentParser):
@@ -68,12 +66,12 @@ def modify_config_for_print(config):
             output[k] = modify_config_for_print(v)
             if not output[k]:
                 output[k] = '{}'
-        elif k in diff_exclusives and v is None:
+        elif k in diff_ignorables and v is None:
             if ns is None:
                 ns = Namespace(config)
-                for k in diff_exclusives:
-                    setattr(ns, k, config.get(k, None))
-                process_exclusive_ignorables(ns, diff_exclusives)
+                for k2 in diff_ignorables:
+                    setattr(ns, k2, config.get(k2, None))
+                process_exclusive_ignorables(ns, diff_ignorables)
             output[k] = '<unset, resolves to {0}>'.format(
                 json.dumps(getattr(ns, k, v)))
         else:
@@ -87,6 +85,8 @@ class ConfigHelpAction(argparse.Action):
             option_strings, dest, nargs=0, help=help)
 
     def __call__(self, parser, namespace, values, option_string=None):
+        from .prettyprint import pretty_print_dict, PrettyPrintConfig
+
         header = entrypoint_configurables[parser.prog].__name__
         config = build_config(parser.prog, True)
         pretty_print_dict(
@@ -297,9 +297,6 @@ def add_diff_args(parser):
         help="process/ignore details not covered by other options.")
 
 
-diff_exclusives = ('sources', 'outputs', 'attachments', 'metadata', 'details')
-
-
 def add_diff_cli_args(parser):
     """Adds a set of arguments for CLI diff commands (i.e. not web).
     """
@@ -358,7 +355,7 @@ def add_git_diff_driver_args(diff_parser):
 
 
 def process_diff_flags(args):
-    process_exclusive_ignorables(args, diff_exclusives)
+    process_exclusive_ignorables(args, diff_ignorables)
     set_notebook_diff_targets(args.sources, args.outputs,
                               args.attachments, args.metadata, args.details)
 
@@ -446,6 +443,44 @@ def add_filename_args(parser, names):
         }
     for name in names:
         parser.add_argument(name, help=helps[name])
+
+
+def add_prettyprint_args(parser):
+    """Adds optional arguments for controlling pretty print behavior.
+    """
+    parser.add_argument(
+        '--no-color',
+        dest='use_color',
+        action="store_false",
+        default=True,
+        help=("prevent use of ANSI color code escapes for text output")
+    )
+    parser.add_argument(
+        '--no-git',
+        dest='use_git',
+        action="store_false",
+        default=True,
+        help=("prevent use of git for formatting diff/merge text output")
+    )
+    parser.add_argument(
+        '--no-use-diff',
+        dest='use_diff',
+        action="store_false",
+        default=True,
+        help=("prevent use of diff/diff3 for formatting diff/merge text output")
+    )
+
+
+def prettyprint_config_from_args(arguments, **kwargs):
+    from .prettyprint import PrettyPrintConfig
+    return PrettyPrintConfig(
+        include=arguments,
+        color_words=getattr(arguments, 'color_words', False),
+        use_color=getattr(arguments, 'use_color', True),
+        use_git=getattr(arguments, 'use_git', True),
+        use_diff=getattr(arguments, 'use_diff', True),
+        **kwargs,
+    )
 
 
 def args_for_server(arguments):

--- a/nbdime/ignorables.py
+++ b/nbdime/ignorables.py
@@ -1,0 +1,8 @@
+# coding: utf-8
+
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from __future__ import unicode_literals
+
+diff_ignorables = ('sources', 'outputs', 'attachments', 'metadata', 'details')

--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -6,21 +6,21 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import json
 import os
 import sys
-import argparse
-import json
 
 from six import string_types
 
-from nbdime.diffing.notebooks import diff_notebooks
-from nbdime.prettyprint import pretty_print_notebook_diff, PrettyPrintConfig
-from nbdime.args import (
+from .args import (
     add_generic_args, add_diff_args, process_diff_flags, resolve_diff_args,
-    add_diff_cli_args, ConfigBackedParser,
+    add_diff_cli_args, add_prettyprint_args, ConfigBackedParser,
+    prettyprint_config_from_args,
     )
-from nbdime.utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
+from .diffing.notebooks import diff_notebooks
 from .gitfiles import changed_notebooks, is_gitref
+from .prettyprint import pretty_print_notebook_diff
+from .utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 
 
 _description = "Compute the difference between two Jupyter notebooks."
@@ -80,7 +80,7 @@ def _handle_diff(base, remote, output, args):
             def write(self, text):
                 print(text, end="")
         # This sets up what to ignore:
-        config = PrettyPrintConfig(out=Printer(), include=args, color_words=args.color_words)
+        config = prettyprint_config_from_args(args, out=Printer())
         # Separate out filenames:
         base_name = base if isinstance(base, string_types) else base.name
         remote_name = remote if isinstance(remote, string_types) else remote.name
@@ -97,6 +97,7 @@ def _build_arg_parser():
     add_generic_args(parser)
     add_diff_args(parser)
     add_diff_cli_args(parser)
+    add_prettyprint_args(parser)
 
     parser.add_argument(
         "base", help="the base notebook filename OR base git-revision.",

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -73,22 +73,6 @@ def tempfiles(tmpdir, filespath):
     return str(dest)
 
 
-@fixture
-def nocolor(request):
-    """Disable color printing for test"""
-    import nbdime.prettyprint as pp
-    patch = mock.patch.multiple(
-        pp,
-        ADD=pp.ADD.replace(pp.GREEN, ''),
-        REMOVE=pp.REMOVE.replace(pp.RED, ''),
-        INFO=pp.INFO.replace(pp.BLUE, ''),
-        RESET='',
-        git_diff_print_cmd=pp.git_diff_print_cmd.replace(' --color-words', ''),
-    )
-    patch.start()
-    request.addfinalizer(patch.stop)
-
-
 @fixture(scope='session')
 def needs_git():
     if not have_git:

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -206,6 +206,16 @@ def test_nbdiff_app_color_words(filespath):
     assert 0 == main_diff(args)
 
 
+def test_nbdiff_app_no_colors(filespath, capsys):
+    # Simply check that the --color-words argument is accepted, not behavior
+    # Behavior is covered elsewhere
+    afn = os.path.join(filespath, "multilevel-test-base.ipynb")
+    bfn = os.path.join(filespath, "multilevel-test-local.ipynb")
+
+    args = nbdiffapp._build_arg_parser().parse_args([afn, bfn, '--no-color'])
+    assert 0 == main_diff(args)
+
+
 def test_nbmerge_app(tempfiles, capsys, reset_log):
     bfn = os.path.join(tempfiles, "multilevel-test-base.ipynb")
     lfn = os.path.join(tempfiles, "multilevel-test-local.ipynb")
@@ -308,6 +318,16 @@ def test_nbmerge_app_decisions(tempfiles, capsys, caplog, reset_log):
     out = capsys.readouterr()[0]
     assert out == ''
     assert not os.path.exists(ofn)
+
+
+def test_nbmerge_app_no_colors(filespath):
+    # Simply check that the --color-words argument is accepted, not behavior
+    bfn = os.path.join(filespath, "multilevel-test-base.ipynb")
+    lfn = os.path.join(filespath, "multilevel-test-local.ipynb")
+    rfn = os.path.join(filespath, "multilevel-test-remote.ipynb")
+
+    args = nbmergeapp._build_arg_parser().parse_args([bfn, lfn, rfn, '--no-color'])
+    assert 0 == main_merge(args)
 
 
 def test_diffdriver_config(git_repo):

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -185,7 +185,7 @@ expected_helper_filter = """nbdiff {0} {1}
 
 """
 
-def test_git_diff_driver(filespath, capsys, nocolor, needs_git):
+def test_git_diff_driver(filespath, capsys, needs_git):
     # Simulate a call from `git diff` to check basic driver functionality
 
     fn1 = pjoin(filespath, 'foo--1.ipynb')
@@ -195,6 +195,7 @@ def test_git_diff_driver(filespath, capsys, nocolor, needs_git):
 
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff',
+        '--no-color',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
         fn2, 'invalid_mock_checksum', '100644']
@@ -206,7 +207,7 @@ def test_git_diff_driver(filespath, capsys, nocolor, needs_git):
         assert cap_out == expected_output.format(fn1, fn2, t1, t2)
 
 
-def test_git_diff_driver_flags(filespath, capsys, nocolor, needs_git, reset_diff_targets):
+def test_git_diff_driver_flags(filespath, capsys, needs_git, reset_diff_targets):
     # Simulate a call from `git diff` to check basic driver functionality
 
     fn1 = pjoin(filespath, 'foo--1.ipynb')
@@ -216,6 +217,7 @@ def test_git_diff_driver_flags(filespath, capsys, nocolor, needs_git, reset_diff
 
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff', '-s',
+        '--no-color',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
         fn2, 'invalid_mock_checksum', '100644']
@@ -227,7 +229,7 @@ def test_git_diff_driver_flags(filespath, capsys, nocolor, needs_git, reset_diff
         assert cap_out == expected_source_only.format(fn1, fn2, t1, t2)
 
 
-def test_git_diff_driver_ignore_flags(filespath, capsys, nocolor, needs_git, reset_diff_targets):
+def test_git_diff_driver_ignore_flags(filespath, capsys, needs_git, reset_diff_targets):
     # Simulate a call from `git diff` to check basic driver functionality
 
     fn1 = pjoin(filespath, 'foo--1.ipynb')
@@ -236,7 +238,9 @@ def test_git_diff_driver_ignore_flags(filespath, capsys, nocolor, needs_git, res
     t2 = file_timestamp(fn2)
 
     mock_argv = [
-        '/mock/path/git-nbdiffdriver', 'diff', '-O',
+        '/mock/path/git-nbdiffdriver', 'diff',
+        '--no-color',
+        '-O',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
         fn2, 'invalid_mock_checksum', '100644']
@@ -260,7 +264,7 @@ def _config_filter_driver(name, capsys):
         call('git config --local --add filter.%s.smudge "%s smudge"' % (name, base_cmd))
 
 
-def test_git_diff_driver_noop_filter(git_repo, filespath, capsys, nocolor):
+def test_git_diff_driver_noop_filter(git_repo, filespath, capsys):
     _config_filter_driver('noop', capsys)
     fn1 = pjoin(git_repo, 'diff.ipynb')
     fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
@@ -270,6 +274,7 @@ def test_git_diff_driver_noop_filter(git_repo, filespath, capsys, nocolor):
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff',
         '--use-filter',
+        '--no-color',
         '-O',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
@@ -282,7 +287,7 @@ def test_git_diff_driver_noop_filter(git_repo, filespath, capsys, nocolor):
         assert cap_out == expected_no_filter.format(fn1, fn2, t1, t2)
 
 
-def test_git_diff_driver_strip_outputs_filter(git_repo, filespath, capsys, nocolor):
+def test_git_diff_driver_strip_outputs_filter(git_repo, filespath, capsys):
     _config_filter_driver('strip_outputs', capsys)
     fn1 = pjoin(git_repo, 'diff.ipynb')
     fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
@@ -292,6 +297,7 @@ def test_git_diff_driver_strip_outputs_filter(git_repo, filespath, capsys, nocol
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff',
         '--use-filter',
+        '--no-color',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
         fn2, 'invalid_mock_checksum', '100644']
@@ -303,7 +309,7 @@ def test_git_diff_driver_strip_outputs_filter(git_repo, filespath, capsys, nocol
         assert cap_out == expected_strip_output_filter.format(fn1, fn2, t1, t2)
 
 
-def test_git_diff_driver_add_helper_filter(git_repo, filespath, capsys, nocolor):
+def test_git_diff_driver_add_helper_filter(git_repo, filespath, capsys):
     _config_filter_driver('add_helper', capsys)
     fn1 = pjoin(git_repo, 'diff.ipynb')
     fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
@@ -313,6 +319,7 @@ def test_git_diff_driver_add_helper_filter(git_repo, filespath, capsys, nocolor)
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff',
         '--use-filter',
+        '--no-color',
         '-O',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',
@@ -325,7 +332,7 @@ def test_git_diff_driver_add_helper_filter(git_repo, filespath, capsys, nocolor)
         assert cap_out == expected_helper_filter.format(fn1, fn2, t1, t2)
 
 
-def test_git_diff_driver_no_filter_without_flag(git_repo, filespath, capsys, nocolor):
+def test_git_diff_driver_no_filter_without_flag(git_repo, filespath, capsys):
     _config_filter_driver('add_helper', capsys)
     fn1 = pjoin(git_repo, 'diff.ipynb')
     fn2 = pjoin(filespath, 'src-and-output--1.ipynb')
@@ -334,6 +341,7 @@ def test_git_diff_driver_no_filter_without_flag(git_repo, filespath, capsys, noc
 
     mock_argv = [
         '/mock/path/git-nbdiffdriver', 'diff',
+        '--no-color',
         '-O',
         fn1,
         fn1, 'invalid_mock_checksum', '100644',

--- a/nbdime/tests/test_hg_differ.py
+++ b/nbdime/tests/test_hg_differ.py
@@ -67,7 +67,7 @@ expected_source_only = """nbdiff {0} {1}
 """
 
 
-def test_hg_diff_driver(filespath, capsys, nocolor, needs_hg):
+def test_hg_diff_driver(filespath, capsys, needs_hg):
     # Simulate a call from `hg diff` to check basic driver functionality
 
     fn1 = pjoin(filespath, 'foo--1.ipynb')
@@ -77,6 +77,7 @@ def test_hg_diff_driver(filespath, capsys, nocolor, needs_hg):
 
     mock_argv = [
         '/mock/path/hg-nbdiffdriver',
+        '--no-color',
         fn1, fn2]
 
     with mock.patch('sys.argv', mock_argv):
@@ -86,7 +87,7 @@ def test_hg_diff_driver(filespath, capsys, nocolor, needs_hg):
         assert cap_out == expected_output.format(fn1, fn2, t1, t2)
 
 
-def test_hg_diff_driver_flags(filespath, capsys, nocolor, needs_hg, reset_diff_targets):
+def test_hg_diff_driver_flags(filespath, capsys, needs_hg, reset_diff_targets):
     # Simulate a call from `hg diff` to check basic driver functionality
 
     fn1 = pjoin(filespath, 'foo--1.ipynb')
@@ -96,6 +97,7 @@ def test_hg_diff_driver_flags(filespath, capsys, nocolor, needs_hg, reset_diff_t
 
     mock_argv = [
         '/mock/path/hg-nbdiffdriver', '-s',
+        '--no-color',
         fn1, fn2]
 
     with mock.patch('sys.argv', mock_argv):
@@ -105,7 +107,7 @@ def test_hg_diff_driver_flags(filespath, capsys, nocolor, needs_hg, reset_diff_t
         assert cap_out == expected_source_only.format(fn1, fn2, t1, t2)
 
 
-def test_hg_diff_driver_ignore_flags(filespath, capsys, nocolor, needs_hg, reset_diff_targets):
+def test_hg_diff_driver_ignore_flags(filespath, capsys, needs_hg, reset_diff_targets):
     # Simulate a call from `hg diff` to check basic driver functionality
 
     fn1 = pjoin(filespath, 'foo--1.ipynb')
@@ -114,7 +116,9 @@ def test_hg_diff_driver_ignore_flags(filespath, capsys, nocolor, needs_hg, reset
     t2 = file_timestamp(fn2)
 
     mock_argv = [
-        '/mock/path/hg-nbdiffdriver', '-O',
+        '/mock/path/hg-nbdiffdriver',
+        '--no-color',
+        '-O',
         fn1, fn2]
 
     with mock.patch('sys.argv', mock_argv):

--- a/nbdime/tests/test_prettyprint.py
+++ b/nbdime/tests/test_prettyprint.py
@@ -33,8 +33,8 @@ def b64text(nbytes):
     return encodebytes(os.urandom(nbytes)).decode('ascii')
 
 
-def TestConfig():
-    return pp.PrettyPrintConfig(out=StringIO())
+def TestConfig(use_color=True):
+    return pp.PrettyPrintConfig(out=StringIO(), use_color=use_color)
 
 
 def test_pretty_print_dict_complex():
@@ -243,12 +243,12 @@ def test_pretty_print_code_cell():
     ]
 
 
-def test_pretty_print_dict_diff(nocolor):
+def test_pretty_print_dict_diff():
     a = {'a': 1}
     b = {'a': 2}
     di = diff(a, b, path='x/y')
 
-    config = TestConfig()
+    config = TestConfig(use_color=False)
     pp.pretty_print_diff(a, di, 'x/y', config)
     text = config.out.getvalue()
     lines = text.splitlines()
@@ -261,13 +261,13 @@ def test_pretty_print_dict_diff(nocolor):
     ]
 
 
-def test_pretty_print_list_diff(nocolor):
+def test_pretty_print_list_diff():
     a = [1]
     b = [2]
     path = '/a/b'
     di = diff(a, b, path=path)
 
-    config = TestConfig()
+    config = TestConfig(use_color=False)
     pp.pretty_print_diff(a, di, path, config)
     text = config.out.getvalue()
     lines = text.splitlines()
@@ -282,13 +282,13 @@ def test_pretty_print_list_diff(nocolor):
     ]
 
 
-def test_pretty_print_list_multilinestrings(nocolor):
+def test_pretty_print_list_multilinestrings():
     a = ["ac\ndf", "qe\nry", 2]
     b = [2, "abc\ndef", "qwe\nrty"]
     path = '/a/b'
     di = diff(a, b, path=path)
 
-    config = TestConfig()
+    config = TestConfig(use_color=False)
     pp.pretty_print_diff(a, di, path, config)
     text = config.out.getvalue()
     lines = text.splitlines()
@@ -319,30 +319,30 @@ def test_pretty_print_list_multilinestrings(nocolor):
     ]
 
 
-def test_pretty_print_string_diff(nocolor):
+def test_pretty_print_string_diff():
     a = '\n'.join(['line 1', 'line 2', 'line 3', ''])
     b = '\n'.join(['line 1', 'line 3', 'line 4', ''])
     path = '/a/b'
     di = diff(a, b, path=path)
 
     with mock.patch('nbdime.prettyprint.which', lambda cmd: None):
-        config = TestConfig()
+        config = TestConfig(use_color=False)
         pp.pretty_print_diff(a, di, path, config)
         text = config.out.getvalue()
         lines = text.splitlines()
 
     text = '\n'.join(lines)
-    assert ('< line 2' in text) or ((pp.REMOVE + 'line 2' + pp.RESET) in text)
-    assert ('> line 4' in text) or ((pp.ADD + 'line 4' + pp.RESET) in text)
+    assert ('< line 2' in text) or ((config.REMOVE + 'line 2' + config.RESET) in text)
+    assert ('> line 4' in text) or ((config.ADD + 'line 4' + config.RESET) in text)
 
 
-def test_pretty_print_string_diff_b64(nocolor):
+def test_pretty_print_string_diff_b64():
     a = b64text(1024)
     b = b64text( 800)
     path = '/a/b'
     di = diff(a, b, path=path)
 
-    config = TestConfig()
+    config = TestConfig(use_color=False)
     pp.pretty_print_diff(a, di, path, config)
     text = config.out.getvalue()
     lines = text.splitlines()

--- a/nbdime/vcs/git/diffdriver.py
+++ b/nbdime/vcs/git/diffdriver.py
@@ -26,6 +26,7 @@ from subprocess import check_call, CalledProcessError
 from nbdime.args import (
     add_git_config_subcommand, add_generic_args, add_diff_args, add_web_args,
     add_git_diff_driver_args, add_diff_cli_args, ConfigBackedParser,
+    add_prettyprint_args
     )
 from nbdime.utils import locate_gitattributes, ensure_dir_exists, setup_std_streams
 from .filter_integration import apply_possible_filter
@@ -86,6 +87,7 @@ def _build_arg_parser():
     add_git_diff_driver_args(diff_parser)
     add_diff_args(diff_parser)
     add_diff_cli_args(diff_parser)
+    add_prettyprint_args(diff_parser)
 
     webdiff_parser = subparsers.add_parser('webdiff',
         description="The actual entrypoint for the webdiff tool. Git will call this."

--- a/nbdime/vcs/hg/diff.py
+++ b/nbdime/vcs/hg/diff.py
@@ -15,11 +15,11 @@ import os
 import sys
 
 from nbdime import nbdiffapp
-from nbdime.diffing.directorydiff import diff_directories
 from nbdime.args import (
-    add_diff_args, add_filename_args, diff_exclusives, process_exclusive_ignorables,
-    add_diff_cli_args, ConfigBackedParser,
+    add_diff_args, add_filename_args, add_diff_cli_args, add_prettyprint_args,
+    ConfigBackedParser,
 )
+from nbdime.diffing.directorydiff import diff_directories
 
 
 def main(args=None):
@@ -32,6 +32,7 @@ def main(args=None):
 
     add_diff_args(parser)
     add_diff_cli_args(parser)
+    add_prettyprint_args(parser)
     add_filename_args(parser, ('base', 'remote'))
 
     opts = parser.parse_args(args)


### PR DESCRIPTION
Expose the following options for configuring the prettyprint module:
- `--no-color`: Do not use ANSI color codes in the output.
- `--no-git`: Do not call out to `git` to format text diffs/conflicts.
- `--no-use-diff`: Do not call out to `diff`/`diff3` to format text diffs/conflicts.

Fixes #426.