### PR TITLE
 Make nbmerge base argument optional

### DIFF
--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -428,21 +428,23 @@ def add_merge_args(parser):
              "execution counts in order to resolve conflicts.")
 
 
+filename_help = {
+    "notebook": "The notebook filename.",
+    "base":   "The base notebook filename.",
+    "local":  "The local modified notebook filename.",
+    "remote": "The remote modified notebook filename.",
+    "merged": "The merge result notebook filename.",
+    "patch":  "The patch filename, output from nbdiff.",
+    }
+
+
 def add_filename_args(parser, names):
     """Add the base, local, remote, and merged positional arguments.
 
     Helps getting consistent doc strings.
     """
-    helps = {
-        "notebook": "The notebook filename.",
-        "base":   "The base notebook filename.",
-        "local":  "The local modified notebook filename.",
-        "remote": "The remote modified notebook filename.",
-        "merged": "The merge result notebook filename.",
-        "patch":  "The patch filename, output from nbdiff.",
-        }
     for name in names:
-        parser.add_argument(name, help=helps[name])
+        parser.add_argument(name, help=filename_help[name])
 
 
 def add_prettyprint_args(parser):

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -19,7 +19,8 @@ from .prettyprint import pretty_print_merge_decisions
 from .utils import EXPLICIT_MISSING_FILE, read_notebook, setup_std_streams
 
 _description = ('Merge two Jupyter notebooks "local" and "remote" with a '
-                'common ancestor "base".')
+                'common ancestor "base". If base is left out, it uses an '
+                'empty notebook as the base.')
 
 
 def main_merge(args):
@@ -107,14 +108,17 @@ def _build_arg_parser():
         add_help=True,
         )
     from .args import (
-        add_generic_args, add_diff_args, add_merge_args, add_filename_args,
-        add_prettyprint_args
+        add_generic_args, add_diff_args, add_merge_args, filename_help,
+        add_filename_args, add_prettyprint_args
     )
     add_generic_args(parser)
     add_diff_args(parser)
     add_merge_args(parser)
     add_prettyprint_args(parser)
-    add_filename_args(parser, ["base", "local", "remote"])
+
+    parser.add_argument("base", help=filename_help['base'],
+        nargs='?', default=EXPLICIT_MISSING_FILE)
+    add_filename_args(parser, ['local', 'remote'])
 
     parser.add_argument(
         '--out',


### PR DESCRIPTION
Now, if the 'base' argument is not supplied, it uses the null file as the default. This translates to an empty, minimal notebook  (`read_notebook(bfn, on_null='minimal')`).

Partially resolves #436.