### PR TITLE
Old git = no git-filter support

### DIFF
--- a/nbdime/vcs/git/filter_integration.py
+++ b/nbdime/vcs/git/filter_integration.py
@@ -21,7 +21,12 @@ def interrogate_filter(path):
         spec = check_output(['git', 'check-attr', '-z', 'filter', path])
     except CalledProcessError:
         return None
-    path_list, attr, info = [s.decode('utf8', 'replace') for s in spec.split(b'\x00')[:3]]
+    try:
+        path_list, attr, info = [s.decode('utf8', 'replace') for s in spec.split(b'\x00')[:3]]
+    except ValueError:
+        # For older versions of git, the `-z` flag is unsupported
+        # This will then raise a ValueError when trying to unpack
+        return None
     if attr != 'filter' or path != path_list:
         raise ValueError(
             'Unexpected output from git check-attr. ' +


### PR DESCRIPTION
When using an older git version, we cannot support git-filter integration (unless someone else wants to contribute code to reliably parse previous output). With this change, we prevent nbdime from falling over completely when it encounters a version of git without support for the `-z` flag to `git check-attr`.

Fixes #440.
Fixes #417.