### PR TITLE
Ensure app widget is updated on cell unhide

### DIFF
--- a/packages/webapp/src/app/common.ts
+++ b/packages/webapp/src/app/common.ts
@@ -9,6 +9,10 @@ import {
 } from '@jupyterlab/coreutils/lib/url';
 
 import {
+  Widget
+} from '@phosphor/widgets';
+
+import {
   NotifyUserError
 } from 'nbdime/lib/common/exceptions';
 
@@ -126,7 +130,7 @@ function toggleSpinner(state?: boolean) {
  * This simply marks with a class, real work is done by CSS.
  */
 export
-function toggleShowUnchanged(show?: boolean) {
+function toggleShowUnchanged(show?: boolean, updateWidget?: Widget | null) {
   let root = document.getElementById('nbdime-root')!;
   let hiding = root.classList.contains(HIDE_UNCHANGED_CLASS);
   if (show === undefined) {
@@ -137,6 +141,9 @@ function toggleShowUnchanged(show?: boolean) {
   }
   if (show) {
     root.classList.remove(HIDE_UNCHANGED_CLASS);
+    if (updateWidget) {
+      updateWidget.update();
+    }
   } else {
     markUnchangedRanges();
     root.classList.add(HIDE_UNCHANGED_CLASS);

--- a/packages/webapp/src/app/diff.ts
+++ b/packages/webapp/src/app/diff.ts
@@ -258,7 +258,7 @@ function initializeDiff() {
   let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
   hideUnchangedChk.checked = getConfigOption('hideUnchanged', true);
   hideUnchangedChk.onchange = () => {
-    toggleShowUnchanged(!hideUnchangedChk.checked);
+    toggleShowUnchanged(!hideUnchangedChk.checked, diffWidget);
   };
 
   let trustBtn = document.getElementById('nbdime-trust') as HTMLButtonElement;

--- a/packages/webapp/src/app/merge.ts
+++ b/packages/webapp/src/app/merge.ts
@@ -410,6 +410,6 @@ function initializeMerge() {
   let hideUnchangedChk = document.getElementById('nbdime-hide-unchanged') as HTMLInputElement;
   hideUnchangedChk.checked = getConfigOption('hideUnchanged', true);
   hideUnchangedChk.onchange = () => {
-    toggleShowUnchanged(!hideUnchangedChk.checked);
+    toggleShowUnchanged(!hideUnchangedChk.checked, mergeWidget);
   };
 }


### PR DESCRIPTION
Fixes an issue where initially hidden cells (unchanged) had a completely collapsed codemirror editor on unhide. The CM editor fails its initial size calculations if the cell is hidden, so it needs to be given the chance when it becomes visible. Most likely, it would be sufficient to call this on the first show, but for now we update on all shows.