### PR TITLE
add Path type for path arguments

### DIFF
--- a/nbdime/nbdiffapp.py
+++ b/nbdime/nbdiffapp.py
@@ -16,6 +16,7 @@ from .args import (
     add_generic_args, add_diff_args, process_diff_flags, resolve_diff_args,
     add_diff_cli_args, add_prettyprint_args, ConfigBackedParser,
     prettyprint_config_from_args,
+    Path,
     )
 from .diffing.notebooks import diff_notebooks
 from .gitfiles import changed_notebooks, is_gitref
@@ -101,19 +102,23 @@ def _build_arg_parser():
 
     parser.add_argument(
         "base", help="the base notebook filename OR base git-revision.",
+        type=Path,
         nargs='?', default='HEAD',
     )
     parser.add_argument(
         "remote", help="the remote modified notebook filename OR remote git-revision.",
+        type=Path,
         nargs='?', default=None,
     )
     parser.add_argument(
         "paths", help="filter diffs for git-revisions based on path",
+        type=Path,
         nargs='*', default=None,
     )
 
     parser.add_argument(
         '--out',
+        type=Path,
         default=None,
         help="if supplied, the diff is written to this file. "
              "Otherwise it is printed to the terminal.")

--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -12,7 +12,7 @@ import sys
 
 import nbformat
 
-from .args import ConfigBackedParser, prettyprint_config_from_args
+from .args import ConfigBackedParser, Path, prettyprint_config_from_args
 from .log import logger
 from .merging import merge_notebooks
 from .prettyprint import pretty_print_merge_decisions
@@ -116,13 +116,18 @@ def _build_arg_parser():
     add_merge_args(parser)
     add_prettyprint_args(parser)
 
-    parser.add_argument("base", help=filename_help['base'],
-        nargs='?', default=EXPLICIT_MISSING_FILE)
+    parser.add_argument(
+        "base",
+        type=Path,
+        help=filename_help['base'],
+        nargs='?',
+        default=EXPLICIT_MISSING_FILE)
     add_filename_args(parser, ['local', 'remote'])
 
     parser.add_argument(
         '--out',
         default=None,
+        type=Path,
         help="if supplied, the merged notebook is written "
              "to this file. Otherwise it is printed to the "
              "terminal.")

--- a/nbdime/vcs/git/difftool.py
+++ b/nbdime/vcs/git/difftool.py
@@ -17,7 +17,8 @@ import sys
 from subprocess import check_call, check_output, CalledProcessError
 
 from nbdime.args import (
-    add_generic_args, add_git_config_subcommand, add_filter_args, ConfigBackedParser
+    add_generic_args, add_git_config_subcommand, add_filter_args, ConfigBackedParser,
+    Path,
 )
 from nbdime.webapp import nbdifftool
 from .filter_integration import apply_possible_filter
@@ -85,7 +86,7 @@ def main(args=None):
     )
     add_filter_args(diff_parser)
     nbdifftool.build_arg_parser(diff_parser)
-    diff_parser.add_argument('path')
+    diff_parser.add_argument('path', type=Path)
 
     config = add_git_config_subcommand(subparsers,
         enable, disable,

--- a/nbdime/webapp/nbmergeweb.py
+++ b/nbdime/webapp/nbmergeweb.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 from ..args import (add_generic_args, add_diff_args, add_merge_args,
     add_web_args, add_filename_args, args_for_server, args_for_browse,
-    process_diff_flags)
+    process_diff_flags, Path)
 from .nbdimeserver import main_server as run_server
 from .webutil import browse
 
@@ -31,6 +31,7 @@ def build_arg_parser():
     add_filename_args(parser, ["base", "local", "remote"])
     parser.add_argument(
         '--out',
+        type=Path,
         default=None,
         help="if supplied, the merged notebook is written "
              "to this file. Otherwise it cannot be saved.")


### PR DESCRIPTION
no-op on Python 3, casts bytes to text with sys.getfilesystemencoding on Python 2

ascii encoding is not respected, instead assuming the much more likely utf8 encoding if ascii is returned. If ascii is indeed correct, the behavior is the same anyway.

closes #452