### PR TITLE
set allow_remote_access when listening on non-localhost ip

### DIFF
--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -336,8 +336,8 @@ def make_app(**params):
         'base_url': base_url,
         'jinja2_env': env,
         'mathjax_url': prefix + '/nb-static/mathjax/MathJax.js',
-        'local_hostnames': ['localhost', '127.0.0.1']
-        }
+        'local_hostnames': ['localhost', '127.0.0.1'],
+    }
 
     if is_in_repo(nbdime_root):
         # don't cache when working from repo
@@ -359,6 +359,9 @@ def init_app(on_port=None, closable=False, **params):
     port = params.pop('port', 0)
     ip = params.pop('ip', '127.0.0.1')
     app = make_app(**params)
+    if ip not in {'127.0.0.1', 'localhost', '::1'}:
+        # enable remote access when listening on a public ip
+        app.settings['allow_remote_access'] = True
     if port != 0:
         server = app.listen(port, address=ip)
         _logger.info('Listening on %s, port %d', ip, port)


### PR DESCRIPTION
otherwise the notebook handlers block access as a CORS / DNS-rebinding protection

closes #455