### PR TITLE
change the order of if statements so that missing is checked first

### DIFF
--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -93,10 +93,10 @@ class NbdimeHandler(IPythonHandler):
                     r = requests.get(arg)
 
             # Let nbformat do the reading and validation
-            if os.path.exists(path):
-                nb = nbformat.read(path, as_version=4)
-            elif path == EXPLICIT_MISSING_FILE:
+            if path == EXPLICIT_MISSING_FILE:
                 nb = nbformat.v4.new_notebook()
+            elif os.path.exists(path):
+                nb = nbformat.read(path, as_version=4)
             else:
                 nb = nbformat.reads(r.text, as_version=4)
         except Exception as e:


### PR DESCRIPTION
Found running this in a container in linux, if `/dev/null` exists on the os then it will try to read from it and tip over. 