### PR TITLE
provide user with detail from failed http requests

### DIFF
--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -100,10 +100,13 @@ class NbdimeHandler(IPythonHandler):
                 nb = nbformat.read(path, as_version=4)
             else:
                 nb = nbformat.reads(r.text, as_version=4)
-        except (ValueError, nbformat.reader.NotJSONError) as e:
+        except requests.exceptions.HTTPError as e:
+            self.log.exception(e)
+            raise web.HTTPError(422, 'Invalid notebook: %s, received http error: %s' % (arg, string(e)))
+        except Exception as e:
             self.log.exception(e)
             raise web.HTTPError(422, 'Invalid notebook: %s' % arg)
-
+    
         return nb
 
     def get_notebook_argument(self, argname):

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -91,6 +91,7 @@ class NbdimeHandler(IPythonHandler):
                         raise ValueError('Supplied argument cannot be read: %r' % arg)
                     # Assume file is URI
                     r = requests.get(arg)
+                    r.raise_for_status()
 
             # Let nbformat do the reading and validation
             if path == EXPLICIT_MISSING_FILE:
@@ -99,7 +100,7 @@ class NbdimeHandler(IPythonHandler):
                 nb = nbformat.read(path, as_version=4)
             else:
                 nb = nbformat.reads(r.text, as_version=4)
-        except Exception as e:
+        except (ValueError, nbformat.reader.NotJSONError) as e:
             self.log.exception(e)
             raise web.HTTPError(422, 'Invalid notebook: %s' % arg)
 


### PR DESCRIPTION
This avoids the application relabelling potential HTTP errors as 422 unprocessable entity.

It does however mean any exceptions other than ValueError and NotJSONError cause crashes which might not be desirable (though I couldn't see any other types of exception would likely come up?)