### PR TITLE
Add a `/gitdiff` API 

### DIFF
--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -126,7 +126,7 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
     return EXPLICIT_MISSING_FILE
 
 
-def changed_notebooks(ref_base, ref_remote, paths=None, repo_dir=None):
+def changed_notebooks(ref_base, ref_remote='WORKING', paths=None, repo_dir=None):
     """Iterator over all notebooks in path that has changed between the two git refs
 
     References are all valid values according to git-rev-parse. If ref_remote
@@ -144,9 +144,13 @@ def changed_notebooks(ref_base, ref_remote, paths=None, repo_dir=None):
         paths = [os.path.join(*(popped + (p,))) for p in paths]
     # Get tree for base:
     tree_base = repo.commit(ref_base).tree
-    if ref_remote is None:
-        # Diff tree against working copy:
+    if ref_remote == 'WORKING' :
+        # If a None value is provided, GitPython diffs against the Working Tree 
+        # https://gitpython.readthedocs.io/en/stable/reference.html#module-git.diff
         diff = tree_base.diff(None, paths)
+    elif ref_remote == 'INDEX':
+        # If no value is provided, GitPython diffs against the Index
+        diff = tree_base.diff(paths=paths)
     else:
         # Get remote tree and diff against base:
         tree_remote = repo.commit(ref_remote).tree

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -151,10 +151,6 @@ def changed_notebooks(ref_base, ref_remote, paths=None, repo_dir=None):
         # All paths need to be prepended by popped
         paths = [os.path.join(*(popped + (p,))) for p in paths]
 
-    if ref_remote is None:
-        # Default case for backwards compatibility
-        ref_remote = GitRefWorkingTree
-
     # Get tree/index for base
     if ref_base == GitRefIndex:
         tree_base = repo.index

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -104,7 +104,8 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
     """Get a stream to the notebook, for a given diff entry's path and blob
 
     Returns None if path is not a Notebook file, and EXPLICIT_MISSING_FILE
-    if path is missing, or the blob is None.
+    if path is missing, or the blob is None (unless diffing against working
+    tree).
     """
     if path:
         if not path.endswith('.ipynb'):
@@ -124,8 +125,8 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
                 except IOError:
                     return EXPLICIT_MISSING_FILE
         elif blob is None:
-            # GitPython uses a None blob to indicate if a file was deleted or added.
-            # https://gitpython.readthedocs.io/en/stable/reference.html#git.diff.Diff
+            # GitPython uses a None blob to indicate if a file was deleted or
+            # added. Workaround for GitPython issue #749.
             return EXPLICIT_MISSING_FILE
         else:
             # There were strange issues with passing blob data_streams around,

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -113,13 +113,12 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
         if ref_name is GitRefWorkingTree:
             # Diffing against working copy, use file on disk!
             with pushd(repo_dir):
-                # Ensure we filter if appropriate:
-                if ref_name is None:
-                    # We are diffing against working dir, so remote is candidate
-                    ret = apply_possible_filter(path)
-                    # ret == path means no filter was applied
-                    if ret != path:
-                        return ret
+                # We are diffing against working dir, so ensure we apply
+                # any git filters before comparing:
+                ret = apply_possible_filter(path)
+                # ret == path means no filter was applied
+                if ret != path:
+                    return ret
                 try:
                     return io.open(path, encoding='utf-8')
                 except IOError:
@@ -134,7 +133,10 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
             # The penalty should be low as long as changed_notebooks are used
             # properly as an iterator.
             f = BlobWrapper(blob.data_stream.read().decode('utf-8'))
-            f.name = '%s (%s)' % (path, ref_name)
+            f.name = '%s (%s)' % (
+                path,
+                ref_name if ref_name != GitRefIndex else '<INDEX>'
+            )
             return f
     return EXPLICIT_MISSING_FILE
 

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -129,8 +129,11 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
 def changed_notebooks(ref_base, ref_remote, paths=None, repo_dir=None):
     """Iterator over all notebooks in path that has changed between the two git refs
 
-    References are all valid values according to git-rev-parse. If ref_remote
-    is None, the difference is taken between ref_base and the working directory.
+    References are all valid values according to git-rev-parse. 
+    
+    - If ref_remote is None or WORKING, the difference is taken between ref_base and the working directory.
+    - If ref_remote is INDEX, the difference is taken between ref_base and the index.
+
     Iterator value is a base/remote pair of streams to Notebooks
     (or possibly EXPLICIT_MISSING_FILE for added/removed files).
     """

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
-import os
 import io
+import os
 from collections import deque
 
 from six import string_types
@@ -104,11 +104,12 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
     """Get a stream to the notebook, for a given diff entry's path and blob
 
     Returns None if path is not a Notebook file, and EXPLICIT_MISSING_FILE
-    if path is missing."""
+    if path is missing, or the blob is None.
+    """
     if path:
         if not path.endswith('.ipynb'):
             return None
-        if blob is None:
+        if ref_name is GitRefWorkingTree:
             # Diffing against working copy, use file on disk!
             with pushd(repo_dir):
                 # Ensure we filter if appropriate:
@@ -122,6 +123,10 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
                     return io.open(path, encoding='utf-8')
                 except IOError:
                     return EXPLICIT_MISSING_FILE
+        elif blob is None:
+            # GitPython uses a None blob to indicate if a file was deleted or added.
+            # https://gitpython.readthedocs.io/en/stable/reference.html#git.diff.Diff
+            return EXPLICIT_MISSING_FILE
         else:
             # There were strange issues with passing blob data_streams around,
             # so we solve this by reading into a StringIO buffer.

--- a/nbdime/gitfiles.py
+++ b/nbdime/gitfiles.py
@@ -126,7 +126,7 @@ def _get_diff_entry_stream(path, blob, ref_name, repo_dir):
     return EXPLICIT_MISSING_FILE
 
 
-def changed_notebooks(ref_base, ref_remote='WORKING', paths=None, repo_dir=None):
+def changed_notebooks(ref_base, ref_remote, paths=None, repo_dir=None):
     """Iterator over all notebooks in path that has changed between the two git refs
 
     References are all valid values according to git-rev-parse. If ref_remote
@@ -144,7 +144,7 @@ def changed_notebooks(ref_base, ref_remote='WORKING', paths=None, repo_dir=None)
         paths = [os.path.join(*(popped + (p,))) for p in paths]
     # Get tree for base:
     tree_base = repo.commit(ref_base).tree
-    if ref_remote == 'WORKING' :
+    if (not ref_remote) or ref_remote == 'WORKING' :
         # If a None value is provided, GitPython diffs against the Working Tree 
         # https://gitpython.readthedocs.io/en/stable/reference.html#module-git.diff
         diff = tree_base.diff(None, paths)

--- a/nbdime/tests/test_server_extension.py
+++ b/nbdime/tests/test_server_extension.py
@@ -96,26 +96,44 @@ def test_diff_api(git_repo2, server_extension_app):
     assert data['diff']
     assert len(data.keys()) == 2
 
-@pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
-def test_git_diff_api(git_repo2, server_extension_app):
+@pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT*6)
+def test_git_diff_api(git_repo2, server_extension_app, filespath):
     local_path = os.path.relpath(git_repo2, server_extension_app['path'])
     url = 'http://127.0.0.1:%i/nbdime/api/gitdiff' % server_extension_app['port']
-    r = requests.post(
-        url, headers=auth_header,
-        data=json.dumps({
-            'ref_prev': {
-                'git': 'HEAD'
-            },
-            'ref_curr': {
-                'special': 'WORKING'
-            },
-            'file_path': pjoin(local_path, 'diff.ipynb')
-        }))
-    r.raise_for_status()
-    data = r.json()
-    nbformat.validate(data['base'])
-    assert data['diff']
-    assert len(data.keys()) == 2
+
+    # Add a difference betweeen index and working tree:
+    shutil.copy(
+        pjoin(filespath, 'foo--1.ipynb'),
+        pjoin(git_repo2, 'sub', 'subfile.ipynb')
+    )
+
+    def _make_ref(key):
+        if key.lower() in ('working', 'index'):
+            return {'special': key}
+        return {'git': key}
+
+    # Test various diffs:
+    for args in (
+        ('HEAD', 'WORKING', 'diff.ipynb'),
+        ('HEAD', 'INDEX', 'diff.ipynb'),
+        ('INDEX', 'HEAD', 'diff.ipynb'),
+        ('INDEX', 'WORKING', 'sub/subfile.ipynb'),
+        ('index', 'working', 'sub/subfile.ipynb'),
+        ('iNdeX', 'WorKING', 'sub/subfile.ipynb'),
+    ):
+        print(args)
+        r = requests.post(
+            url, headers=auth_header,
+            data=json.dumps({
+                'ref_local': _make_ref(args[0]),
+                'ref_remote': _make_ref(args[1]),
+                'file_path': pjoin(local_path, args[2])
+            }))
+        r.raise_for_status()
+        data = r.json()
+        nbformat.validate(data['base'])
+        assert data['diff']
+        assert len(data.keys()) == 2
 
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)

--- a/nbdime/tests/test_server_extension.py
+++ b/nbdime/tests/test_server_extension.py
@@ -96,6 +96,27 @@ def test_diff_api(git_repo2, server_extension_app):
     assert data['diff']
     assert len(data.keys()) == 2
 
+@pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
+def test_git_diff_api(git_repo2, server_extension_app):
+    local_path = os.path.relpath(git_repo2, server_extension_app['path'])
+    url = 'http://127.0.0.1:%i/nbdime/api/gitdiff' % server_extension_app['port']
+    r = requests.post(
+        url, headers=auth_header,
+        data=json.dumps({
+            'ref_prev': {
+                'git': 'HEAD'
+            },
+            'ref_curr': {
+                'special': 'WORKING'
+            },
+            'file_path': pjoin(local_path, 'diff.ipynb')
+        }))
+    r.raise_for_status()
+    data = r.json()
+    nbformat.validate(data['base'])
+    assert data['diff']
+    assert len(data.keys()) == 2
+
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
 def test_diff_api_checkpoint(tmpdir, filespath, server_extension_app):

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -123,6 +123,13 @@ class BaseGitDiffHandler(ApiDiffHandler):
 
         return base_nb, remote_nb
 
+    @property
+    def curdir(self):
+        root_dir = getattr(self.contents_manager, 'root_dir', None)
+        if root_dir is None:
+            return super(ExtensionApiDiffHandler, self).curdir
+        return root_dir
+
 
 class ExtensionApiDiffHandler(BaseGitDiffHandler):
     """Diff API handler that also handles diff to git HEAD"""
@@ -181,13 +188,6 @@ class ExtensionApiDiffHandler(BaseGitDiffHandler):
             'diff': thediff,
             }
         self.finish(data)
-
-    @property
-    def curdir(self):
-        root_dir = getattr(self.contents_manager, 'root_dir', None)
-        if root_dir is None:
-            return super(ExtensionApiDiffHandler, self).curdir
-        return root_dir
 
 
 class GitDiffHandler(BaseGitDiffHandler):
@@ -271,13 +271,6 @@ class GitDiffHandler(BaseGitDiffHandler):
             self.log.exception('Error diffing documents:')
             raise HTTPError(500, 'Error while attempting to diff documents')
 
-
-    @property
-    def curdir(self):
-        root_dir = getattr(self.contents_manager, 'root_dir', None)
-        if root_dir is None:
-            return super(ExtensionApiDiffHandler, self).curdir
-        return root_dir
 
 class IsGitHandler(NbdimeHandler, APIHandler):
     """API handler for querying if path is in git repo"""

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -146,8 +146,8 @@ class GitDiffHandler(ApiDiffHandler):
             ref_curr = body['ref_curr']
             file_name = body['file_name']
         except KeyError:
-            self.log.exception('Required keys not provided in input')
-            raise HTTPError(400, 'Required inputs ref_prev, ref_curr, file_name not provided inputs')
+            self.log.exception('Required keys ref_prev, ref_curr, file_name not provided in the request')
+            raise HTTPError(400, 'Required keys ref_prev, ref_curr, file_name not provided in the request')
 
         base_nb, remote_nb = self.get_git_notebooks(file_name, ref_prev, ref_curr)
 

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -11,7 +11,7 @@ from jinja2 import ChoiceLoader, FileSystemLoader
 from notebook.utils import url_path_join, to_os_path
 from notebook.services.contents.checkpoints import GenericCheckpointsMixin
 from notebook.services.contents.filecheckpoints import FileCheckpoints
-from tornado.web import HTTPError, escape, authenticated, gen, MissingArgumentError
+from tornado.web import HTTPError, escape, authenticated, gen
 
 from ..args import process_diff_flags
 from ..config import build_config, Namespace

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -78,11 +78,11 @@ class CheckpointDifftoolHandler(NbdimeHandler):
 
 class BaseGitDiffHandler(ApiDiffHandler):
 
-    def get_git_notebooks(self, file_path, ref_base='HEAD', ref_remote=None):
+    def get_git_notebooks(self, file_path_arg, ref_base='HEAD', ref_remote=None):
         """
         Gets the content of the before and after state of the notebook based on the given Git refs.
 
-        :param file_path: The path to the file being diffed
+        :param file_path_arg: The path to the file being diffed
         :param ref_base: the Git ref for the "local" or the "previous" state
         :param ref_remote: the Git ref for the "remote" or the "current" state
         :return: (base_nb, remote_nb)
@@ -90,7 +90,7 @@ class BaseGitDiffHandler(ApiDiffHandler):
         # Sometimes the root dir of the files is not cwd
         nb_root = getattr(self.contents_manager, 'root_dir', None)
         # Resolve base argument to a file system path
-        file_path = os.path.realpath(to_os_path(file_path, nb_root))
+        file_path = os.path.realpath(to_os_path(file_path_arg, nb_root))
 
         # Ensure path/root_dir that can be sent to git:
         try:
@@ -114,7 +114,7 @@ class BaseGitDiffHandler(ApiDiffHandler):
                 remote_nb = base_nb
         except (InvalidGitRepositoryError, BadName) as e:
             self.log.exception(e)
-            raise HTTPError(422, 'Invalid notebook: %s' % file_path)
+            raise HTTPError(422, 'Invalid notebook: %s' % file_path_arg)
         except GitCommandNotFound as e:
             self.log.exception(e)
             raise HTTPError(

--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -227,7 +227,7 @@ class GitDiffHandler(BaseGitDiffHandler):
                         _fail('Only "index" is allowed for the "special" value '
                               'on ref_local, got %r.' % (special,))
                 elif special not in ('index', 'working'):
-                    _fail('Only "index" or "working is allowed for the "special" value '
+                    _fail('Only "index" or "working" is allowed for the "special" value '
                           'on ref_remote, got %r.' % (special,))
 
 

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -237,6 +237,16 @@ class ApiDiffHandler(NbdimeHandler, APIHandler):
         return super(ApiDiffHandler, self).get_notebook_argument(argname)
 
     def get_git_notebooks(self, input_file_path, ref_base='HEAD', ref_remote=None, special_remote=None):
+        """
+        Gets the content of the before and after state of the notebook based on the given Git refs.
+
+        :param input_file_path: The path to the file being diff'd
+        :param ref_base: the Git ref for the "base" or the "previous" state
+        :param ref_remote: the Git ref for the "remote" or the "current" state
+        :param special_remote: the Special ref for the "base" or the "current" state.
+                This is denoted separately to avoid conflicts with real Git refs with the same name.
+        :return: (base_nb, remote_nb)
+        """
         # Sometimes the root dir of the files is not cwd
         nb_root = getattr(self.contents_manager, 'root_dir', None)
         # Resolve base argument to a file system path

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -15,19 +15,21 @@ from jinja2 import FileSystemLoader, Environment
 import nbformat
 from notebook.base.handlers import IPythonHandler, APIHandler
 from notebook import DEFAULT_STATIC_FILES_PATH
-from notebook.utils import url_path_join
+from notebook.utils import url_path_join, to_os_path
 from notebook.log import log_request
 import requests
 from six import string_types
 from tornado import ioloop, web, escape, netutil, httpserver
+from tornado.web import HTTPError, escape, authenticated, gen
 
 from .. import __file__ as nbdime_root
 from ..args import add_generic_args, add_web_args
 from ..diffing.notebooks import diff_notebooks
+from ..gitfiles import find_repo_root, InvalidGitRepositoryError, BadName, GitCommandNotFound, changed_notebooks
 from ..log import logger
 from ..merging.notebooks import decide_notebook_merge
 from ..nbmergeapp import _build_arg_parser as build_merge_parser
-from ..utils import EXPLICIT_MISSING_FILE, is_in_repo
+from ..utils import EXPLICIT_MISSING_FILE, is_in_repo, read_notebook
 
 
 # TODO: See <notebook>/notebook/services/contents/handlers.py for possibly useful utilities:
@@ -233,6 +235,43 @@ class ApiDiffHandler(NbdimeHandler, APIHandler):
                 return nbformat.read(arg, as_version=4)
             return self.read_notebook(arg)
         return super(ApiDiffHandler, self).get_notebook_argument(argname)
+
+    def get_git_notebooks(self, file_name, ref_base='HEAD', ref_remote=None):
+        # Sometimes the root dir of the files is not cwd
+        nb_root = getattr(self.contents_manager, 'root_dir', None)
+        # Resolve base argument to a file system path
+        file_path = os.path.realpath(to_os_path(file_name, nb_root))
+
+        # Ensure path/root_dir that can be sent to git:
+        try:
+            git_root = find_repo_root(file_path)
+        except InvalidGitRepositoryError as e:
+            self.log.exception(e)
+            raise HTTPError(422, 'Invalid notebook: %s' % file_path)
+        file_path = os.path.relpath(file_path, git_root)
+
+        # Get the base/remote notebooks:
+        try:
+            for fbase, fremote in changed_notebooks(ref_base, ref_remote, file_path, git_root):
+                base_nb = read_notebook(fbase, on_null='minimal')
+                remote_nb = read_notebook(fremote, on_null='minimal')
+                break  # there should only ever be one set of files
+            else:
+                # The filename was either invalid or the file is unchanged
+                # Assume unchanged, and let read_notebook handle error
+                # reporting if invalid
+                base_nb = self.read_notebook(os.path.join(git_root, file_path))
+                remote_nb = base_nb
+        except (InvalidGitRepositoryError, BadName) as e:
+            self.log.exception(e)
+            raise HTTPError(422, 'Invalid notebook: %s' % file_name)
+        except GitCommandNotFound as e:
+            self.log.exception(e)
+            raise HTTPError(
+                500, 'Could not find git executable. '
+                     'Please ensure git is available to the server process.')
+
+        return base_nb, remote_nb
 
 
 class ApiMergeHandler(NbdimeHandler, APIHandler):


### PR DESCRIPTION
#### Overview
This change adds a server endpoint to diff two git refs for a single file. This is flexible to perform diffs across various points in the Git lifecycle such as diff'ing changes in the Working Tree, Index, or two arbitrary commits. There are two reserved refs WORKING and INDEX to designate the Working Tree and the git Index


A separate API was added to avoid using the "git:" prefix to designate git diffs and add many optional parameters in the existing `/api/diff`. This is backwards compatible, the existing `/api/diff` will work as expected.

Addresses #480 

```
curl -X POST \
  http://localhost:8888/nbdime/api/diff \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{
    "base": "git:Untitled1.ipynb"
}'
```


#### Other details

* Submitting early to get feedback. I'll add tests if the overall approach looks fine

#### Testing scenarios
Various cases for the `git diff` API


(Diff all changes in Working Tree)
```
curl -X POST \
  http://localhost:8888/nbdime/api/gitdiff \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{
	"ref_prev": "HEAD",
	"ref_curr": "WORKING",
	"file_name": "Untitled1.ipynb"
}'
```

(Diff all changes in staging)
```
curl -X POST \
  http://localhost:8888/nbdime/api/gitdiff \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{
	"ref_prev": "HEAD",
	"ref_curr": "INDEX",
	"file_name": "Untitled1.ipynb"
}'
```

(Diff changes between to Git refs in the local or remote history)

```
curl -X POST \
  http://localhost:8888/nbdime/api/gitdiff \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{
	"ref_prev": "origin/HEAD",
	"ref_curr": "HEAD",
	"file_name": "Untitled1.ipynb"
}'
```
