### PR TITLE
Honour absolute paths during git diffs

### DIFF
--- a/nbdime/webapp/nb_server_extension.py
+++ b/nbdime/webapp/nb_server_extension.py
@@ -87,10 +87,14 @@ class BaseGitDiffHandler(ApiDiffHandler):
         :param ref_remote: the Git ref for the "remote" or the "current" state
         :return: (base_nb, remote_nb)
         """
-        # Sometimes the root dir of the files is not cwd
-        nb_root = getattr(self.contents_manager, 'root_dir', None)
-        # Resolve base argument to a file system path
-        file_path = os.path.realpath(to_os_path(file_path_arg, nb_root))
+
+        if os.path.isabs(file_path_arg):
+            file_path = os.path.realpath(file_path_arg)
+        else:
+            # Sometimes the root dir of the files is not cwd
+            nb_root = getattr(self.contents_manager, 'root_dir', None)
+            # Resolve base argument to a file system path
+            file_path = os.path.realpath(to_os_path(file_path_arg, nb_root))
 
         # Ensure path/root_dir that can be sent to git:
         try:


### PR DESCRIPTION
Previously, the `get_git_notebooks` would always pre-pend the Jupyter server root to the passed path, even if it was an absolute path. This change makes it such that that is only done if an absolute path. This is helpful in cases when the Git repo root is separate from the server root.

Tested for both cases on the `/gitdiff` API by passing both `/server/repo/file` and and `repo/file`

cc @vidartf for discussion

This is one way to address https://github.com/jupyterlab/jupyterlab-git/issues/391