### PR TITLE
Remove run-time deps from webapps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,12 @@ before_install:
       npm install -g codecov
     fi
 install:
+  # Don't use -v with JS as travis chokes with [Errno 11] write could not complete without blocking
   - |
     if [[ $GROUP == python ]]; then
       pip install --upgrade --upgrade-strategy=eager ".[test]" -v
     elif [[ $GROUP == js ]]; then
-      pip install --upgrade --upgrade-strategy=eager -e ".[test]" -v
+      pip install --upgrade --upgrade-strategy=eager -e ".[test]"
     fi
 before_script:
   # Set up a virtual screen for Firefox browser testing:

--- a/nbdime/webapp/templates/nbdimepage.html
+++ b/nbdime/webapp/templates/nbdimepage.html
@@ -4,9 +4,6 @@
   <head>
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
-    <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
 
     <title>nbdime - diff and merge your Jupyter notebooks</title>
 

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -11,6 +11,7 @@
     "watch": "webpack --watch"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.12.0",
     "@jupyterlab/application": "^2.0.0",
     "@jupyterlab/apputils": "^2.0.0",
     "@jupyterlab/cells": "^2.0.0",

--- a/packages/webapp/src/index.ts
+++ b/packages/webapp/src/index.ts
@@ -19,6 +19,9 @@ import {
 } from './app/common';
 
 
+import '@fortawesome/fontawesome-free/css/all.min.css';
+import '@fortawesome/fontawesome-free/css/v4-shims.min.css';
+
 import 'codemirror/lib/codemirror.css';
 import '@jupyterlab/codemirror/style/index.css';
 


### PR DESCRIPTION
No external requests for the webapps when running.

- Assume browsers support promises
- Remove require (nothng should use it?)
- Include font-awesome as part of the bundle (~80 kB).

Fixes #501.