### PR TITLE
fix test dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ extras_require = setup_args['extras_require'] = {
         'pytest>=3.6',
         'pytest-cov',
         'pytest-timeout',
-        'pytest-tornado5>=2',
+        'pytest-tornado',
         'jsonschema',
         'mock',
         'requests',


### PR DESCRIPTION
Now that pytest-tornado has minimal maintenance again, we can switch back.