### PR TITLE
Limit the size of stream outputs to diff

### DIFF
--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -139,7 +139,7 @@ def _compare_mimedata(mimetype, x, y, comp_text, comp_base64):
     # TODO: Compare binary images?
     #if mimetype.startswith("image/"):
     if isinstance(x, string_types) and isinstance(y, string_types):
-        _compare_mimedata_strings(x, y, comp_text, comp_base64)
+        return _compare_mimedata_strings(x, y, comp_text, comp_base64)
     # Fallback to exactly equal
     return x == y
 

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -40,6 +40,7 @@ re_repr = re.compile(r"<[a-z0-9._]+ at 0x[a-f0-9]{8,16}>", re.IGNORECASE)
 re_pointer = re.compile(r"0x[a-f0-9]{8,16}", re.IGNORECASE)
 
 TEXT_MIMEDATA_MAX_COMPARE_LENGTH = 10000
+STREAM_MAX_COMPARE_LENGTH = 1000
 
 
 # List of mimes we can diff recursively
@@ -228,7 +229,7 @@ def compare_output_approximate(x, y):
     if ot == "stream":
         if x["name"] != y["name"]:
             return False
-        if not compare_strings_approximate(x["text"], y["text"]):
+        if not compare_strings_approximate(x["text"], y["text"], maxlen=STREAM_MAX_COMPARE_LENGTH):
             return False
         handled.update(("name", "text"))
 


### PR DESCRIPTION
This prevents large text outputs from taking up a lot of time in comparison. As the value of very large outputs is low, the impact on performance should be worth the improved performance.