### PR TITLE
Fix error with empty base in merge

### DIFF
--- a/nbdime/nbmergeapp.py
+++ b/nbdime/nbmergeapp.py
@@ -44,7 +44,8 @@ def main_merge(args):
         # Agreed on deletion = no conflics = return 0
         return 0
 
-    b = read_notebook(bfn, on_null='minimal')
+    # Git seems to give empty base file for double insertions
+    b = read_notebook(bfn, on_null='minimal', on_empty='minimal')
     l = read_notebook(lfn, on_null='minimal')
     r = read_notebook(rfn, on_null='minimal')
 


### PR DESCRIPTION
Git seems to prefer to give a zero-length base file if we have conclicting creation of the same file in two branches, instead of using the explicit missing file (/dev/null or NUL). This PR adds code to handle this behavior.

We still let nbdime fall over in most other cases where the file is "real", as empty .ipynb files are invalid JSON.

Fixes #536.