### PR TITLE
Use sendBeacon to send close requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
+  - 3.9-dev
   - 3.8
   - 3.7
   - 3.6
-  - 3.5
 sudo: false
 dist: xenial
 services:
@@ -13,7 +13,7 @@ env:
     - GROUP=python
 matrix:
   include:
-    - python: 3.5
+    - python: 3.8
       env: GROUP=js
 cache:
   pip: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ skip_branch_with_pr: true
 environment:
   nodejs_version: "8.15"
   matrix:
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_MAJOR: 3
       PYTHON_ARCH: "64"
     - PYTHON: "C:\\Python38-x64"

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -609,7 +609,7 @@ def test_git_difftool(git_repo, unique_port, popen_with_terminator):
         r = requests.get(url + '/difftool')
         r.raise_for_status()
         # close it
-        r = requests.post(url + '/api/closetool', headers={'exit_code': '0'})
+        r = requests.post(url + '/api/closetool', json={'exitCode': 0})
         r.raise_for_status()
         time.sleep(0.25)
     # wait for exit
@@ -647,7 +647,7 @@ def test_git_mergetool(git_repo, unique_port, popen_with_terminator):
     )
     r.raise_for_status()
     # close it
-    r = requests.post(url + '/api/closetool', headers={'exit_code': '0'})
+    r = requests.post(url + '/api/closetool', json={'exitCode': 0})
     r.raise_for_status()
     # wait for exit
     process.wait()
@@ -709,7 +709,7 @@ def test_hg_diffweb(hg_repo, unique_port, popen_with_terminator):
         r = requests.get(url + '/difftool')
         r.raise_for_status()
         # close it
-        r = requests.post(url + '/api/closetool', headers={'exit_code': '0'})
+        r = requests.post(url + '/api/closetool', json={'exitCode': 0})
         r.raise_for_status()
         time.sleep(0.25)
     # wait for exit
@@ -743,7 +743,7 @@ def test_hg_mergetool(hg_repo, unique_port, popen_with_terminator):
     )
     r.raise_for_status()
     # close it
-    r = requests.post(url + '/api/closetool', headers={'exit_code': '0'})
+    r = requests.post(url + '/api/closetool', json={'exitCode': 0})
     r.raise_for_status()
     # wait for exit
     process.wait()

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -297,7 +297,10 @@ class ApiCloseHandler(NbdimeHandler, APIHandler):
                 400, 'This server cannot be closed remotely.')
 
         # Fail if no exit code is supplied:
-        self.application.exit_code = int(self.request.headers.get('exit_code', 1))
+        try:
+            self.application.exit_code = json.loads(self.request.body).get('exitCode', 1)
+        except json.JSONDecodeError:
+            self.application.exit_code = 1
 
         _logger.info('Closing server on remote request')
         self.finish()

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -297,10 +297,11 @@ class ApiCloseHandler(NbdimeHandler, APIHandler):
                 400, 'This server cannot be closed remotely.')
 
         # Fail if no exit code is supplied:
+        fallback = int(self.request.headers.get('exit_code', 1))
         try:
-            self.application.exit_code = json.loads(self.request.body).get('exitCode', 1)
+            self.application.exit_code = json.loads(self.request.body).get('exitCode', fallback)
         except json.JSONDecodeError:
-            self.application.exit_code = 1
+            self.application.exit_code = fallback
 
         _logger.info('Closing server on remote request')
         self.finish()

--- a/packages/webapp/src/app/common.ts
+++ b/packages/webapp/src/app/common.ts
@@ -221,11 +221,8 @@ export
 function closeTool(exitCode=0) {
   if (!toolClosed) {
     toolClosed = true;
-    let xhttp = new XMLHttpRequest();
     let url = '/api/closetool';
-    xhttp.open('POST', url, false);
-    xhttp.setRequestHeader('exit_code', exitCode.toString());
-    xhttp.send();
+    navigator.sendBeacon(url, JSON.stringify({exitCode}));
     window.close();
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ extras_require = setup_args['extras_require'] = {
     ],
 }
 
-setup_args['python_requires'] = '>=3.5'
+setup_args['python_requires'] = '>=3.6'
 
 setup_args['entry_points'] = {
     'console_scripts': [


### PR DESCRIPTION
`sendBeacon` allows us to send the request while not using syncchorous requests to block the closing of the browser tab.