### PR TITLE
Rely on jupyter-server-mathjax

### DIFF
--- a/nbdime/tests/test_web.py
+++ b/nbdime/tests/test_web.py
@@ -129,7 +129,7 @@ def test_api_merge(http_client, base_url, nbdime_base_url, merge_validator, file
 
 @pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)
 @pytest.mark.gen_test
-def test_offline_mathjax(http_client, base_url, nbdime_base_url):
+def test_offline_mathjax(http_client, base_url, nbdime_base_url, ioloop_patch):
     url = base_url + nbdime_base_url + '/nb-static/mathjax/MathJax.js'
     response = yield http_client.fetch(url)
     assert response.code == 200

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -13,7 +13,7 @@ import sys
 from jinja2 import FileSystemLoader, Environment
 import nbformat
 from jupyter_server.base.handlers import JupyterHandler, APIHandler
-from jupyter_server import DEFAULT_STATIC_FILES_PATH
+from jupyter_server_mathjax.app import STATIC_ASSETS_PATH
 from jupyter_server.utils import url_path_join
 from jupyter_server.log import log_request
 import requests
@@ -364,7 +364,7 @@ def make_app(**params):
         (r'/api/store', ApiMergeStoreHandler, params),
         (r'/api/closetool', ApiCloseHandler, params),
         (r'/nb-static/mathjax/(.*)', web.StaticFileHandler, {
-            'path': os.path.join(DEFAULT_STATIC_FILES_PATH, 'components', 'MathJax')
+            'path': STATIC_ASSETS_PATH
         })
         # Static handler will be added automatically
     ]

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ install_requires = setup_args['install_requires'] = [
     'requests',
     'GitPython!=2.1.4, !=2.1.5, !=2.1.6',  # For difftool taking git refs
     'jupyter_server',
+    'jupyter_server_mathjax>=0.2.2',
     'jinja2>=2.9',
 ]
 


### PR DESCRIPTION
Relies on https://github.com/jupyter-server/jupyter_server_mathjax for mathjax static assets.

Fixes #573.