### PR TITLE
Format note and code correctly on installation page

### DIFF
--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -83,10 +83,12 @@ and use :command:`pip` to install::
 Installing Jupyter extensions
 -----------------------------
 
+.. note::
+
+    Only run one of the following two server commands, running both can cause issues in some cases
+
 If you want to use the development version of the notebook and lab extensions,
 you will also have to run the following commands after the pip dev install::
-
-> Note: only run one of the following two server commands, running both can cause issues in some cases
 
     jupyter serverextension enable --py nbdime --sys-prefix # if developing for jupyter notebook
 


### PR DESCRIPTION
This section currently looks a bit odd on the installation page, so I suggest moving the note on top and format it as an admonition.

Current appearance:

![image](https://user-images.githubusercontent.com/4560057/135488866-d42e4eae-9a4b-4a92-813e-f55922fce10f.png)
