### PR TITLE
Make INFO text more readable in black terminal

### DIFF
--- a/nbdime/prettyprint.py
+++ b/nbdime/prettyprint.py
@@ -57,7 +57,7 @@ col_const = {
         KEEP   = '{color}   '.format(color=''),
         REMOVE = '{color}-  '.format(color=colorama.Fore.RED),
         ADD    = '{color}+  '.format(color=colorama.Fore.GREEN),
-        INFO   = '{color}## '.format(color=colorama.Fore.BLUE),
+        INFO   = '{color}## '.format(color=colorama.Fore.BLUE + colorama.Style.BRIGHT),
         RESET  = colorama.Style.RESET_ALL,
     ),
 


### PR DESCRIPTION
As addressed in https://github.com/jupyter/nbdime/issues/240 the
headers are printed in BLUE, which is hard to read when using git
integration in a dark terminal.

This allows for the color to remain the same, but just to brighten it up
such that is more readable.

Refs:
    - https://github.com/tartley/colorama/blob/34703ece90fc4996727adff31502bad8a8e88066/demos/demo03.py#L15

	modified:   prettyprint.py