### PR TITLE
Use full path when changing directory

### DIFF
--- a/nbdime/utils.py
+++ b/nbdime/utils.py
@@ -316,7 +316,7 @@ def split_os_path(path):
 @contextmanager
 def pushd(path):
     """Change current directory with context manager (changes back)"""
-    old = os.curdir
+    old = os.getcwd()
     try:
         os.chdir(path)
         yield


### PR DESCRIPTION
The behavior of `os.curdir` is to return a string representation of the current directory which
can be '.' (representing the current directory). This causes problems when changing to one
directory and then back as going "back" to '.' keeps you in the same place. Instead you need
to track the full path to the cwd using `os.getcwd()` which returns a path like
/foo/bar instead of '.'.

This triggered a bug where the user has the current directory structure:

```
/notebooks
/notebooks/Untitled.ipynb
...
/notebooks/git-repo
/notebooks/git-repo/.git
/notebooks/git-repo/Untitled2.ipynb
...

```

The steps for the bug:
1. The Jupyter server is launched from the /notebooks folder.
2. The user navigates to the git-repo folder in the /tree view.
3. The user opens Untitled2.ipynb.
4. The user clicks the nbdiff icon to diff the notebook.
5. The user returns to the /tree tab and it is now rooted in the git-repo
   folder with no way to return to the parent folder other than restarting
   the Jupyter server.

Closes #619