### PR TITLE
Move global flags to start of regex

### DIFF
--- a/setupbase.py
+++ b/setupbase.py
@@ -661,7 +661,7 @@ def _translate_glob(pat):
         translated_parts.append(_translate_glob_part(part))
     os_sep_class = '[%s]' % re.escape(SEPARATORS)
     res = _join_translated(translated_parts, os_sep_class)
-    return '{res}\\Z(?ms)'.format(res=res)
+    return '(?ms){res}\\Z'.format(res=res)
 
 
 def _join_translated(translated_parts, os_sep_class):


### PR DESCRIPTION
This prevents the error "re.error: global flags not at the start of the expression at position 35" on Python 3.11