### PR TITLE
Added cookie_secret to tornado app creation

### DIFF
--- a/nbdime/_version.py
+++ b/nbdime/_version.py
@@ -1,2 +1,2 @@
-version_info = (3, 1, 1, 'dev')
+version_info = (3, 1, 2, 'dev')
 __version__ = ".".join(map(str, version_info))

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -4,6 +4,7 @@
 
 
 
+import base64
 import io
 import json
 import logging
@@ -386,6 +387,7 @@ def make_app(**params):
         'jinja2_env': env,
         'mathjax_url': prefix + '/nb-static/mathjax/MathJax.js',
         'local_hostnames': ['localhost', '127.0.0.1'],
+        'cookie_secret': base64.encodebytes(os.urandom(32)), # Needed even for an unsecured server.
     }
 
     if is_in_repo(nbdime_root):


### PR DESCRIPTION
Resolves https://github.com/jupyter/nbdime/issues/645

Creates a random `cookie_secret` and passes it to the tornado application. I copied the secret generation from the `jupyter_server` code here:
https://github.com/jupyter-server/jupyter_server/blob/a55bc587e9c343509e95bd93961e27e331882834/jupyter_server/serverapp.py#L1047

I tested this in a fresh environment after installing `jupyter_server==1.23.3` and again in a fresh environment after installing `jupyter_server==2.0.1` and confirmed it's working with both.

**Note**: With jupyter_server 2 there is a separate warning thrown unrelated to this change, but I'll note it here (could probably be a followup issue):
```
 UserWarning: The Tornado web application does not have an 'identity_provider' defined in its settings. In future releases of jupyter_server, this will be a required key for all subclasses of `JupyterHandler`. For an example, see the jupyter_server source code for how to add an identity provider to the tornado settings: https://github.com/jupyter-server/jupyter_server/blob/aa8fd8b3faf37466eeb99689d5555314c5bf6640/jupyter_server/serverapp.py#L253
```