### PR TITLE
Replace mock with unittest.mock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         python -m pip install jupyterlab~=3.0
         npm install -g codecov
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: Get npm cache directory
       id: npm-cache-dir
       run: |
@@ -95,6 +95,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
+        export NODE_OPTIONS="--openssl-legacy-provider"
         python -m pip install codecov
         python -m pip install --upgrade pip
         python -m pip install jupyterlab~=3.0

--- a/nbdime/tests/test_git_diffdriver.py
+++ b/nbdime/tests/test_git_diffdriver.py
@@ -9,8 +9,8 @@ import io
 import os
 from os.path import join as pjoin
 import sys
+from unittest import mock
 
-import mock
 import pytest
 from tornado import ioloop
 

--- a/nbdime/tests/test_hg_differ.py
+++ b/nbdime/tests/test_hg_differ.py
@@ -7,8 +7,8 @@
 
 import os
 from os.path import join as pjoin
+from unittest import mock
 
-import mock
 import pytest
 from tornado import ioloop
 

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,6 @@ extras_require = setup_args['extras_require'] = {
         'pytest-tornado',
         'jupyter_server[test]',
         'jsonschema',
-        'mock',
         'notebook',
         'requests',
         'tabulate',  # For profiling


### PR DESCRIPTION
The latter is available with Python 3.3 [1], and nbdime requires Python 3.6+ as per setup.py.

This change removes the need of an external library.

[1] https://docs.python.org/3/library/unittest.mock.html