### PR TITLE
Fix wrong picker marker (a typo during lab 4.0 migration)

### DIFF
--- a/packages/nbdime/src/common/mergeview.ts
+++ b/packages/nbdime/src/common/mergeview.ts
@@ -691,7 +691,7 @@ Add a gap DOM element between 2 editors
                 !hasEntries(s.decision.localDiff) &&
                 !hasEntries(s.decision.remoteDiff)
               ) {
-                // We have a custom decision, add picker on base only!*/
+                // We have a custom decision, add picker on base only!
                 effects = effects.concat(
                   this.createGutterEffects(
                     editor,
@@ -727,6 +727,7 @@ Add a gap DOM element between 2 editors
         }
       }
       if (chunkFirstLine === chunkLastLine) {
+        // When the chunk is empty, make sure a horizontal line shows up
         const startingOffset = posToOffset(editor.state.doc, {
           line: chunkFirstLine,
           column: 0,
@@ -750,13 +751,14 @@ Add a gap DOM element between 2 editors
             ),
           );
         } else if (conflict) {
+          // Add conflict markers on editor, if conflicted
           effects = effects.concat(
             this.createGutterEffects(
               editor,
               chunk,
               startingOffset,
               true,
-              'picker',
+              'conflict',
             ),
           );
         }


### PR DESCRIPTION
This is a follow-up to #673, something I noticed when looking into https://github.com/jupyter/nbdime/issues/676

For reference, this is the corresponding code on 3.2 branch:

https://github.com/jupyter/nbdime/blob/1b368a884405914e9b1861a445c20927f7c88a5b/packages/nbdime/src/common/mergeview.ts#L555-L572

it was also using `conflict` so I assume `picker` here on the master branch is a typo.