### PR TITLE
Fix syntax highlighting issue in diffchunks.

### DIFF
--- a/packages/nbdime/src/styles/merge.css
+++ b/packages/nbdime/src/styles/merge.css
@@ -225,7 +225,6 @@
 .jp-Notebook-merge .cm-central-editor .cm-line .cm-merge-l-deleted,
 .jp-Notebook-merge .cm-central-editor .cm-line .cm-merge-r-deleted {
   background-color: initial;
-  color: #b00;
 }
 
 .jp-Notebook-merge .CodeMirror-gutter-wrapper {


### PR DESCRIPTION
Fixes mixed approach observed in issue #678, where both syntax highlighting and diff chunk text coloring was observed in the central editor of the mergeview.