### PR TITLE
Add src for sourcemap

### DIFF
--- a/packages/labextension/package.json
+++ b/packages/labextension/package.json
@@ -25,7 +25,8 @@
     "lib/*.js.map",
     "lib/*.d.ts",
     "style/*.css",
-    "schema/*.json"
+    "schema/*.json",
+    "src/*.ts"
   ],
   "style": "style/index.css",
   "scripts": {

--- a/packages/nbdime/package.json
+++ b/packages/nbdime/package.json
@@ -10,6 +10,10 @@
   "directories": {
     "lib": "lib/"
   },
+  "files": [
+    "lib/**/*.{js,js.map,d.ts}",
+    "src/**/*.ts"
+  ],
   "scripts": {
     "build": "tsc --project . && node scripts/copy-files.js",
     "build:dev": "tsc --project .",


### PR DESCRIPTION
Similar to https://github.com/jupyterlab/jupyterlab/pull/14028

It follows error messages seen in @jupyterlab/git similar to that one:

```
WARNING in ./node_modules/nbdime/lib/upstreaming/flexpanel.js
Invalid dependencies have been reported by plugins or loaders for this module. All reported dependencies need to be absolute paths.
Invalid dependencies may lead to broken watching and caching.
As best effort we try to convert all invalid values to absolute paths and converting globs into context dependencies, but this is deprecated behavior.
Loaders: Pass absolute paths to this.addDependency (existing files), this.addMissingDependency (not existing files), and this.addContextDependency (directories).
Plugins: Pass absolute paths to fileDependencies (existing files), missingDependencies (not existing files), and contextDependencies (directories).
Globs: They are not supported. Pass absolute path to the directory as context dependencies.
The following invalid values have been reported:
 * "../../src/upstreaming/flexpanel.ts"
```