### PR TITLE
Add Node.js to docs runtime

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+    nodejs: "18"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
This should resolve current failures of documentation build (https://github.com/jupyter/nbdime/issues/685#issuecomment-1735985166).