### PR TITLE
RTD: make sure nodes is present

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
+    nodejs: "20"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
and build with Python 3.11

builds are [failing](https://readthedocs.org/projects/nbdime/builds/22047074/) with missing `npm`.