### PR TITLE
Minimal change to permit non-interactive html diff generation (#468)

### DIFF
--- a/packages/webapp/src/app/diff.ts
+++ b/packages/webapp/src/app/diff.ts
@@ -244,12 +244,23 @@ function attachToForm() {
  *
  */
 export function initializeDiff() {
-  attachToForm();
-  // If arguments supplied in config, run diff directly:
-  let base = getConfigOption('base');
-  let remote = getConfigOption('remote');
-  if (base && (remote || hasPrefix(base))) {
-    compare(base, remote, 'replace');
+  let diff_data = getConfigOption('diff_data');
+  if (diff_data === undefined) {
+    // This is the normal case.
+    attachToForm();
+    // If arguments supplied in config, run diff directly:
+    let base = getConfigOption('base');
+    let remote = getConfigOption('remote');
+    if (base && (remote || hasPrefix(base))) {
+      compare(base, remote, 'replace');
+    }
+  } else {
+    // Then the diff was pre-generated and included in the config data,
+    // e.g. for non-interactive generation of html diffs.
+    // The diff data should have "base" and "diff" keys for showDiff().
+    // showDiff() requires the data to be mutable, so make a mutable copy.
+    const cloned_diff_data = JSON.parse(JSON.stringify(diff_data))
+    onDiffRequestCompleted(cloned_diff_data);
   }
 
   let exportBtn = document.getElementById('nbdime-export') as HTMLButtonElement;


### PR DESCRIPTION
This is a minimal PR to support addressing issue #468. Specifically, it contains a minimal code change needed to let html diffs be created non-interactively (e.g. from the command-line in CI) without having to patch nbdime's source code. A gist demonstrating this (in conjunction with this PR) can be found here: https://gist.github.com/cjerdonek/2dad48eea22846476487d594cd906493

This PR also doesn't even require any changes to the default template, though the gist I wrote above does support providing your own template if you want (which again doesn't require modifying nbdime's source code).

My hope is that, because this PR has a lighter footprint than PR #552, it can provide an interim and more flexible way to address issue #468 in the short-term so people no longer have to patch or fork nbdime to get the benefit of off-line html diffs.
