### PR TITLE
Allow unauthenticated access to jupyter server

### DIFF
--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -388,6 +388,7 @@ def make_app(**params):
         'jinja2_env': env,
         'local_hostnames': ['localhost', '127.0.0.1'],
         'cookie_secret': base64.encodebytes(os.urandom(32)), # Needed even for an unsecured server.
+        'allow_unauthenticated_access': True,
     }
 
     try:


### PR DESCRIPTION
Fixes #749.

Since `jupyter_server` enabled authentication by default, `nbdime` has been failing. This is a fix (or maybe just a workaround) to allow unauthenticated access, and was written by @yan12125 in [this comment](https://github.com/jupyter/nbdime/issues/749#issuecomment-2001967952).

I am interested in this because I am trying to add visual tests to `matplotlib-inline` (ipython/matplotlib-inline#32) and without this fix I have to pin `jupyter_server<2.12.6`.