### PR TITLE
Allow unauthenticated access to jupyter server

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -14,6 +14,11 @@ nbdime provides the following CLI commands::
 
 Pass ``--help`` to each command to see help text for the command's usage.
 
+.. warning::
+    The `-web` variants will start up a local, unsecured server.
+    If the port used by this server is accessible to others users
+    (which is commonly the case in HPC setups) the content of the
+    diffed/merged notebook will be accessibly by other users.
 
 Additional commands are available for :ref:`git-integration`.
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -16,7 +16,7 @@ Pass ``--help`` to each command to see help text for the command's usage.
 
 .. warning::
     The `-web` variants will start up a local, unsecured server.
-    If the port used by this server is accessible to others users
+    If the port used by this server is accessible to other users
     (which is commonly the case in HPC setups) the content of the
     diffed/merged notebook will be accessibly by other users.
 

--- a/nbdime/webapp/nbdimeserver.py
+++ b/nbdime/webapp/nbdimeserver.py
@@ -388,6 +388,7 @@ def make_app(**params):
         'jinja2_env': env,
         'local_hostnames': ['localhost', '127.0.0.1'],
         'cookie_secret': base64.encodebytes(os.urandom(32)), # Needed even for an unsecured server.
+        'allow_unauthenticated_access': True,
     }
 
     try:


### PR DESCRIPTION
- Fixes https://github.com/jupyter/nbdime/issues/749
- Reopens https://github.com/jupyter/nbdime/pull/756

While ideally we would rewrite nbdime to use a secure solution server it does not seem likely to happen any time soon. In the meantime we need to fix this even to allow the CI to pass and to let users to run `nbdime` server locally.