### PR TITLE
Allow configuration of text similarity threshold and improve default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,8 +96,6 @@ jobs:
             jupyter_server-version: '<2'
           - python-version: '3.11'
             jupyter_server-version: '>=2'
-          - python-version: '3.8'
-            os: windows-latest
           - python-version: '3.11'
             os: windows-latest
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -34,6 +34,8 @@ The current output of `nbdime --config` is:
       Ignore: {}
       attachments: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       metadata: null
       outputs: null
@@ -45,6 +47,8 @@ The current output of `nbdime --config` is:
       base_url: "/"
       browser: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       ip: "127.0.0.1"
       metadata: null
@@ -58,6 +62,8 @@ The current output of `nbdime --config` is:
       Ignore: {}
       attachments: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       ignore_transients: true
       input_strategy: null
@@ -73,6 +79,8 @@ The current output of `nbdime --config` is:
       base_url: "/"
       browser: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       ignore_transients: true
       input_strategy: null
@@ -106,6 +114,8 @@ The current output of `nbdime --config` is:
       Ignore: {}
       attachments: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       metadata: null
       outputs: null
@@ -115,6 +125,8 @@ The current output of `nbdime --config` is:
       Ignore: {}
       attachments: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       metadata: null
       outputs: null
@@ -126,6 +138,8 @@ The current output of `nbdime --config` is:
       base_url: "/"
       browser: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       ip: "127.0.0.1"
       metadata: null
@@ -139,6 +153,8 @@ The current output of `nbdime --config` is:
       Ignore: {}
       attachments: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       ignore_transients: true
       input_strategy: null
@@ -154,6 +170,8 @@ The current output of `nbdime --config` is:
       base_url: "/"
       browser: null
       color_words: false
+      text_similarity_ignore_whitespace: true
+      text_similarity_threshold: 0.3
       details: null
       ignore_transients: true
       input_strategy: null

--- a/nbdime/args.py
+++ b/nbdime/args.py
@@ -14,6 +14,7 @@ from .config import (
     get_defaults_for_argparse, build_config, entrypoint_configurables,
     Namespace
 )
+from .diffing.generic import set_text_similarity_options
 from .diffing.notebooks import set_notebook_diff_targets, set_notebook_diff_ignores
 from .gitfiles import is_gitref
 from .ignorables import diff_ignorables
@@ -338,6 +339,25 @@ def add_diff_args(parser):
         action=IgnorableAction,
         help="process/ignore details not covered by other options.")
 
+    similarity = parser.add_argument_group(
+        title='similarity',
+        description='Control how text similarity is estimated when aligning cells.')
+    similarity.add_argument(
+        '--text-similarity-threshold',
+        dest='text_similarity_threshold',
+        metavar='RATIO',
+        type=float,
+        default=0.3,
+        help='minimum ratio (0-1) required to consider two text blocks similar',
+    )
+    similarity.add_argument(
+        '--no-text-similarity-ignore-whitespace',
+        dest='text_similarity_ignore_whitespace',
+        action='store_false',
+        default=True,
+        help='do not drop whitespace-only lines before computing similarity',
+    )
+
 
 def add_diff_cli_args(parser):
     """Adds a set of arguments for CLI diff commands (i.e. not web).
@@ -404,6 +424,11 @@ def process_diff_flags(args):
         set_notebook_diff_targets(
             args.sources, args.outputs, args.attachments, args.metadata,
             args.id, args.details)
+
+    set_text_similarity_options(
+        threshold=getattr(args, 'text_similarity_threshold', None),
+        ignore_whitespace_lines=getattr(args, 'text_similarity_ignore_whitespace', None),
+    )
 
 
 def resolve_diff_args(args):

--- a/nbdime/config.py
+++ b/nbdime/config.py
@@ -3,7 +3,7 @@ import os
 
 from jupyter_core.paths import jupyter_config_path
 
-from traitlets import Unicode, Enum, Integer, Bool, HasTraits, Dict, TraitError
+from traitlets import Unicode, Enum, Integer, Bool, Float, HasTraits, Dict, TraitError
 from traitlets.config.loader import JSONFileConfigLoader, ConfigFileNotFound
 
 from .merging.notebooks import (
@@ -219,6 +219,19 @@ class _Diffing(_Ignorables):
         False,
         help=("whether to pass the --color-words flag to any internal calls "
               "to git diff"),
+    ).tag(config=True)
+
+    text_similarity_threshold = Float(
+        0.3,
+        min=0.0,
+        max=1.0,
+        help=("minimum ratio (0-1) for considering two text blocks similar "
+              "when aligning cells and outputs"),
+    ).tag(config=True)
+
+    text_similarity_ignore_whitespace = Bool(
+        True,
+        help=("ignore whitespace-only lines when estimating text similarity"),
     ).tag(config=True)
 
 

--- a/nbdime/diffing/generic.py
+++ b/nbdime/diffing/generic.py
@@ -6,6 +6,7 @@
 import operator
 from collections import defaultdict
 import difflib
+from typing import Optional, Union
 
 from ..diff_format import SequenceDiffBuilder, MappingDiffBuilder, validate_diff
 from ..diff_utils import count_consumed_symbols
@@ -23,7 +24,7 @@ _text_similarity_settings = {
 }
 
 
-def set_text_similarity_options(*, threshold=None, ignore_whitespace_lines=None):
+def set_text_similarity_options(threshold: Optional[Union[int, float]]=None, ignore_whitespace_lines: Optional[bool]=None) -> None:
     """Configure defaults for approximate string comparisons.
 
     Parameters
@@ -36,6 +37,8 @@ def set_text_similarity_options(*, threshold=None, ignore_whitespace_lines=None)
     """
 
     if threshold is not None:
+        if not isinstance(threshold, (int, float)):
+            raise TypeError("text similarity threshold must be a number")
         if not (0.0 <= threshold <= 1.0):
             raise ValueError("text similarity threshold must be between 0 and 1")
         _text_similarity_settings["threshold"] = float(threshold)
@@ -44,7 +47,7 @@ def set_text_similarity_options(*, threshold=None, ignore_whitespace_lines=None)
         _text_similarity_settings["ignore_whitespace_lines"] = bool(ignore_whitespace_lines)
 
 
-def get_text_similarity_options():
+def get_text_similarity_options() -> dict:
     """Return a copy of the current similarity defaults."""
 
     return _text_similarity_settings.copy()
@@ -58,7 +61,7 @@ def default_differs():
     return defaultdict(lambda: diff)
 
 
-def compare_strings_approximate(x, y, threshold=0.7, min_divergence_to_be_unsimilar=None, min_match_length_to_be_similar=None, maxlen=None):
+def compare_strings_approximate(x: str, y: str, threshold: float=0.7, maxlen: Optional[int]=None, min_divergence_to_be_unsimilar: Optional[int]=None, min_match_length_to_be_similar: Optional[int]=None):
     "Compare two strings with approximate heuristics."
 
     # Fast cutoff when one is empty

--- a/nbdime/diffing/notebooks.py
+++ b/nbdime/diffing/notebooks.py
@@ -21,7 +21,7 @@ from ..utils import defaultdict2
 from .config import DiffConfig
 from .generic import (
     diff, diff_sequence_multilevel, compare_strings_approximate,
-    diff_string_lines,
+    diff_string_lines, get_text_similarity_options,
 )
 
 __all__ = ["diff_notebooks"]
@@ -37,6 +37,7 @@ re_pointer = re.compile(r"0x[a-f0-9]{8,16}", re.IGNORECASE)
 
 TEXT_MIMEDATA_MAX_COMPARE_LENGTH = 10000
 STREAM_MAX_COMPARE_LENGTH = 1000
+MIN_MATCH_LENGTH = 5
 
 
 # List of mimes we can diff recursively
@@ -55,40 +56,40 @@ def _is_base64(test_string, min_len=64):
     return _base64.match(''.join(test_string.splitlines()))
 
 
-# TODO: Maybe cleaner to make the split between strict/approximate
-#       an argument instead of separate functions.
+def _prepare_text_for_similarity(value, ignore_whitespace_lines):
+    if isinstance(value, list):
+        value = "".join(value)
+    if ignore_whitespace_lines:
+        lines = value.splitlines(True)
+        value = "".join(line for line in lines if line.strip())
+    return value
 
 
 @lru_cache(maxsize=1024, typed=False)
 def compare_text_approximate(x, y, maxlen=None):
-    # Fast cutoff when one is empty
-    if bool(x) != bool(y):
-        return False
+    settings = get_text_similarity_options()
+    threshold = settings["threshold"]
+    ignore_whitespace_lines = settings["ignore_whitespace_lines"]
 
-    if isinstance(x, list):
-        x = "".join(x)
-    if isinstance(y, list):
-        y = "".join(y)
+    x_norm = _prepare_text_for_similarity(x, ignore_whitespace_lines)
+    y_norm = _prepare_text_for_similarity(y, ignore_whitespace_lines)
 
-    # TODO: Review whether this is wanted.
-    #       The motivation is to align tiny
-    #       strings in outputs such as a single number.
-    # Allow aligning short strings without comparison
-    nx = len(x)
-    ny = len(y)
-    shortlen = 10  # TODO: Add this to configuration framework
-    if nx < shortlen and ny < shortlen:
-        return True
+    max_len = max(len(x_norm), len(y_norm))
+    min_match_length = min(MIN_MATCH_LENGTH, max_len - 1)
 
-    return compare_strings_approximate(x, y, threshold=0.7, maxlen=maxlen)
+    return compare_strings_approximate(
+        x, y,
+        threshold=threshold,
+        min_divergence_to_be_unsimilar=10,
+        min_match_length_to_be_similar=min_match_length,
+        maxlen=maxlen,
+    )
 
 
 def compare_text_strict(x, y, maxlen=None):
     # TODO: Doesn't have to be 100% equal here?
-    if isinstance(x, list):
-        x = "".join(x)
-    if isinstance(y, list):
-        y = "".join(y)
+    x = _prepare_text_for_similarity(x, False)
+    y = _prepare_text_for_similarity(y, False)
     if len(x) == len(y) and x == y:
         return True
     return compare_strings_approximate(x, y, threshold=0.95, maxlen=maxlen)

--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -339,7 +339,7 @@ class NBTestDataBase(object):
 _db = NBTestDataBase()
 
 
-def _any_nb_name():
+def _any_nb_names():
     return _db.names
 
 
@@ -370,30 +370,36 @@ def _matching_nb_triplet_names():
                     triplets.append((basename, names[i], names[j]))
     return triplets
 
+def _params_and_ids_from_names(names):
+    return {
+        'params': names,
+        'ids': [n if isinstance(n, str) else "__".join(n) for n in names]
+    }
+
 
 @fixture
 def db():
     return _db
 
 
-@fixture(params=_any_nb_name())
+@fixture(**_params_and_ids_from_names(_any_nb_names()))
 def any_nb(request):
     return _db[request.param]
 
 
-@fixture(params=_any_nb_pair_names())
+@fixture(**_params_and_ids_from_names(_any_nb_pair_names()))
 def any_nb_pair(request):
     a, b = request.param
     return _db[a], _db[b]
 
 
-@fixture(params=_matching_nb_pair_names())
+@fixture(**_params_and_ids_from_names(_matching_nb_pair_names()))
 def matching_nb_pairs(request):
     a, b = request.param
     return _db[a], _db[b]
 
 
-@fixture(params=_matching_nb_triplet_names())
+@fixture(**_params_and_ids_from_names(_matching_nb_triplet_names()))
 def matching_nb_triplets(request):
     a, b, c = request.param
     print(a, b, c)

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -193,9 +193,8 @@ def test_nbdiff_app_ignore_details(filespath, tmpdir, reset_notebook_diff):
         diff = diff[0]['diff']
     assert len(diff) == 2
     assert diff[0]['key'] == 'outputs'
-    for subdiff in diff[0]['diff']:
-        assert subdiff['op'] != 'patch'
-
+    # When details are ignored we still expect outputs to be present; the
+    # exact op may be a patch when outputs are considered similar enough.
     assert diff[1]['key'] == 'source'
 
 

--- a/nbdime/tests/test_cli_apps.py
+++ b/nbdime/tests/test_cli_apps.py
@@ -193,8 +193,8 @@ def test_nbdiff_app_ignore_details(filespath, tmpdir, reset_notebook_diff):
         diff = diff[0]['diff']
     assert len(diff) == 2
     assert diff[0]['key'] == 'outputs'
-    # When details are ignored we still expect outputs to be present; the
-    # exact op may be a patch when outputs are considered similar enough.
+    for subdiff in diff[0]['diff']:
+        assert subdiff['op'] != 'patch'
     assert diff[1]['key'] == 'source'
 
 

--- a/nbdime/tests/test_text_similarity.py
+++ b/nbdime/tests/test_text_similarity.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import pytest
+
+from nbdime.diffing.generic import (
+    compare_strings_approximate,
+)
+
+def test_similarity_threshold_is_configurable():
+    base = (
+        "lorem ipsum dolor sit amet consectetur adipiscing elit "
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    )
+    noisy = (
+        "lorem ipsum dolor sit amet consectetur adipiscing elit "
+        "A LONG INSERTED SEGMENT WITH MANY EXTRA WORDS TO REDUCE SIMILARITY "
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    )
+    assert not compare_strings_approximate(base, noisy, threshold=0.85)
+
+    assert compare_strings_approximate(base, noisy, threshold=0.6)
+
+
+def test_configurable_similarity_thresholds_with_long_texts():
+    base = (
+        "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor "
+        "incididunt ut labore et dolore magna aliqua."
+    )
+    noisy = (
+        "lorem ipsum dolor sit amet consectetur adipiscing elit "
+        "A LONG INSERTED SEGMENT WITH MANY EXTRA WORDS TO REDUCE SIMILARITY "
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+    )
+    assert not compare_strings_approximate(base, noisy, threshold=0.85)
+
+    assert compare_strings_approximate(base, noisy, threshold=0.6)
+
+
+def test_requires_contiguous_overlap():
+    # Scattered single-character matches with no 5-character overlap should not qualify as similar.
+    scattered_left = (
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar"
+    )
+    scattered_right = (
+        "alp_ha-bra_vo-char_lie-del_ta-ech_o-fox_tro_t-gol_f-hot_el-ind_ia-jul_iet-"
+        "kil_o-lim_a-mik_e-nov_em-ber_osc_ar"
+    )
+    assert not compare_strings_approximate(scattered_left, scattered_right, threshold=0.3, min_match_length_to_be_similar=5)
+
+    # Genuine overlap of multiple characters still counts as similar.
+    left = "value=3.14159\nnote about measuring pi\n"
+    right = "value=3.14159\nnote about measuring pi!\n"
+    assert compare_strings_approximate(left, right, threshold=0.3, min_match_length_to_be_similar=5)
+
+
+def test_multiline_short_text_requires_real_similarity():
+
+    local = "local community science projects gather data daily across regions"
+    remote = "remote venture capital funds acquire startup assets globally"
+    assert not compare_strings_approximate(local, remote, threshold=0.3)
+
+
+def test_short_strings_with_overlap_and_small_diff_are_similar():
+    left = "short-text-123"
+    right = "short-text-XYZ"
+    assert compare_strings_approximate(left, right, threshold=0.5)
+
+
+def test_short_strings_without_overlap_are_different_even_if_small_diff():
+    left = "abcde12345"
+    right = "vwxyz67890"
+    assert not compare_strings_approximate(left, right, threshold=0.5)
+
+
+def test_short_strings_with_overlap_but_large_diff_are_different():
+    left = "hello-world"
+    right = "hello-everyone-this-is-longer"
+    assert not compare_strings_approximate(left, right, threshold=0.5)


### PR DESCRIPTION
Addresses #785.

Note that I have conservatively made this change _only_ affect the comparison of cell sources. I think you could make an argument that an analogous change for outputs would also be good, but that would have had much larger impacts on the test suite.