### PR TITLE
Remove unused mock dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ test = [
     "pytest-timeout",
     "jupyter_server[test]",
     "jsonschema",
-    "mock",
     "notebook",
     "requests",
     "tabulate",


### PR DESCRIPTION
All of the tests that use mock import it from unittest.  The old standalone mock module is not needed.