### PR TITLE
Implement the nbdime:diff command

### DIFF
--- a/packages/labextension/src/plugin.ts
+++ b/packages/labextension/src/plugin.ts
@@ -208,8 +208,11 @@ function addCommands(
         name: 'base' | 'remote',
       ): Promise<string | null> {
         const value = args[name];
-        if (typeof value === 'string' && value.trim()) {
-          return value;
+        if (typeof value === 'string') {
+          const path = value.trim();
+          if (path) {
+            return path;
+          }
         }
 
         const label =
@@ -224,9 +227,8 @@ function addCommands(
           placeholder: trans.__('path/to/notebook.ipynb'),
           okLabel: trans.__('Compare'),
         });
-        return result.button.accept && result.value?.trim()
-          ? result.value
-          : null;
+        const path = result.value?.trim();
+        return result.button.accept && path ? path : null;
       }
 
       const base = await getNotebookPath('base');

--- a/packages/labextension/src/plugin.ts
+++ b/packages/labextension/src/plugin.ts
@@ -6,7 +6,7 @@ import type {
   JupyterFrontEnd,
 } from '@jupyterlab/application';
 
-import { CommandToolbarButton } from '@jupyterlab/apputils';
+import { CommandToolbarButton, InputDialog } from '@jupyterlab/apputils';
 
 import { IEditorServices } from '@jupyterlab/codeeditor';
 
@@ -32,7 +32,12 @@ import type { CommandRegistry } from '@lumino/commands';
 
 import { type IDisposable, DisposableDelegate } from '@lumino/disposable';
 
-import { diffNotebookGit, diffNotebookCheckpoint, isNbInGit } from './actions';
+import {
+  diffNotebook,
+  diffNotebookGit,
+  diffNotebookCheckpoint,
+  isNbInGit,
+} from './actions';
 
 const pluginId = 'nbdime-jupyterlab:plugin';
 
@@ -198,11 +203,54 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.diffNotebook, {
-    execute: args => {
-      // TODO: Check args for base/remote
-      // if missing, prompt with dialog.
-      //let content = current.notebook;
-      //diffNotebook({base, remote, translator});
+    execute: async args => {
+      async function getNotebookPath(
+        name: 'base' | 'remote',
+      ): Promise<string | null> {
+        const value = args[name];
+        if (typeof value === 'string' && value.trim()) {
+          return value;
+        }
+
+        const label =
+          name === 'base'
+            ? trans.__('Base notebook path')
+            : trans.__('Remote notebook path');
+        const result = await InputDialog.getText({
+          title: trans.__('Compare notebooks'),
+          label,
+          text:
+            name === 'remote' ? tracker.currentWidget?.context.path ?? '' : '',
+          placeholder: trans.__('path/to/notebook.ipynb'),
+          okLabel: trans.__('Compare'),
+        });
+        return result.button.accept && result.value?.trim()
+          ? result.value
+          : null;
+      }
+
+      const base = await getNotebookPath('base');
+      if (!base) {
+        return;
+      }
+      const remote = await getNotebookPath('remote');
+      if (!remote) {
+        return;
+      }
+
+      const widget = diffNotebook({
+        base,
+        remote,
+        editorFactory,
+        rendermime,
+        hideUnchanged,
+        translator,
+        serverSettings,
+      });
+      shell.add(widget);
+      if (args['activate'] !== false) {
+        shell.activateById(widget.id);
+      }
     },
     label: erroredGen(trans.__('Notebook diff')),
     caption: erroredGen(trans.__('Display nbdiff between two notebooks')),

--- a/packages/labextension/src/plugin.ts
+++ b/packages/labextension/src/plugin.ts
@@ -203,6 +203,31 @@ function addCommands(
   });
 
   commands.addCommand(CommandIDs.diffNotebook, {
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          base: {
+            type: 'string',
+            description: trans.__(
+              'Path to the base notebook. If omitted, the command prompts for it.',
+            ),
+          },
+          remote: {
+            type: 'string',
+            description: trans.__(
+              'Path to the remote notebook. If omitted, the command prompts for it.',
+            ),
+          },
+          activate: {
+            type: 'boolean',
+            description: trans.__(
+              'Whether to activate the diff widget after opening it.',
+            ),
+          },
+        },
+      },
+    },
     execute: async args => {
       async function getNotebookPath(
         name: 'base' | 'remote',

--- a/packages/nbdime/test/src/labextension-command.spec.ts
+++ b/packages/nbdime/test/src/labextension-command.spec.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+jest.mock('../../../labextension/src/actions', () => ({
+  diffNotebook: jest.fn(() => ({ id: 'notebook-diff' })),
+  diffNotebookCheckpoint: jest.fn(),
+  diffNotebookGit: jest.fn(),
+  isNbInGit: jest.fn(() => Promise.resolve(true)),
+}));
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { diffNotebook } from '../../../labextension/src/actions';
+import nbdimePlugin, { CommandIDs } from '../../../labextension/src/plugin';
+
+describe('nbdime:diff command', () => {
+  it('opens a notebook diff for the supplied paths', async () => {
+    const commands = new CommandRegistry();
+    const add = jest.fn();
+    const activateById = jest.fn();
+    const app = {
+      commands,
+      shell: { add, activateById },
+      docRegistry: { addWidgetExtension: jest.fn() },
+      serviceManager: { serverSettings: {} },
+    };
+    const tracker = {
+      currentWidget: { context: { path: 'current.ipynb' } },
+      currentChanged: { connect: jest.fn() },
+      size: 1,
+    };
+    const settings = {
+      changed: { connect: jest.fn() },
+      get: jest.fn(() => ({ composite: true })),
+    };
+    const settingsRegistry = {
+      load: jest.fn(() => Promise.resolve(settings)),
+    };
+    const editorFactory = jest.fn();
+    const editorServices = {
+      factoryService: { newInlineEditor: editorFactory },
+    };
+
+    await (nbdimePlugin.activate as any)(
+      app,
+      tracker,
+      {},
+      settingsRegistry,
+      editorServices,
+      null,
+    );
+    await commands.execute(CommandIDs.diffNotebook, {
+      base: 'base.ipynb',
+      remote: 'remote.ipynb',
+    });
+
+    expect(diffNotebook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base: 'base.ipynb',
+        remote: 'remote.ipynb',
+      }),
+    );
+    expect(add).toHaveBeenCalledWith({ id: 'notebook-diff' });
+    expect(activateById).toHaveBeenCalledWith('notebook-diff');
+  });
+});

--- a/packages/nbdime/test/src/labextension-command.spec.ts
+++ b/packages/nbdime/test/src/labextension-command.spec.ts
@@ -50,8 +50,8 @@ describe('nbdime:diff command', () => {
       null,
     );
     await commands.execute(CommandIDs.diffNotebook, {
-      base: 'base.ipynb',
-      remote: 'remote.ipynb',
+      base: ' base.ipynb ',
+      remote: ' remote.ipynb ',
     });
 
     expect(diffNotebook).toHaveBeenCalledWith(

--- a/packages/nbdime/test/src/labextension-command.spec.ts
+++ b/packages/nbdime/test/src/labextension-command.spec.ts
@@ -49,6 +49,18 @@ describe('nbdime:diff command', () => {
       editorServices,
       null,
     );
+
+    expect(await commands.describedBy(CommandIDs.diffNotebook)).toMatchObject({
+      args: {
+        type: 'object',
+        properties: {
+          base: { type: 'string', description: expect.any(String) },
+          remote: { type: 'string', description: expect.any(String) },
+          activate: { type: 'boolean', description: expect.any(String) },
+        },
+      },
+    });
+
     await commands.execute(CommandIDs.diffNotebook, {
       base: ' base.ipynb ',
       remote: ' remote.ipynb ',


### PR DESCRIPTION
🤖🤖

Closes #796.

## Summary

- pass `base` and `remote` command arguments to the existing notebook diff widget
- prompt for either notebook path when the caller omits it
- open and optionally activate the resulting diff widget consistently with the other nbdime commands
- add regression coverage for the command-to-widget path