### PR TITLE
Fix saving retained deleted cells

### DIFF
--- a/packages/nbdime/src/merge/model/cell.ts
+++ b/packages/nbdime/src/merge/model/cell.ts
@@ -412,6 +412,11 @@ export class CellMergeModel extends ObjectMergeModel<
     }
     let decisions: MergeDecision[] = [];
     for (let md of this.decisions) {
+      // Cell-level removal decisions are represented by deleteCell. They
+      // cannot be applied as patches to the contents of a retained cell.
+      if (arraysEqual(md.absolutePath, ['cells'])) {
+        continue;
+      }
       let nmd = new MergeDecision(md);
       nmd.level = 2;
       decisions.push(nmd);
@@ -421,12 +426,13 @@ export class CellMergeModel extends ObjectMergeModel<
     if (Array.isArray(src)) {
       src = src.join('');
     }
-    if (src !== this._merged!.source.remote) {
+    const mergedSource = this._merged!.source.remote;
+    if (mergedSource !== null && src !== mergedSource) {
       console.warn(
         "Serialized outputs doesn't match model value! " +
           'Keeping the model value.',
       );
-      output.source = splitLines(this._merged!.source.remote!);
+      output.source = splitLines(mergedSource);
     }
     if (this.clearOutputs && nbformat.isCode(output)) {
       output.outputs = [];

--- a/packages/nbdime/test/src/merge/model.spec.ts
+++ b/packages/nbdime/test/src/merge/model.spec.ts
@@ -220,6 +220,22 @@ describe('merge', () => {
         expect(model.base).toBe(notebook);
       });
 
+      it('should preserve a remotely deleted cell when deletion is unchecked', () => {
+        const decision: IMergeDecision = {
+          local_diff: null,
+          remote_diff: [opRemoveRange(0, 1)],
+          action: 'remote',
+          common_path: ['cells'],
+        };
+        const model = new NotebookMergeModel(notebook, [decision]);
+
+        expect(model.cells[0].deleteCell).toBe(true);
+
+        model.cells[0].deleteCell = false;
+
+        expect(model.cells[0].serialize()).toEqual(notebook.cells[0]);
+      });
+
       describe('decision splitting', () => {
         const diff: IDiffEntry[] = [
           opPatch(0, [opPatch('metadata', [opReplace('collapsed', true)])]),


### PR DESCRIPTION
Fixes #495.

## What changed

Cell-level deletion decisions use the absolute path `['cells']`. When a user unchecked **Delete cell**, `CellMergeModel.serialize()` rebased that list-level `removerange` and applied it inside the retained cell. The object patcher then rejected its numeric key, preventing both Save and Download.

This change:

- skips the already-represented cell-level removal when serializing a retained cell;
- avoids replacing retained content with the deleted merge model's `null` source; and
- adds a regression test for retaining a remotely deleted cell.

Sub-cell decisions continue to be applied normally.

## Verification

- `npm test --workspace=nbdime -- --runInBand` — 14 suites, 300 tests passed
- `npm run build:tsc`
- `npx prettier --check packages/nbdime/src/merge/model/cell.ts packages/nbdime/test/src/merge/model.spec.ts`
- Reproduced the issue with the attached `a.ipynb` and `b.ipynb`, unchecked **Delete cell** in the web UI, and saved successfully with both original cells present and no console errors or warnings
